### PR TITLE
Move landing page to root and fix GitHub Pages URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This toolkit helps teams build consistent, well-documented APIs for safety net programs—enabling faster integration between benefits systems and reducing the technical barriers to improving service delivery.
 
-**New here?** Start with the [Executive Summary](https://codeforamerica.github.io/safety-net-openapi/presentation/executive-summary.html) for a one-page overview, the [Toolkit Overview](https://codeforamerica.github.io/safety-net-openapi/presentation/safety-net-openapi-overview.html) presentation for a detailed walkthrough, or the [ORCA Data Explorer](https://codeforamerica.github.io/safety-net-openapi/packages/schemas/docs/schema-reference.html) to browse the data model.
+**New here?** Start with the [Executive Summary](https://codeforamerica.github.io/safety-net-openapi/docs/presentation/executive-summary.html) for a one-page overview, the [Toolkit Overview](https://codeforamerica.github.io/safety-net-openapi/docs/presentation/safety-net-openapi-overview.html) presentation for a detailed walkthrough, or the [ORCA Data Explorer](https://codeforamerica.github.io/safety-net-openapi/packages/schemas/docs/schema-reference.html) to browse the data model.
 
 ## About This Repository
 

--- a/docs/presentation/executive-summary.md
+++ b/docs/presentation/executive-summary.md
@@ -35,7 +35,7 @@ The Safety Net OpenAPI Toolkit provides **pre-built, shared API definitions for 
 
 ### Get Started
 
-Visit the [Toolkit Overview presentation](https://codeforamerica.github.io/safety-net-openapi/presentation/safety-net-openapi-overview.html) for a detailed walkthrough, or explore the [repository on GitHub](https://github.com/codeforamerica/safety-net-openapi).
+Visit the [Toolkit Overview presentation](https://codeforamerica.github.io/safety-net-openapi/docs/presentation/safety-net-openapi-overview.html) for a detailed walkthrough, explore the [ORCA Data Explorer](https://codeforamerica.github.io/safety-net-openapi/packages/schemas/docs/schema-reference.html) to see the data model, or visit the [repository on GitHub](https://github.com/codeforamerica/safety-net-openapi).
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -111,17 +111,17 @@
     <p class="tagline">Pre-built API definitions for benefits eligibility programs</p>
 
     <div class="links">
-      <a href="presentation/executive-summary.html" class="link-card">
+      <a href="docs/presentation/executive-summary.html" class="link-card">
         <h2>Executive Summary</h2>
         <p>One-page overview of the toolkit and its benefits</p>
       </a>
 
-      <a href="presentation/safety-net-openapi-overview.html" class="link-card">
+      <a href="docs/presentation/safety-net-openapi-overview.html" class="link-card">
         <h2>Toolkit Overview</h2>
         <p>Detailed presentation walkthrough</p>
       </a>
 
-      <a href="../packages/schemas/docs/schema-reference.html" class="link-card">
+      <a href="packages/schemas/docs/schema-reference.html" class="link-card">
         <h2>ORCA Data Explorer</h2>
         <p>Browse the data model interactively</p>
       </a>


### PR DESCRIPTION
- Move index.html from docs/ to root for cleaner URL
- Update all GitHub Pages links to include /docs/ prefix
- Add ORCA Data Explorer link to executive-summary.md