### PR TITLE
Improve ORCA data explorer UX

### DIFF
--- a/packages/schemas/docs/schema-reference.html
+++ b/packages/schemas/docs/schema-reference.html
@@ -1516,152 +1516,47 @@
         <td class="field-required"></td>
         <td class="field-notes">Options: draft, submitted, under review, approved, denied, pending information, withdrawn</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Assister</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="applicationAssister" class="expandable">
-        <td class="field-name">applicationAssister</td>
-        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">The person who helped complete this application. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Preferences</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="preferences" class="expandable">
-        <td class="field-name">preferences</td>
-        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application preferences and consents. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Screening Flags</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="screeningFlags" class="expandable">
         <td class="field-name">screeningFlags</td>
         <td class="field-type">→ <a href="#ApplicationScreeningFlags" class="type-link">ApplicationScreeningFlags</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Flags indicating screening criteria relevant to this application. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Authorized Representative</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="authorizedRepresentative" class="expandable">
-        <td class="field-name">authorizedRepresentative</td>
-        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+      <tr data-field="preferences" class="expandable">
+        <td class="field-name">preferences</td>
+        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
+        <td class="field-notes">Application preferences and consents. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expedited SNAPInfo</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expeditedSNAPInfo" class="expandable">
-        <td class="field-name">expeditedSNAPInfo</td>
-        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Household</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="household" class="expandable">
         <td class="field-name">household</td>
         <td class="field-type">→ <a href="#Household" class="type-link">Household</a></td>
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Household information including members, occupants, expenses, and related data. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signatures</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="expeditedSNAPInfo" class="expandable">
+        <td class="field-name">expeditedSNAPInfo</td>
+        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="signatures" class="expandable">
         <td class="field-name">signatures</td>
         <td class="field-type">→ <a href="#Signatures" class="type-link">Signatures</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Application signatures. [Nested]</td>
+      </tr>
+      <tr data-field="applicationAssister" class="expandable">
+        <td class="field-name">applicationAssister</td>
+        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">The person who helped complete this application. [Nested]</td>
+      </tr>
+      <tr data-field="authorizedRepresentative" class="expandable">
+        <td class="field-name">authorizedRepresentative</td>
+        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -1725,152 +1620,47 @@
         <td class="field-required"></td>
         <td class="field-notes">Options: draft, submitted, under review, approved, denied, pending information, withdrawn</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Assister</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="applicationAssister" class="expandable">
-        <td class="field-name">applicationAssister</td>
-        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">The person who helped complete this application. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Preferences</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="preferences" class="expandable">
-        <td class="field-name">preferences</td>
-        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application preferences and consents. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Screening Flags</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="screeningFlags" class="expandable">
         <td class="field-name">screeningFlags</td>
         <td class="field-type">→ <a href="#ApplicationScreeningFlags" class="type-link">ApplicationScreeningFlags</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Flags indicating screening criteria relevant to this application. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Authorized Representative</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="authorizedRepresentative" class="expandable">
-        <td class="field-name">authorizedRepresentative</td>
-        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+      <tr data-field="preferences" class="expandable">
+        <td class="field-name">preferences</td>
+        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
+        <td class="field-notes">Application preferences and consents. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expedited SNAPInfo</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expeditedSNAPInfo" class="expandable">
-        <td class="field-name">expeditedSNAPInfo</td>
-        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Household</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="household" class="expandable">
         <td class="field-name">household</td>
         <td class="field-type">→ <a href="#Household" class="type-link">Household</a></td>
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Household information including members, occupants, expenses, and related data. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signatures</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="expeditedSNAPInfo" class="expandable">
+        <td class="field-name">expeditedSNAPInfo</td>
+        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="signatures" class="expandable">
         <td class="field-name">signatures</td>
         <td class="field-type">→ <a href="#Signatures" class="type-link">Signatures</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Application signatures. [Nested]</td>
+      </tr>
+      <tr data-field="applicationAssister" class="expandable">
+        <td class="field-name">applicationAssister</td>
+        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">The person who helped complete this application. [Nested]</td>
+      </tr>
+      <tr data-field="authorizedRepresentative" class="expandable">
+        <td class="field-name">authorizedRepresentative</td>
+        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -1934,152 +1724,47 @@
         <td class="field-required"></td>
         <td class="field-notes">Options: draft, submitted, under review, approved, denied, pending information, withdrawn</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Assister</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="applicationAssister" class="expandable">
-        <td class="field-name">applicationAssister</td>
-        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">The person who helped complete this application. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Preferences</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="preferences" class="expandable">
-        <td class="field-name">preferences</td>
-        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application preferences and consents. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Application Screening Flags</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="screeningFlags" class="expandable">
         <td class="field-name">screeningFlags</td>
         <td class="field-type">→ <a href="#ApplicationScreeningFlags" class="type-link">ApplicationScreeningFlags</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Flags indicating screening criteria relevant to this application. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Authorized Representative</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="authorizedRepresentative" class="expandable">
-        <td class="field-name">authorizedRepresentative</td>
-        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+      <tr data-field="preferences" class="expandable">
+        <td class="field-name">preferences</td>
+        <td class="field-type">→ <a href="#ApplicationPreferences" class="type-link">ApplicationPreferences</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
+        <td class="field-notes">Application preferences and consents. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expedited SNAPInfo</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expeditedSNAPInfo" class="expandable">
-        <td class="field-name">expeditedSNAPInfo</td>
-        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Household</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="household" class="expandable">
         <td class="field-name">household</td>
         <td class="field-type">→ <a href="#Household" class="type-link">Household</a></td>
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Household information including members, occupants, expenses, and related data. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signatures</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="expeditedSNAPInfo" class="expandable">
+        <td class="field-name">expeditedSNAPInfo</td>
+        <td class="field-type">→ <a href="#ExpeditedSNAPInfo" class="type-link">ExpeditedSNAPInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expedited SNAP screening information. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="signatures" class="expandable">
         <td class="field-name">signatures</td>
         <td class="field-type">→ <a href="#Signatures" class="type-link">Signatures</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Application signatures. [Nested]</td>
+      </tr>
+      <tr data-field="applicationAssister" class="expandable">
+        <td class="field-name">applicationAssister</td>
+        <td class="field-type">→ <a href="#ApplicationAssister" class="type-link">ApplicationAssister</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">The person who helped complete this application. [Nested]</td>
+      </tr>
+      <tr data-field="authorizedRepresentative" class="expandable">
+        <td class="field-name">authorizedRepresentative</td>
+        <td class="field-type">→ <a href="#AuthorizedRepresentative" class="type-link">AuthorizedRepresentative</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Authorized representative for the applicant. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -2212,8 +1897,8 @@
     </div>
     <div class="orca-panel" data-tab="attributes">
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -2236,47 +1921,17 @@
         <td class="field-required"></td>
         <td class="field-notes">Mailing address if different from home address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Member</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="members" class="expandable">
-        <td class="field-name">members</td>
-        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Primary phone number for the household. [Nested]</td>
+      </tr>
+      <tr data-field="members" class="expandable">
+        <td class="field-name">members</td>
+        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -2316,8 +1971,8 @@
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -2340,47 +1995,17 @@
         <td class="field-required"></td>
         <td class="field-notes">Mailing address if different from home address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Member</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="members" class="expandable">
-        <td class="field-name">members</td>
-        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Primary phone number for the household. [Nested]</td>
+      </tr>
+      <tr data-field="members" class="expandable">
+        <td class="field-name">members</td>
+        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -2420,8 +2045,8 @@
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -2444,47 +2069,17 @@
         <td class="field-required"></td>
         <td class="field-notes">Mailing address if different from home address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Member</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="members" class="expandable">
-        <td class="field-name">members</td>
-        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Primary phone number for the household. [Nested]</td>
+      </tr>
+      <tr data-field="members" class="expandable">
+        <td class="field-name">members</td>
+        <td class="field-type">List of → <a href="#Member" class="type-link">Member</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">List of household members with their relationship to the head of household. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -2610,6 +2205,12 @@
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -2622,6 +2223,12 @@
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -2633,6 +2240,48 @@
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
+      </tr>
+      <tr data-field="demographicInfo" class="expandable">
+        <td class="field-name">demographicInfo</td>
+        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
+      </tr>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
+      </tr>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
+      </tr>
+      <tr data-field="employmentInfo" class="expandable">
+        <td class="field-name">employmentInfo</td>
+        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employment and self-employment information. [Nested]</td>
+      </tr>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="militaryInfo" class="expandable">
+        <td class="field-name">militaryInfo</td>
+        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Military and veteran status information. [Nested]</td>
+      </tr>
+      <tr data-field="tribalInfo" class="expandable">
+        <td class="field-name">tribalInfo</td>
+        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
       </tr>
       <tr data-field="consentToShareInformation">
         <td class="field-name">consentToShareInformation</td>
@@ -2652,662 +2301,143 @@
         <td class="field-required"></td>
         <td class="field-notes">Options: snap, tanf, adult financial, medical assistance</td>
       </tr>
-      <tr data-field="hasLegalClaim">
-        <td class="field-name">hasLegalClaim</td>
-        <td class="field-type">Yes/No</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Absent Parent</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="absentParents" class="expandable">
-        <td class="field-name">absentParents</td>
-        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Absent parents for this child. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="demographicInfo" class="expandable">
-        <td class="field-name">demographicInfo</td>
-        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Disability Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="disabilityInfo" class="expandable">
-        <td class="field-name">disabilityInfo</td>
-        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employmentInfo" class="expandable">
-        <td class="field-name">employmentInfo</td>
-        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employment and self-employment information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expense Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expenses" class="expandable">
-        <td class="field-name">expenses</td>
-        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Family Planning Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="familyPlanningInfo" class="expandable">
-        <td class="field-name">familyPlanningInfo</td>
-        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Aid Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="financialAidInfo" class="expandable">
-        <td class="field-name">financialAidInfo</td>
-        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial aid information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Foster Care History</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="fosterCareInfo" class="expandable">
-        <td class="field-name">fosterCareInfo</td>
-        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Foster care history for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInfo" class="expandable">
-        <td class="field-name">healthInfo</td>
-        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Insurance Enrollment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInsuranceEnrollments" class="expandable">
-        <td class="field-name">healthInsuranceEnrollments</td>
-        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Income Change Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="incomeChangeInfo" class="expandable">
-        <td class="field-name">incomeChangeInfo</td>
-        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Institutionalized Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="institutionalizedInfo" class="expandable">
         <td class="field-name">institutionalizedInfo</td>
         <td class="field-type">→ <a href="#InstitutionalizedInfo" class="type-link">InstitutionalizedInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Information about institutionalization if this person is temporarily in an institution. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job Income Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="disabilityInfo" class="expandable">
+        <td class="field-name">disabilityInfo</td>
+        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="hasLegalClaim">
+        <td class="field-name">hasLegalClaim</td>
+        <td class="field-type">Yes/No</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
+      </tr>
+      <tr data-field="expenses" class="expandable">
+        <td class="field-name">expenses</td>
+        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
+      </tr>
+      <tr data-field="incomeChangeInfo" class="expandable">
+        <td class="field-name">incomeChangeInfo</td>
+        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
+      </tr>
+      <tr data-field="fosterCareInfo" class="expandable">
+        <td class="field-name">fosterCareInfo</td>
+        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Foster care history for this person. [Nested]</td>
+      </tr>
+      <tr data-field="absentParents" class="expandable">
+        <td class="field-name">absentParents</td>
+        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Absent parents for this child. [Nested]</td>
+      </tr>
       <tr data-field="employmentHistory" class="expandable">
         <td class="field-name">employmentHistory</td>
         <td class="field-type">List of → <a href="#JobIncomeInfo" class="type-link">JobIncomeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employment history for this person (jobs with endDate are past jobs). [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Lump Sum Payment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="lumpSumPayments" class="expandable">
-        <td class="field-name">lumpSumPayments</td>
-        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="militaryInfo" class="expandable">
-        <td class="field-name">militaryInfo</td>
-        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Military and veteran status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Non Citizen Application Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="nonCitizenApplicationInfo" class="expandable">
-        <td class="field-name">nonCitizenApplicationInfo</td>
-        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Past Benefits From Other States</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
-        <td class="field-name">pastBenefitsFromOtherStates</td>
-        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Prior Convictions Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="priorConvictions" class="expandable">
-        <td class="field-name">priorConvictions</td>
-        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Resource Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="resourceInfo" class="expandable">
-        <td class="field-name">resourceInfo</td>
-        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Retroactive Medical Request</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="retroactiveMedicalRequest" class="expandable">
-        <td class="field-name">retroactiveMedicalRequest</td>
-        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Self Employment Record</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="selfEmployment" class="expandable">
         <td class="field-name">selfEmployment</td>
         <td class="field-type">List of → <a href="#SelfEmploymentRecord" class="type-link">SelfEmploymentRecord</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Self-employment businesses for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Strike Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="unearnedIncomeSources" class="expandable">
+        <td class="field-name">unearnedIncomeSources</td>
+        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="lumpSumPayments" class="expandable">
+        <td class="field-name">lumpSumPayments</td>
+        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
+      </tr>
       <tr data-field="strikeInfo" class="expandable">
         <td class="field-name">strikeInfo</td>
         <td class="field-type">→ <a href="#StrikeInfo" class="type-link">StrikeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Strike information if this person is on strike. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tax Filing Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="nonCitizenApplicationInfo" class="expandable">
+        <td class="field-name">nonCitizenApplicationInfo</td>
+        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="familyPlanningInfo" class="expandable">
+        <td class="field-name">familyPlanningInfo</td>
+        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="financialAidInfo" class="expandable">
+        <td class="field-name">financialAidInfo</td>
+        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial aid information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="priorConvictions" class="expandable">
+        <td class="field-name">priorConvictions</td>
+        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
+      </tr>
       <tr data-field="taxFilingInfo" class="expandable">
         <td class="field-name">taxFilingInfo</td>
         <td class="field-type">→ <a href="#TaxFilingInfo" class="type-link">TaxFilingInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Tax filing information for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Transferred Asset</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="resourceInfo" class="expandable">
+        <td class="field-name">resourceInfo</td>
+        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="transferredAssets" class="expandable">
         <td class="field-name">transferredAssets</td>
         <td class="field-type">List of → <a href="#TransferredAsset" class="type-link">TransferredAsset</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Assets transferred by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="tribalInfo" class="expandable">
-        <td class="field-name">tribalInfo</td>
-        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+      <tr data-field="retroactiveMedicalRequest" class="expandable">
+        <td class="field-name">retroactiveMedicalRequest</td>
+        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
+        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Unearned Income Source</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="unearnedIncomeSources" class="expandable">
-        <td class="field-name">unearnedIncomeSources</td>
-        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+      <tr data-field="healthInfo" class="expandable">
+        <td class="field-name">healthInfo</td>
+        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
+        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
+      </tr>
+      <tr data-field="healthInsuranceEnrollments" class="expandable">
+        <td class="field-name">healthInsuranceEnrollments</td>
+        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
+      </tr>
+      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
+        <td class="field-name">pastBenefitsFromOtherStates</td>
+        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -3363,6 +2493,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -3375,6 +2511,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -3386,6 +2528,48 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
+      </tr>
+      <tr data-field="demographicInfo" class="expandable">
+        <td class="field-name">demographicInfo</td>
+        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
+      </tr>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
+      </tr>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
+      </tr>
+      <tr data-field="employmentInfo" class="expandable">
+        <td class="field-name">employmentInfo</td>
+        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employment and self-employment information. [Nested]</td>
+      </tr>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="militaryInfo" class="expandable">
+        <td class="field-name">militaryInfo</td>
+        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Military and veteran status information. [Nested]</td>
+      </tr>
+      <tr data-field="tribalInfo" class="expandable">
+        <td class="field-name">tribalInfo</td>
+        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
       </tr>
       <tr data-field="consentToShareInformation">
         <td class="field-name">consentToShareInformation</td>
@@ -3405,662 +2589,143 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Options: calfresh, calworks, medi cal, calfresh healthy living, general assistance, capi, ihss</td>
       </tr>
-      <tr data-field="hasLegalClaim">
-        <td class="field-name">hasLegalClaim</td>
-        <td class="field-type">Yes/No</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Absent Parent</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="absentParents" class="expandable">
-        <td class="field-name">absentParents</td>
-        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Absent parents for this child. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="demographicInfo" class="expandable">
-        <td class="field-name">demographicInfo</td>
-        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Disability Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="disabilityInfo" class="expandable">
-        <td class="field-name">disabilityInfo</td>
-        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employmentInfo" class="expandable">
-        <td class="field-name">employmentInfo</td>
-        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employment and self-employment information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expense Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expenses" class="expandable">
-        <td class="field-name">expenses</td>
-        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Family Planning Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="familyPlanningInfo" class="expandable">
-        <td class="field-name">familyPlanningInfo</td>
-        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Aid Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="financialAidInfo" class="expandable">
-        <td class="field-name">financialAidInfo</td>
-        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial aid information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Foster Care History</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="fosterCareInfo" class="expandable">
-        <td class="field-name">fosterCareInfo</td>
-        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Foster care history for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInfo" class="expandable">
-        <td class="field-name">healthInfo</td>
-        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Insurance Enrollment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInsuranceEnrollments" class="expandable">
-        <td class="field-name">healthInsuranceEnrollments</td>
-        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Income Change Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="incomeChangeInfo" class="expandable">
-        <td class="field-name">incomeChangeInfo</td>
-        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Institutionalized Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="institutionalizedInfo" class="expandable">
         <td class="field-name">institutionalizedInfo</td>
         <td class="field-type">→ <a href="#InstitutionalizedInfo" class="type-link">InstitutionalizedInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Information about institutionalization if this person is temporarily in an institution. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job Income Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="disabilityInfo" class="expandable">
+        <td class="field-name">disabilityInfo</td>
+        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="hasLegalClaim">
+        <td class="field-name">hasLegalClaim</td>
+        <td class="field-type">Yes/No</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
+      </tr>
+      <tr data-field="expenses" class="expandable">
+        <td class="field-name">expenses</td>
+        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
+      </tr>
+      <tr data-field="incomeChangeInfo" class="expandable">
+        <td class="field-name">incomeChangeInfo</td>
+        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
+      </tr>
+      <tr data-field="fosterCareInfo" class="expandable">
+        <td class="field-name">fosterCareInfo</td>
+        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Foster care history for this person. [Nested]</td>
+      </tr>
+      <tr data-field="absentParents" class="expandable">
+        <td class="field-name">absentParents</td>
+        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Absent parents for this child. [Nested]</td>
+      </tr>
       <tr data-field="employmentHistory" class="expandable">
         <td class="field-name">employmentHistory</td>
         <td class="field-type">List of → <a href="#JobIncomeInfo" class="type-link">JobIncomeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employment history for this person (jobs with endDate are past jobs). [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Lump Sum Payment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="lumpSumPayments" class="expandable">
-        <td class="field-name">lumpSumPayments</td>
-        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="militaryInfo" class="expandable">
-        <td class="field-name">militaryInfo</td>
-        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Military and veteran status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Non Citizen Application Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="nonCitizenApplicationInfo" class="expandable">
-        <td class="field-name">nonCitizenApplicationInfo</td>
-        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Past Benefits From Other States</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
-        <td class="field-name">pastBenefitsFromOtherStates</td>
-        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Prior Convictions Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="priorConvictions" class="expandable">
-        <td class="field-name">priorConvictions</td>
-        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Resource Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="resourceInfo" class="expandable">
-        <td class="field-name">resourceInfo</td>
-        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Retroactive Medical Request</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="retroactiveMedicalRequest" class="expandable">
-        <td class="field-name">retroactiveMedicalRequest</td>
-        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Self Employment Record</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="selfEmployment" class="expandable">
         <td class="field-name">selfEmployment</td>
         <td class="field-type">List of → <a href="#SelfEmploymentRecord" class="type-link">SelfEmploymentRecord</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Self-employment businesses for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Strike Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="unearnedIncomeSources" class="expandable">
+        <td class="field-name">unearnedIncomeSources</td>
+        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="lumpSumPayments" class="expandable">
+        <td class="field-name">lumpSumPayments</td>
+        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
+      </tr>
       <tr data-field="strikeInfo" class="expandable">
         <td class="field-name">strikeInfo</td>
         <td class="field-type">→ <a href="#StrikeInfo" class="type-link">StrikeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Strike information if this person is on strike. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tax Filing Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="nonCitizenApplicationInfo" class="expandable">
+        <td class="field-name">nonCitizenApplicationInfo</td>
+        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="familyPlanningInfo" class="expandable">
+        <td class="field-name">familyPlanningInfo</td>
+        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="financialAidInfo" class="expandable">
+        <td class="field-name">financialAidInfo</td>
+        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial aid information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="priorConvictions" class="expandable">
+        <td class="field-name">priorConvictions</td>
+        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
+      </tr>
       <tr data-field="taxFilingInfo" class="expandable">
         <td class="field-name">taxFilingInfo</td>
         <td class="field-type">→ <a href="#TaxFilingInfo" class="type-link">TaxFilingInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Tax filing information for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Transferred Asset</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="resourceInfo" class="expandable">
+        <td class="field-name">resourceInfo</td>
+        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="transferredAssets" class="expandable">
         <td class="field-name">transferredAssets</td>
         <td class="field-type">List of → <a href="#TransferredAsset" class="type-link">TransferredAsset</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Assets transferred by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="tribalInfo" class="expandable">
-        <td class="field-name">tribalInfo</td>
-        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+      <tr data-field="retroactiveMedicalRequest" class="expandable">
+        <td class="field-name">retroactiveMedicalRequest</td>
+        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
+        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Unearned Income Source</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="unearnedIncomeSources" class="expandable">
-        <td class="field-name">unearnedIncomeSources</td>
-        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+      <tr data-field="healthInfo" class="expandable">
+        <td class="field-name">healthInfo</td>
+        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
+        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
+      </tr>
+      <tr data-field="healthInsuranceEnrollments" class="expandable">
+        <td class="field-name">healthInsuranceEnrollments</td>
+        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
+      </tr>
+      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
+        <td class="field-name">pastBenefitsFromOtherStates</td>
+        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -4116,6 +2781,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -4128,6 +2799,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -4139,6 +2816,48 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
+      </tr>
+      <tr data-field="demographicInfo" class="expandable">
+        <td class="field-name">demographicInfo</td>
+        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
+      </tr>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
+      </tr>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
+      </tr>
+      <tr data-field="employmentInfo" class="expandable">
+        <td class="field-name">employmentInfo</td>
+        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employment and self-employment information. [Nested]</td>
+      </tr>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="militaryInfo" class="expandable">
+        <td class="field-name">militaryInfo</td>
+        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Military and veteran status information. [Nested]</td>
+      </tr>
+      <tr data-field="tribalInfo" class="expandable">
+        <td class="field-name">tribalInfo</td>
+        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
       </tr>
       <tr data-field="consentToShareInformation">
         <td class="field-name">consentToShareInformation</td>
@@ -4158,662 +2877,143 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Options: snap, colorado works, health first colorado, child health plan plus, old age pension, andcs, leap, cccap</td>
       </tr>
-      <tr data-field="hasLegalClaim">
-        <td class="field-name">hasLegalClaim</td>
-        <td class="field-type">Yes/No</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Absent Parent</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="absentParents" class="expandable">
-        <td class="field-name">absentParents</td>
-        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Absent parents for this child. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship information extended with eligibility immigration fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information extended with eligibility fields. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="demographicInfo" class="expandable">
-        <td class="field-name">demographicInfo</td>
-        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Disability Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="disabilityInfo" class="expandable">
-        <td class="field-name">disabilityInfo</td>
-        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employmentInfo" class="expandable">
-        <td class="field-name">employmentInfo</td>
-        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employment and self-employment information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expense Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expenses" class="expandable">
-        <td class="field-name">expenses</td>
-        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Family Planning Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="familyPlanningInfo" class="expandable">
-        <td class="field-name">familyPlanningInfo</td>
-        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Aid Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="financialAidInfo" class="expandable">
-        <td class="field-name">financialAidInfo</td>
-        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial aid information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Foster Care History</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="fosterCareInfo" class="expandable">
-        <td class="field-name">fosterCareInfo</td>
-        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Foster care history for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInfo" class="expandable">
-        <td class="field-name">healthInfo</td>
-        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Insurance Enrollment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInsuranceEnrollments" class="expandable">
-        <td class="field-name">healthInsuranceEnrollments</td>
-        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Income Change Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="incomeChangeInfo" class="expandable">
-        <td class="field-name">incomeChangeInfo</td>
-        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Institutionalized Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="institutionalizedInfo" class="expandable">
         <td class="field-name">institutionalizedInfo</td>
         <td class="field-type">→ <a href="#InstitutionalizedInfo" class="type-link">InstitutionalizedInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Information about institutionalization if this person is temporarily in an institution. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job Income Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="disabilityInfo" class="expandable">
+        <td class="field-name">disabilityInfo</td>
+        <td class="field-type">→ <a href="#DisabilityInfo" class="type-link">DisabilityInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Disability and SSI/SSDI information for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="hasLegalClaim">
+        <td class="field-name">hasLegalClaim</td>
+        <td class="field-type">Yes/No</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Whether this person has a legal claim related to medical care.</td>
+      </tr>
+      <tr data-field="expenses" class="expandable">
+        <td class="field-name">expenses</td>
+        <td class="field-type">→ <a href="#ExpenseInfo" class="type-link">ExpenseInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Expenses paid by or for this person. [Nested]</td>
+      </tr>
+      <tr data-field="incomeChangeInfo" class="expandable">
+        <td class="field-name">incomeChangeInfo</td>
+        <td class="field-type">→ <a href="#IncomeChangeInfo" class="type-link">IncomeChangeInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Income change information for health insurance eligibility. [Nested]</td>
+      </tr>
+      <tr data-field="fosterCareInfo" class="expandable">
+        <td class="field-name">fosterCareInfo</td>
+        <td class="field-type">→ <a href="#FosterCareHistory" class="type-link">FosterCareHistory</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Foster care history for this person. [Nested]</td>
+      </tr>
+      <tr data-field="absentParents" class="expandable">
+        <td class="field-name">absentParents</td>
+        <td class="field-type">List of → <a href="#AbsentParent" class="type-link">AbsentParent</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Absent parents for this child. [Nested]</td>
+      </tr>
       <tr data-field="employmentHistory" class="expandable">
         <td class="field-name">employmentHistory</td>
         <td class="field-type">List of → <a href="#JobIncomeInfo" class="type-link">JobIncomeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employment history for this person (jobs with endDate are past jobs). [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Lump Sum Payment</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="lumpSumPayments" class="expandable">
-        <td class="field-name">lumpSumPayments</td>
-        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="militaryInfo" class="expandable">
-        <td class="field-name">militaryInfo</td>
-        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Military and veteran status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Non Citizen Application Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="nonCitizenApplicationInfo" class="expandable">
-        <td class="field-name">nonCitizenApplicationInfo</td>
-        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Past Benefits From Other States</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
-        <td class="field-name">pastBenefitsFromOtherStates</td>
-        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Prior Convictions Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="priorConvictions" class="expandable">
-        <td class="field-name">priorConvictions</td>
-        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Resource Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="resourceInfo" class="expandable">
-        <td class="field-name">resourceInfo</td>
-        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Retroactive Medical Request</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="retroactiveMedicalRequest" class="expandable">
-        <td class="field-name">retroactiveMedicalRequest</td>
-        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Self Employment Record</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="selfEmployment" class="expandable">
         <td class="field-name">selfEmployment</td>
         <td class="field-type">List of → <a href="#SelfEmploymentRecord" class="type-link">SelfEmploymentRecord</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Self-employment businesses for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Strike Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="unearnedIncomeSources" class="expandable">
+        <td class="field-name">unearnedIncomeSources</td>
+        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="lumpSumPayments" class="expandable">
+        <td class="field-name">lumpSumPayments</td>
+        <td class="field-type">List of → <a href="#LumpSumPayment" class="type-link">LumpSumPayment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Lump sum payments received by this person. [Nested]</td>
+      </tr>
       <tr data-field="strikeInfo" class="expandable">
         <td class="field-name">strikeInfo</td>
         <td class="field-type">→ <a href="#StrikeInfo" class="type-link">StrikeInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Strike information if this person is on strike. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tax Filing Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="nonCitizenApplicationInfo" class="expandable">
+        <td class="field-name">nonCitizenApplicationInfo</td>
+        <td class="field-type">→ <a href="#NonCitizenApplicationInfo" class="type-link">NonCitizenApplicationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Application-specific information for non-citizens. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="familyPlanningInfo" class="expandable">
+        <td class="field-name">familyPlanningInfo</td>
+        <td class="field-type">→ <a href="#FamilyPlanningInfo" class="type-link">FamilyPlanningInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Family planning and pregnancy information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="financialAidInfo" class="expandable">
+        <td class="field-name">financialAidInfo</td>
+        <td class="field-type">→ <a href="#FinancialAidInfo" class="type-link">FinancialAidInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial aid information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="priorConvictions" class="expandable">
+        <td class="field-name">priorConvictions</td>
+        <td class="field-type">→ <a href="#PriorConvictionsInfo" class="type-link">PriorConvictionsInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Prior convictions information for this person. [Nested]</td>
+      </tr>
       <tr data-field="taxFilingInfo" class="expandable">
         <td class="field-name">taxFilingInfo</td>
         <td class="field-type">→ <a href="#TaxFilingInfo" class="type-link">TaxFilingInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Tax filing information for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Transferred Asset</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="resourceInfo" class="expandable">
+        <td class="field-name">resourceInfo</td>
+        <td class="field-type">→ <a href="#ResourceInfo" class="type-link">ResourceInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Financial resources and assets for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="transferredAssets" class="expandable">
         <td class="field-name">transferredAssets</td>
         <td class="field-type">List of → <a href="#TransferredAsset" class="type-link">TransferredAsset</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Assets transferred by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="tribalInfo" class="expandable">
-        <td class="field-name">tribalInfo</td>
-        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+      <tr data-field="retroactiveMedicalRequest" class="expandable">
+        <td class="field-name">retroactiveMedicalRequest</td>
+        <td class="field-type">→ <a href="#RetroactiveMedicalRequest" class="type-link">RetroactiveMedicalRequest</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Tribal information extended with income eligibility fields. [Nested]</td>
+        <td class="field-notes">Request for retroactive medical coverage for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Unearned Income Source</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="unearnedIncomeSources" class="expandable">
-        <td class="field-name">unearnedIncomeSources</td>
-        <td class="field-type">List of → <a href="#UnearnedIncomeSource" class="type-link">UnearnedIncomeSource</a></td>
+      <tr data-field="healthInfo" class="expandable">
+        <td class="field-name">healthInfo</td>
+        <td class="field-type">→ <a href="#HealthInfo" class="type-link">HealthInfo</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Unearned income sources for this person. [Nested]</td>
+        <td class="field-notes">Health and insurance coverage information for eligibility determination. [Nested]</td>
+      </tr>
+      <tr data-field="healthInsuranceEnrollments" class="expandable">
+        <td class="field-name">healthInsuranceEnrollments</td>
+        <td class="field-type">List of → <a href="#HealthInsuranceEnrollment" class="type-link">HealthInsuranceEnrollment</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">This person&#039;s enrollments or eligibilities for health insurance plans. [Nested]</td>
+      </tr>
+      <tr data-field="pastBenefitsFromOtherStates" class="expandable">
+        <td class="field-name">pastBenefitsFromOtherStates</td>
+        <td class="field-type">→ <a href="#PastBenefitsFromOtherStates" class="type-link">PastBenefitsFromOtherStates</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Information about SNAP or cash benefits received in another state in the last 30 days. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -5528,21 +3728,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Certificate number if naturalized or derived citizen.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Immigration Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="immigrationInfo" class="expandable">
         <td class="field-name">immigrationInfo</td>
         <td class="field-type">→ <a href="#ImmigrationInfo" class="type-link">ImmigrationInfo</a></td>
@@ -5578,21 +3763,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Certificate number if naturalized or derived citizen.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Immigration Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="immigrationInfo" class="expandable">
         <td class="field-name">immigrationInfo</td>
         <td class="field-type">→ <a href="#ImmigrationInfo" class="type-link">ImmigrationInfo</a></td>
@@ -5628,21 +3798,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Certificate number if naturalized or derived citizen.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Immigration Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="immigrationInfo" class="expandable">
         <td class="field-name">immigrationInfo</td>
         <td class="field-type">→ <a href="#ImmigrationInfo" class="type-link">ImmigrationInfo</a></td>
@@ -5675,6 +3830,18 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="otherPhoneNumber" class="expandable">
+        <td class="field-name">otherPhoneNumber</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Alternative phone number. [Nested]</td>
+      </tr>
+      <tr data-field="mailingAddress" class="expandable">
+        <td class="field-name">mailingAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
+      </tr>
       <tr data-field="isHomeless">
         <td class="field-name">isHomeless</td>
         <td class="field-type">Yes/No</td>
@@ -5687,6 +3854,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Options: paper, email, both</td>
       </tr>
+      <tr data-field="languagePreference" class="expandable">
+        <td class="field-name">languagePreference</td>
+        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Language preferences for communications. [Nested]</td>
+      </tr>
       <tr data-field="preferredContactMethod">
         <td class="field-name">preferredContactMethod</td>
         <td class="field-type">Dropdown</td>
@@ -5698,69 +3871,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether the person is a resident of the state (for eligibility).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mailingAddress" class="expandable">
-        <td class="field-name">mailingAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Language Preference</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="languagePreference" class="expandable">
-        <td class="field-name">languagePreference</td>
-        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Language preferences for communications. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="otherPhoneNumber" class="expandable">
-        <td class="field-name">otherPhoneNumber</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Alternative phone number. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -5779,6 +3889,18 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="otherPhoneNumber" class="expandable">
+        <td class="field-name">otherPhoneNumber</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Alternative phone number. [Nested]</td>
+      </tr>
+      <tr data-field="mailingAddress" class="expandable">
+        <td class="field-name">mailingAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
+      </tr>
       <tr data-field="isHomeless">
         <td class="field-name">isHomeless</td>
         <td class="field-type">Yes/No</td>
@@ -5791,6 +3913,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Options: paper, email, both</td>
       </tr>
+      <tr data-field="languagePreference" class="expandable">
+        <td class="field-name">languagePreference</td>
+        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Language preferences for communications. [Nested]</td>
+      </tr>
       <tr data-field="preferredContactMethod">
         <td class="field-name">preferredContactMethod</td>
         <td class="field-type">Dropdown</td>
@@ -5802,69 +3930,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether the person is a resident of the state (for eligibility).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mailingAddress" class="expandable">
-        <td class="field-name">mailingAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Language Preference</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="languagePreference" class="expandable">
-        <td class="field-name">languagePreference</td>
-        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Language preferences for communications. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="otherPhoneNumber" class="expandable">
-        <td class="field-name">otherPhoneNumber</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Alternative phone number. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -5883,6 +3948,18 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="otherPhoneNumber" class="expandable">
+        <td class="field-name">otherPhoneNumber</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Alternative phone number. [Nested]</td>
+      </tr>
+      <tr data-field="mailingAddress" class="expandable">
+        <td class="field-name">mailingAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
+      </tr>
       <tr data-field="isHomeless">
         <td class="field-name">isHomeless</td>
         <td class="field-type">Yes/No</td>
@@ -5895,6 +3972,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Options: paper, email, both</td>
       </tr>
+      <tr data-field="languagePreference" class="expandable">
+        <td class="field-name">languagePreference</td>
+        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Language preferences for communications. [Nested]</td>
+      </tr>
       <tr data-field="preferredContactMethod">
         <td class="field-name">preferredContactMethod</td>
         <td class="field-type">Dropdown</td>
@@ -5906,69 +3989,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether the person is a resident of the state (for eligibility).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mailingAddress" class="expandable">
-        <td class="field-name">mailingAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mailing address if different from residential address. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Language Preference</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="languagePreference" class="expandable">
-        <td class="field-name">languagePreference</td>
-        <td class="field-type">→ <a href="#LanguagePreference" class="type-link">LanguagePreference</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Language preferences for communications. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="otherPhoneNumber" class="expandable">
-        <td class="field-name">otherPhoneNumber</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Alternative phone number. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -6158,6 +4178,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether this person has a medical or developmental condition.</td>
       </tr>
+      <tr data-field="socialSecurityApplications" class="expandable">
+        <td class="field-name">socialSecurityApplications</td>
+        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
+      </tr>
       <tr data-field="hasReceivedSsiOrSsdi">
         <td class="field-name">hasReceivedSsiOrSsdi</td>
         <td class="field-type">Yes/No</td>
@@ -6169,27 +4195,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date SSI or SSDI benefits ended for this person (if applicable).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Application</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityApplications" class="expandable">
-        <td class="field-name">socialSecurityApplications</td>
-        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -6226,6 +4231,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether this person has a medical or developmental condition.</td>
       </tr>
+      <tr data-field="socialSecurityApplications" class="expandable">
+        <td class="field-name">socialSecurityApplications</td>
+        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
+      </tr>
       <tr data-field="hasReceivedSsiOrSsdi">
         <td class="field-name">hasReceivedSsiOrSsdi</td>
         <td class="field-type">Yes/No</td>
@@ -6237,27 +4248,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date SSI or SSDI benefits ended for this person (if applicable).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Application</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityApplications" class="expandable">
-        <td class="field-name">socialSecurityApplications</td>
-        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -6294,6 +4284,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether this person has a medical or developmental condition.</td>
       </tr>
+      <tr data-field="socialSecurityApplications" class="expandable">
+        <td class="field-name">socialSecurityApplications</td>
+        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
+      </tr>
       <tr data-field="hasReceivedSsiOrSsdi">
         <td class="field-name">hasReceivedSsiOrSsdi</td>
         <td class="field-type">Yes/No</td>
@@ -6305,27 +4301,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date SSI or SSDI benefits ended for this person (if applicable).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Application</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityApplications" class="expandable">
-        <td class="field-name">socialSecurityApplications</td>
-        <td class="field-type">List of → <a href="#SocialSecurityApplication" class="type-link">SocialSecurityApplication</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">SSI/SSDI applications for this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -6509,8 +4484,8 @@ UUIDs upon submission.
   </div>
   <p class="description">Basic employment information (employers and dates only).</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6532,8 +4507,8 @@ UUIDs upon submission.
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6555,8 +4530,8 @@ UUIDs upon submission.
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6587,50 +4562,8 @@ UUIDs upon submission.
   </div>
   <p class="description">Expenses paid by or for this person.</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Additional Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="additionalExpenses" class="expandable">
-        <td class="field-name">additionalExpenses</td>
-        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expense</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6647,24 +4580,21 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">List of → <a href="#UtilityExpense" class="type-link">UtilityExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="additionalExpenses" class="expandable">
+        <td class="field-name">additionalExpenses</td>
+        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
@@ -6673,50 +4603,8 @@ UUIDs upon submission.
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Additional Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="additionalExpenses" class="expandable">
-        <td class="field-name">additionalExpenses</td>
-        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expense</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6733,24 +4621,21 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">List of → <a href="#UtilityExpense" class="type-link">UtilityExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="additionalExpenses" class="expandable">
+        <td class="field-name">additionalExpenses</td>
+        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
@@ -6759,50 +4644,8 @@ UUIDs upon submission.
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Additional Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="additionalExpenses" class="expandable">
-        <td class="field-name">additionalExpenses</td>
-        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">[Nested object]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expense</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -6819,24 +4662,21 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Expense</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">List of → <a href="#MortgageExpense" class="type-link">MortgageExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">List of → <a href="#UtilityExpense" class="type-link">UtilityExpense</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="additionalExpenses" class="expandable">
+        <td class="field-name">additionalExpenses</td>
+        <td class="field-type">List of → <a href="#AdditionalExpense" class="type-link">AdditionalExpense</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
@@ -7250,29 +5090,8 @@ UUIDs upon submission.
   </div>
   <p class="description">Health and insurance coverage information for eligibility determination.</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Federal Health Benefit</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="federalHealthBenefits" class="expandable">
-        <td class="field-name">federalHealthBenefits</td>
-        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Coverage Detail</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -7289,55 +5108,25 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Health insurance coverage details for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Medicare Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="medicare" class="expandable">
         <td class="field-name">medicare</td>
         <td class="field-type">→ <a href="#MedicareInfo" class="type-link">MedicareInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Medicare coverage information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="federalHealthBenefits" class="expandable">
+        <td class="field-name">federalHealthBenefits</td>
+        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
       </tr>
     </tbody>
   </table>
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Federal Health Benefit</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="federalHealthBenefits" class="expandable">
-        <td class="field-name">federalHealthBenefits</td>
-        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Coverage Detail</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -7354,55 +5143,25 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Health insurance coverage details for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Medicare Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="medicare" class="expandable">
         <td class="field-name">medicare</td>
         <td class="field-type">→ <a href="#MedicareInfo" class="type-link">MedicareInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Medicare coverage information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="federalHealthBenefits" class="expandable">
+        <td class="field-name">federalHealthBenefits</td>
+        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
       </tr>
     </tbody>
   </table>
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Federal Health Benefit</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="federalHealthBenefits" class="expandable">
-        <td class="field-name">federalHealthBenefits</td>
-        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Coverage Detail</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -7419,26 +5178,17 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Health insurance coverage details for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Medicare Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="medicare" class="expandable">
         <td class="field-name">medicare</td>
         <td class="field-type">→ <a href="#MedicareInfo" class="type-link">MedicareInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Medicare coverage information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="federalHealthBenefits" class="expandable">
+        <td class="field-name">federalHealthBenefits</td>
+        <td class="field-type">List of → <a href="#FederalHealthBenefit" class="type-link">FederalHealthBenefit</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Federal health benefit programs this person is enrolled in. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -7730,6 +5480,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="sponsor" class="expandable">
+        <td class="field-name">sponsor</td>
+        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
+      </tr>
       <tr data-field="livedInUSSince1996">
         <td class="field-name">livedInUSSince1996</td>
         <td class="field-type">Yes/No</td>
@@ -7741,27 +5497,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether spouse or parent is a veteran or active duty military.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Sponsor</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="sponsor" class="expandable">
-        <td class="field-name">sponsor</td>
-        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -7822,6 +5557,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="sponsor" class="expandable">
+        <td class="field-name">sponsor</td>
+        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
+      </tr>
       <tr data-field="livedInUSSince1996">
         <td class="field-name">livedInUSSince1996</td>
         <td class="field-type">Yes/No</td>
@@ -7833,27 +5574,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether spouse or parent is a veteran or active duty military.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Sponsor</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="sponsor" class="expandable">
-        <td class="field-name">sponsor</td>
-        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -7914,6 +5634,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="sponsor" class="expandable">
+        <td class="field-name">sponsor</td>
+        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
+      </tr>
       <tr data-field="livedInUSSince1996">
         <td class="field-name">livedInUSSince1996</td>
         <td class="field-type">Yes/No</td>
@@ -7925,27 +5651,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether spouse or parent is a veteran or active duty military.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Sponsor</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="sponsor" class="expandable">
-        <td class="field-name">sponsor</td>
-        <td class="field-type">→ <a href="#Sponsor" class="type-link">Sponsor</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Sponsor information for this non-citizen. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -8009,21 +5714,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether deductions change from month to month.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Deduction Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="deductions" class="expandable">
         <td class="field-name">deductions</td>
         <td class="field-type">List of → <a href="#DeductionItem" class="type-link">DeductionItem</a></td>
@@ -8083,21 +5773,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether deductions change from month to month.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Deduction Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="deductions" class="expandable">
         <td class="field-name">deductions</td>
         <td class="field-type">List of → <a href="#DeductionItem" class="type-link">DeductionItem</a></td>
@@ -8157,21 +5832,6 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Whether deductions change from month to month.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Deduction Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="deductions" class="expandable">
         <td class="field-name">deductions</td>
         <td class="field-type">List of → <a href="#DeductionItem" class="type-link">DeductionItem</a></td>
@@ -8540,6 +6200,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -8551,27 +6217,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date employment ended (omit if current job).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -8590,6 +6235,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -8601,27 +6252,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date employment ended (omit if current job).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -8640,6 +6270,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -8651,27 +6287,6 @@ UUIDs upon submission.
         <td class="field-type">Date</td>
         <td class="field-required"></td>
         <td class="field-notes">Date employment ended (omit if current job).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -9251,8 +6866,8 @@ UUIDs upon submission.
   </div>
   <p class="description">Financial resources and assets.</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Resource</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -9269,76 +6884,31 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Financial resources owned by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Insurance Policy</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="vehicles" class="expandable">
+        <td class="field-name">vehicles</td>
+        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="insurancePolicies" class="expandable">
         <td class="field-name">insurancePolicies</td>
         <td class="field-type">List of → <a href="#InsurancePolicy" class="type-link">InsurancePolicy</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Life or burial insurance policies for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Property</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="realEstateProperties" class="expandable">
         <td class="field-name">realEstateProperties</td>
         <td class="field-type">List of → <a href="#Property" class="type-link">Property</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Real estate properties owned by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Vehicle</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="vehicles" class="expandable">
-        <td class="field-name">vehicles</td>
-        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Resource</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -9355,76 +6925,31 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Financial resources owned by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Insurance Policy</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="vehicles" class="expandable">
+        <td class="field-name">vehicles</td>
+        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="insurancePolicies" class="expandable">
         <td class="field-name">insurancePolicies</td>
         <td class="field-type">List of → <a href="#InsurancePolicy" class="type-link">InsurancePolicy</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Life or burial insurance policies for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Property</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="realEstateProperties" class="expandable">
         <td class="field-name">realEstateProperties</td>
         <td class="field-type">List of → <a href="#Property" class="type-link">Property</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Real estate properties owned by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Vehicle</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="vehicles" class="expandable">
-        <td class="field-name">vehicles</td>
-        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Financial Resource</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -9441,68 +6966,23 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Financial resources owned by this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Insurance Policy</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="vehicles" class="expandable">
+        <td class="field-name">vehicles</td>
+        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="insurancePolicies" class="expandable">
         <td class="field-name">insurancePolicies</td>
         <td class="field-type">List of → <a href="#InsurancePolicy" class="type-link">InsurancePolicy</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Life or burial insurance policies for this person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Property</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="realEstateProperties" class="expandable">
         <td class="field-name">realEstateProperties</td>
         <td class="field-type">List of → <a href="#Property" class="type-link">Property</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Real estate properties owned by this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Vehicle</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="vehicles" class="expandable">
-        <td class="field-name">vehicles</td>
-        <td class="field-type">List of → <a href="#Vehicle" class="type-link">Vehicle</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Vehicles owned by this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -10265,6 +7745,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -10276,6 +7762,12 @@ UUIDs upon submission.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -10289,200 +7781,53 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
       </tr>
-      <tr data-field="consentToShareInformation">
-        <td class="field-name">consentToShareInformation</td>
-        <td class="field-type">Yes/No</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Consent to share information with partner agencies.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="demographicInfo" class="expandable">
         <td class="field-name">demographicInfo</td>
         <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="employmentInfo" class="expandable">
         <td class="field-name">employmentInfo</td>
         <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employment and self-employment information. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="militaryInfo" class="expandable">
         <td class="field-name">militaryInfo</td>
         <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Military and veteran status information. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="tribalInfo" class="expandable">
         <td class="field-name">tribalInfo</td>
         <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
         <td class="field-required"></td>
         <td class="field-notes">American Indian or Alaska Native tribal information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="consentToShareInformation">
+        <td class="field-name">consentToShareInformation</td>
+        <td class="field-type">Yes/No</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Consent to share information with partner agencies.</td>
       </tr>
     </tbody>
   </table>
@@ -10538,6 +7883,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth" class="">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -10550,6 +7901,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber" class="">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -10561,6 +7918,48 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
+      </tr>
+      <tr data-field="demographicInfo" class="expandable">
+        <td class="field-name">demographicInfo</td>
+        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
+      </tr>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
+      </tr>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
+      </tr>
+      <tr data-field="employmentInfo" class="expandable">
+        <td class="field-name">employmentInfo</td>
+        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employment and self-employment information. [Nested]</td>
+      </tr>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="militaryInfo" class="expandable">
+        <td class="field-name">militaryInfo</td>
+        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Military and veteran status information. [Nested]</td>
+      </tr>
+      <tr data-field="tribalInfo" class="expandable">
+        <td class="field-name">tribalInfo</td>
+        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">American Indian or Alaska Native tribal information for this person. [Nested]</td>
       </tr>
       <tr data-field="consentToShareInformation" class="">
         <td class="field-name">consentToShareInformation</td>
@@ -10597,195 +7996,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Indicates eligibility for Medi-Cal.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="demographicInfo" class="expandable">
-        <td class="field-name">demographicInfo</td>
-        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employmentInfo" class="expandable">
-        <td class="field-name">employmentInfo</td>
-        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employment and self-employment information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="militaryInfo" class="expandable">
-        <td class="field-name">militaryInfo</td>
-        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Military and veteran status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="tribalInfo" class="expandable">
-        <td class="field-name">tribalInfo</td>
-        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">American Indian or Alaska Native tribal information for this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -10841,6 +8051,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required">&#10003;</td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth" class="">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -10853,6 +8069,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber" class="">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -10864,6 +8086,48 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
+      </tr>
+      <tr data-field="demographicInfo" class="expandable">
+        <td class="field-name">demographicInfo</td>
+        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
+      </tr>
+      <tr data-field="citizenshipInfo" class="expandable">
+        <td class="field-name">citizenshipInfo</td>
+        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
+      </tr>
+      <tr data-field="contactInfo" class="expandable">
+        <td class="field-name">contactInfo</td>
+        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
+      </tr>
+      <tr data-field="employmentInfo" class="expandable">
+        <td class="field-name">employmentInfo</td>
+        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employment and self-employment information. [Nested]</td>
+      </tr>
+      <tr data-field="educationInfo" class="expandable">
+        <td class="field-name">educationInfo</td>
+        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
+      </tr>
+      <tr data-field="militaryInfo" class="expandable">
+        <td class="field-name">militaryInfo</td>
+        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Military and veteran status information. [Nested]</td>
+      </tr>
+      <tr data-field="tribalInfo" class="expandable">
+        <td class="field-name">tribalInfo</td>
+        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">American Indian or Alaska Native tribal information for this person. [Nested]</td>
       </tr>
       <tr data-field="consentToShareInformation" class="">
         <td class="field-name">consentToShareInformation</td>
@@ -10912,195 +8176,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Indicates eligibility for Aid to the Needy Disabled - Colorado Supplement.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Citizenship Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="citizenshipInfo" class="expandable">
-        <td class="field-name">citizenshipInfo</td>
-        <td class="field-type">→ <a href="#CitizenshipInfo" class="type-link">CitizenshipInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Citizenship and immigration status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Contact Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="contactInfo" class="expandable">
-        <td class="field-name">contactInfo</td>
-        <td class="field-type">→ <a href="#ContactInfo" class="type-link">ContactInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Contact information and communication preferences. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Demographic Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="demographicInfo" class="expandable">
-        <td class="field-name">demographicInfo</td>
-        <td class="field-type">→ <a href="#DemographicInfo" class="type-link">DemographicInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Demographic information including sex, marital status, and race. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Education Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="educationInfo" class="expandable">
-        <td class="field-name">educationInfo</td>
-        <td class="field-type">→ <a href="#EducationInfo" class="type-link">EducationInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Student enrollment information for this person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employment Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employmentInfo" class="expandable">
-        <td class="field-name">employmentInfo</td>
-        <td class="field-type">→ <a href="#EmploymentInfo" class="type-link">EmploymentInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employment and self-employment information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Military Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="militaryInfo" class="expandable">
-        <td class="field-name">militaryInfo</td>
-        <td class="field-type">→ <a href="#MilitaryInfo" class="type-link">MilitaryInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Military and veteran status information. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required">&#10003;</td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Tribal Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="tribalInfo" class="expandable">
-        <td class="field-name">tribalInfo</td>
-        <td class="field-type">→ <a href="#TribalInfo" class="type-link">TribalInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">American Indian or Alaska Native tribal information for this person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11197,6 +8272,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11208,6 +8289,12 @@ UUIDs upon submission.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -11226,48 +8313,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether applicant tried to get medical support from this absent parent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11286,6 +8331,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11297,6 +8348,12 @@ UUIDs upon submission.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -11315,48 +8372,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether applicant tried to get medical support from this absent parent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11375,6 +8390,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11386,6 +8407,12 @@ UUIDs upon submission.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -11404,48 +8431,6 @@ UUIDs upon submission.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether applicant tried to get medical support from this absent parent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11605,6 +8590,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11617,6 +8608,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -11628,48 +8625,6 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11688,6 +8643,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11700,6 +8661,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -11711,48 +8678,6 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11771,6 +8696,12 @@ UUIDs upon submission.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -11783,6 +8714,12 @@ UUIDs upon submission.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -11794,48 +8731,6 @@ UUIDs upon submission.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -11997,6 +8892,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="programs" class="expandable">
+        <td class="field-name">programs</td>
+        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Program-specific screening flags. [Nested]</td>
+      </tr>
       <tr data-field="familyPlanning">
         <td class="field-name">familyPlanning</td>
         <td class="field-type">Multi-select</td>
@@ -12074,27 +8975,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Multi-select</td>
         <td class="field-required"></td>
         <td class="field-notes">Options: has military service</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Programs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="programs" class="expandable">
-        <td class="field-name">programs</td>
-        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Program-specific screening flags. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -12113,6 +8993,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="programs" class="expandable">
+        <td class="field-name">programs</td>
+        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Program-specific screening flags. [Nested]</td>
+      </tr>
       <tr data-field="familyPlanning">
         <td class="field-name">familyPlanning</td>
         <td class="field-type">Multi-select</td>
@@ -12190,27 +9076,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Multi-select</td>
         <td class="field-required"></td>
         <td class="field-notes">Options: has military service</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Programs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="programs" class="expandable">
-        <td class="field-name">programs</td>
-        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Program-specific screening flags. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -12229,6 +9094,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="programs" class="expandable">
+        <td class="field-name">programs</td>
+        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Program-specific screening flags. [Nested]</td>
+      </tr>
       <tr data-field="familyPlanning">
         <td class="field-name">familyPlanning</td>
         <td class="field-type">Multi-select</td>
@@ -12306,27 +9177,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Multi-select</td>
         <td class="field-required"></td>
         <td class="field-notes">Options: has military service</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Programs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="programs" class="expandable">
-        <td class="field-name">programs</td>
-        <td class="field-type">→ <a href="#Programs" class="type-link">Programs</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Program-specific screening flags. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -12354,6 +9204,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -12365,6 +9221,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -12402,63 +9264,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Whether this representative should receive official notices.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="applicantSignature" class="expandable">
         <td class="field-name">applicantSignature</td>
         <td class="field-type">→ <a href="#Signature" class="type-link">Signature</a></td>
@@ -12488,6 +9293,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -12499,6 +9310,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -12536,63 +9353,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Whether this representative should receive official notices.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="applicantSignature" class="expandable">
         <td class="field-name">applicantSignature</td>
         <td class="field-type">→ <a href="#Signature" class="type-link">Signature</a></td>
@@ -12622,6 +9382,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -12633,6 +9399,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -12670,63 +9442,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Whether this representative should receive official notices.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="applicantSignature" class="expandable">
         <td class="field-name">applicantSignature</td>
         <td class="field-type">→ <a href="#Signature" class="type-link">Signature</a></td>
@@ -12948,53 +9663,23 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Employer or business name.</td>
       </tr>
-      <tr data-field="identificationNumber">
-        <td class="field-name">identificationNumber</td>
-        <td class="field-type">Text</td>
+      <tr data-field="phone" class="expandable">
+        <td class="field-name">phone</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer Identification Number (EIN).</td>
+        <td class="field-notes">Employer phone number. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="address" class="expandable">
         <td class="field-name">address</td>
         <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employer address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="phone" class="expandable">
-        <td class="field-name">phone</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+      <tr data-field="identificationNumber">
+        <td class="field-name">identificationNumber</td>
+        <td class="field-type">Text</td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer phone number. [Nested]</td>
+        <td class="field-notes">Employer Identification Number (EIN).</td>
       </tr>
     </tbody>
   </table>
@@ -13019,53 +9704,23 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Employer or business name.</td>
       </tr>
-      <tr data-field="identificationNumber">
-        <td class="field-name">identificationNumber</td>
-        <td class="field-type">Text</td>
+      <tr data-field="phone" class="expandable">
+        <td class="field-name">phone</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer Identification Number (EIN).</td>
+        <td class="field-notes">Employer phone number. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="address" class="expandable">
         <td class="field-name">address</td>
         <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employer address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="phone" class="expandable">
-        <td class="field-name">phone</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+      <tr data-field="identificationNumber">
+        <td class="field-name">identificationNumber</td>
+        <td class="field-type">Text</td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer phone number. [Nested]</td>
+        <td class="field-notes">Employer Identification Number (EIN).</td>
       </tr>
     </tbody>
   </table>
@@ -13090,53 +9745,23 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Employer or business name.</td>
       </tr>
-      <tr data-field="identificationNumber">
-        <td class="field-name">identificationNumber</td>
-        <td class="field-type">Text</td>
+      <tr data-field="phone" class="expandable">
+        <td class="field-name">phone</td>
+        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer Identification Number (EIN).</td>
+        <td class="field-notes">Employer phone number. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="address" class="expandable">
         <td class="field-name">address</td>
         <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Employer address. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="phone" class="expandable">
-        <td class="field-name">phone</td>
-        <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
+      <tr data-field="identificationNumber">
+        <td class="field-name">identificationNumber</td>
+        <td class="field-type">Text</td>
         <td class="field-required"></td>
-        <td class="field-notes">Employer phone number. [Nested]</td>
+        <td class="field-notes">Employer Identification Number (EIN).</td>
       </tr>
     </tbody>
   </table>
@@ -13200,21 +9825,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Monthly rent payment amount.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Costs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilityCosts" class="expandable">
         <td class="field-name">utilityCosts</td>
         <td class="field-type">→ <a href="#UtilityCosts" class="type-link">UtilityCosts</a></td>
@@ -13274,21 +9884,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Monthly rent payment amount.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Costs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilityCosts" class="expandable">
         <td class="field-name">utilityCosts</td>
         <td class="field-type">→ <a href="#UtilityCosts" class="type-link">UtilityCosts</a></td>
@@ -13348,21 +9943,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Monthly rent payment amount.</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utility Costs</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilityCosts" class="expandable">
         <td class="field-name">utilityCosts</td>
         <td class="field-type">→ <a href="#UtilityCosts" class="type-link">UtilityCosts</a></td>
@@ -13393,6 +9973,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -13405,6 +9991,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -13416,48 +10008,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -13476,6 +10026,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -13488,6 +10044,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -13499,48 +10061,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -13559,6 +10079,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -13571,6 +10097,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
       </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">Phone</td>
@@ -13582,48 +10114,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Email</td>
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14111,6 +10601,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Options: medicare, tricare, va health care, peace corps, cobra, retiree health plan, employer sponsored, railroad retirement</td>
       </tr>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
+      </tr>
       <tr data-field="contactAboutCoverage">
         <td class="field-name">contactAboutCoverage</td>
         <td class="field-type">Text</td>
@@ -14152,27 +10648,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Text</td>
         <td class="field-required"></td>
         <td class="field-notes">Policy number (for non-employer plans).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14203,6 +10678,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Options: medicare, tricare, va health care, peace corps, cobra, retiree health plan, employer sponsored, railroad retirement</td>
       </tr>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
+      </tr>
       <tr data-field="contactAboutCoverage">
         <td class="field-name">contactAboutCoverage</td>
         <td class="field-type">Text</td>
@@ -14244,27 +10725,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Text</td>
         <td class="field-required"></td>
         <td class="field-notes">Policy number (for non-employer plans).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14295,6 +10755,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required">&#10003;</td>
         <td class="field-notes">Options: medicare, tricare, va health care, peace corps, cobra, retiree health plan, employer sponsored, railroad retirement</td>
       </tr>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
+      </tr>
       <tr data-field="contactAboutCoverage">
         <td class="field-name">contactAboutCoverage</td>
         <td class="field-type">Text</td>
@@ -14336,27 +10802,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Text</td>
         <td class="field-required"></td>
         <td class="field-notes">Policy number (for non-employer plans).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer offering the coverage (for employer_sponsored plans). [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14370,29 +10815,8 @@ Presence of a flag in an array indicates the condition is true.
   </div>
   <p class="description">Household-level expense information.</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expenses</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expenses</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -14409,21 +10833,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Rent expenses and settings. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utilities</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">→ <a href="#Utilities" class="type-link">Utilities</a></td>
@@ -14435,29 +10850,8 @@ Presence of a flag in an array indicates the condition is true.
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expenses</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expenses</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -14474,21 +10868,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Rent expenses and settings. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utilities</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">→ <a href="#Utilities" class="type-link">Utilities</a></td>
@@ -14500,29 +10885,8 @@ Presence of a flag in an array indicates the condition is true.
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage Expenses</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent Expenses</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -14539,21 +10903,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Rent expenses and settings. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utilities</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">→ <a href="#MortgageExpenses" class="type-link">MortgageExpenses</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">→ <a href="#Utilities" class="type-link">Utilities</a></td>
@@ -14584,6 +10939,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -14595,6 +10956,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -14625,48 +10992,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether meals are included with the rent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14685,6 +11010,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -14696,6 +11027,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -14726,48 +11063,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether meals are included with the rent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -14786,6 +11081,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -14797,6 +11098,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -14827,48 +11134,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Yes/No</td>
         <td class="field-required"></td>
         <td class="field-notes">Whether meals are included with the rent.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -15063,6 +11328,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -15122,27 +11393,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes">Amount of last paycheck (for ended jobs).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -15161,6 +11411,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -15220,27 +11476,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes">Amount of last paycheck (for ended jobs).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -15259,6 +11494,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="employer" class="expandable">
+        <td class="field-name">employer</td>
+        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Employer information. [Nested]</td>
+      </tr>
       <tr data-field="startDate">
         <td class="field-name">startDate</td>
         <td class="field-type">Date</td>
@@ -15318,27 +11559,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes">Amount of last paycheck (for ended jobs).</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Employer Info</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="employer" class="expandable">
-        <td class="field-name">employer</td>
-        <td class="field-type">→ <a href="#EmployerInfo" class="type-link">EmployerInfo</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Employer information. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -15367,8 +11587,8 @@ Presence of a flag in an array indicates the condition is true.
   </div>
   <p class="description">Medicare coverage information for eligibility determination.</p>
 <div class="attributes-content" data-state-content="base">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part A</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -15385,63 +11605,18 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part B</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partB" class="expandable">
         <td class="field-name">partB</td>
         <td class="field-type">→ <a href="#PartB" class="type-link">PartB</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part C</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partC" class="expandable">
         <td class="field-name">partC</td>
         <td class="field-type">→ <a href="#PartC" class="type-link">PartC</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part D</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partD" class="expandable">
         <td class="field-name">partD</td>
         <td class="field-type">→ <a href="#PartD" class="type-link">PartD</a></td>
@@ -15453,8 +11628,8 @@ Presence of a flag in an array indicates the condition is true.
 </div>
 </div>
 <div class="attributes-content" data-state-content="california" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part A</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -15471,63 +11646,18 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part B</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partB" class="expandable">
         <td class="field-name">partB</td>
         <td class="field-type">→ <a href="#PartB" class="type-link">PartB</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part C</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partC" class="expandable">
         <td class="field-name">partC</td>
         <td class="field-type">→ <a href="#PartC" class="type-link">PartC</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part D</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partD" class="expandable">
         <td class="field-name">partD</td>
         <td class="field-type">→ <a href="#PartD" class="type-link">PartD</a></td>
@@ -15539,8 +11669,8 @@ Presence of a flag in an array indicates the condition is true.
 </div>
 </div>
 <div class="attributes-content" data-state-content="colorado" style="display: none;">
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part A</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -15557,63 +11687,18 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part B</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partB" class="expandable">
         <td class="field-name">partB</td>
         <td class="field-type">→ <a href="#PartB" class="type-link">PartB</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part C</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partC" class="expandable">
         <td class="field-name">partC</td>
         <td class="field-type">→ <a href="#PartC" class="type-link">PartC</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Part D</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="partD" class="expandable">
         <td class="field-name">partD</td>
         <td class="field-type">→ <a href="#PartD" class="type-link">PartD</a></td>
@@ -15771,21 +11856,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -15821,21 +11891,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -15871,21 +11926,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -16049,116 +12089,41 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
-      <tr data-field="dateOfBirth">
-        <td class="field-name">dateOfBirth</td>
-        <td class="field-type">Date</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Birth date of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Email</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="email" class="expandable">
-        <td class="field-name">email</td>
-        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Email address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="name" class="expandable">
         <td class="field-name">name</td>
         <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="dateOfBirth">
+        <td class="field-name">dateOfBirth</td>
+        <td class="field-type">Date</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Birth date of the person.</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="socialSecurityNumber" class="expandable">
+        <td class="field-name">socialSecurityNumber</td>
+        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Phone number for the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityNumber" class="expandable">
-        <td class="field-name">socialSecurityNumber</td>
-        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+      <tr data-field="email" class="expandable">
+        <td class="field-name">email</td>
+        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+        <td class="field-notes">Email address of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16177,116 +12142,41 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
-      <tr data-field="dateOfBirth">
-        <td class="field-name">dateOfBirth</td>
-        <td class="field-type">Date</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Birth date of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Email</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="email" class="expandable">
-        <td class="field-name">email</td>
-        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Email address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="name" class="expandable">
         <td class="field-name">name</td>
         <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="dateOfBirth">
+        <td class="field-name">dateOfBirth</td>
+        <td class="field-type">Date</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Birth date of the person.</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="socialSecurityNumber" class="expandable">
+        <td class="field-name">socialSecurityNumber</td>
+        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Phone number for the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityNumber" class="expandable">
-        <td class="field-name">socialSecurityNumber</td>
-        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+      <tr data-field="email" class="expandable">
+        <td class="field-name">email</td>
+        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+        <td class="field-notes">Email address of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16305,116 +12195,41 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
-      <tr data-field="dateOfBirth">
-        <td class="field-name">dateOfBirth</td>
-        <td class="field-type">Date</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Birth date of the person.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Email</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="email" class="expandable">
-        <td class="field-name">email</td>
-        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Email address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="name" class="expandable">
         <td class="field-name">name</td>
         <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Legal name of the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Phone Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="dateOfBirth">
+        <td class="field-name">dateOfBirth</td>
+        <td class="field-type">Date</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Birth date of the person.</td>
       </tr>
-    </thead>
-    <tbody>
+      <tr data-field="socialSecurityNumber" class="expandable">
+        <td class="field-name">socialSecurityNumber</td>
+        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
+      </tr>
       <tr data-field="phoneNumber" class="expandable">
         <td class="field-name">phoneNumber</td>
         <td class="field-type">→ <a href="#PhoneNumber" class="type-link">PhoneNumber</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Phone number for the person. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Social Security Number</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="socialSecurityNumber" class="expandable">
-        <td class="field-name">socialSecurityNumber</td>
-        <td class="field-type">→ <a href="#SocialSecurityNumber" class="type-link">SocialSecurityNumber</a></td>
+      <tr data-field="email" class="expandable">
+        <td class="field-name">email</td>
+        <td class="field-type">→ <a href="#Email" class="type-link">Email</a></td>
         <td class="field-required"></td>
-        <td class="field-notes">Social Security Number for identity verification. [Nested]</td>
+        <td class="field-notes">Email address of the person. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16664,6 +12479,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="propertyAddress" class="expandable">
+        <td class="field-name">propertyAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
+      </tr>
       <tr data-field="primaryPropertyUse">
         <td class="field-name">primaryPropertyUse</td>
         <td class="field-type">Multi-select</td>
@@ -16681,27 +12502,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="propertyAddress" class="expandable">
-        <td class="field-name">propertyAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16726,6 +12526,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="propertyAddress" class="expandable">
+        <td class="field-name">propertyAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
+      </tr>
       <tr data-field="primaryPropertyUse">
         <td class="field-name">primaryPropertyUse</td>
         <td class="field-type">Multi-select</td>
@@ -16743,27 +12549,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="propertyAddress" class="expandable">
-        <td class="field-name">propertyAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16788,6 +12573,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
+      <tr data-field="propertyAddress" class="expandable">
+        <td class="field-name">propertyAddress</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
+      </tr>
       <tr data-field="primaryPropertyUse">
         <td class="field-name">primaryPropertyUse</td>
         <td class="field-type">Multi-select</td>
@@ -16805,27 +12596,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">Number</td>
         <td class="field-required"></td>
         <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="propertyAddress" class="expandable">
-        <td class="field-name">propertyAddress</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Residential or mailing address used to determine eligibility. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -16984,21 +12754,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -17040,21 +12795,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -17096,21 +12836,6 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Housing Expense Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → <a href="#HousingExpenseItem" class="type-link">HousingExpenseItem</a></td>
@@ -17293,32 +13018,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
-      <tr data-field="totalNetIncome">
-        <td class="field-name">totalNetIncome</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Other Business Cost</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="otherBusinessCosts" class="expandable">
         <td class="field-name">otherBusinessCosts</td>
         <td class="field-type">List of → <a href="#OtherBusinessCost" class="type-link">OtherBusinessCost</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="totalNetIncome">
+        <td class="field-name">totalNetIncome</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes"></td>
       </tr>
     </tbody>
   </table>
@@ -17391,32 +13101,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
-      <tr data-field="totalNetIncome">
-        <td class="field-name">totalNetIncome</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Other Business Cost</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="otherBusinessCosts" class="expandable">
         <td class="field-name">otherBusinessCosts</td>
         <td class="field-type">List of → <a href="#OtherBusinessCost" class="type-link">OtherBusinessCost</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="totalNetIncome">
+        <td class="field-name">totalNetIncome</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes"></td>
       </tr>
     </tbody>
   </table>
@@ -17489,32 +13184,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes"></td>
       </tr>
-      <tr data-field="totalNetIncome">
-        <td class="field-name">totalNetIncome</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes"></td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Other Business Cost</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="otherBusinessCosts" class="expandable">
         <td class="field-name">otherBusinessCosts</td>
         <td class="field-type">List of → <a href="#OtherBusinessCost" class="type-link">OtherBusinessCost</a></td>
         <td class="field-required"></td>
         <td class="field-notes">[Nested object]</td>
+      </tr>
+      <tr data-field="totalNetIncome">
+        <td class="field-name">totalNetIncome</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes"></td>
       </tr>
     </tbody>
   </table>
@@ -17783,6 +13463,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -17794,6 +13480,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -17807,74 +13499,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
       </tr>
-      <tr data-field="totalPeopleInHousehold">
-        <td class="field-name">totalPeopleInHousehold</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Person Identity</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="spouse" class="expandable">
         <td class="field-name">spouse</td>
         <td class="field-type">→ <a href="#PersonIdentity" class="type-link">PersonIdentity</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Basic identity and contact information for a person. [Nested]</td>
+      </tr>
+      <tr data-field="totalPeopleInHousehold">
+        <td class="field-name">totalPeopleInHousehold</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
       </tr>
     </tbody>
   </table>
@@ -17893,6 +13528,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -17904,6 +13545,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -17917,74 +13564,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
       </tr>
-      <tr data-field="totalPeopleInHousehold">
-        <td class="field-name">totalPeopleInHousehold</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Person Identity</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="spouse" class="expandable">
         <td class="field-name">spouse</td>
         <td class="field-type">→ <a href="#PersonIdentity" class="type-link">PersonIdentity</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Basic identity and contact information for a person. [Nested]</td>
+      </tr>
+      <tr data-field="totalPeopleInHousehold">
+        <td class="field-name">totalPeopleInHousehold</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
       </tr>
     </tbody>
   </table>
@@ -18003,6 +13593,12 @@ Presence of a flag in an array indicates the condition is true.
       </tr>
     </thead>
     <tbody>
+      <tr data-field="name" class="expandable">
+        <td class="field-name">name</td>
+        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Legal name of the person. [Nested]</td>
+      </tr>
       <tr data-field="dateOfBirth">
         <td class="field-name">dateOfBirth</td>
         <td class="field-type">Date</td>
@@ -18014,6 +13610,12 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-type">SSN</td>
         <td class="field-required"></td>
         <td class="field-notes">Social Security Number for identity verification.</td>
+      </tr>
+      <tr data-field="address" class="expandable">
+        <td class="field-name">address</td>
+        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
+        <td class="field-required"></td>
+        <td class="field-notes">Address of the person. [Nested]</td>
       </tr>
       <tr data-field="phoneNumber">
         <td class="field-name">phoneNumber</td>
@@ -18027,74 +13629,17 @@ Presence of a flag in an array indicates the condition is true.
         <td class="field-required"></td>
         <td class="field-notes">Email address of the person.</td>
       </tr>
-      <tr data-field="totalPeopleInHousehold">
-        <td class="field-name">totalPeopleInHousehold</td>
-        <td class="field-type">Number</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Address</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="address" class="expandable">
-        <td class="field-name">address</td>
-        <td class="field-type">→ <a href="#Address" class="type-link">Address</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Address of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Name</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="name" class="expandable">
-        <td class="field-name">name</td>
-        <td class="field-type">→ <a href="#Name" class="type-link">Name</a></td>
-        <td class="field-required"></td>
-        <td class="field-notes">Legal name of the person. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Person Identity</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="spouse" class="expandable">
         <td class="field-name">spouse</td>
         <td class="field-type">→ <a href="#PersonIdentity" class="type-link">PersonIdentity</a></td>
         <td class="field-required"></td>
         <td class="field-notes">Basic identity and contact information for a person. [Nested]</td>
+      </tr>
+      <tr data-field="totalPeopleInHousehold">
+        <td class="field-name">totalPeopleInHousehold</td>
+        <td class="field-type">Number</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Total number of people in the sponsor&#039;s household.</td>
       </tr>
     </tbody>
   </table>
@@ -18557,51 +14102,8 @@ Presence of a flag in an array indicates the condition is true.
     <h2>Household</h2>
   </div>
   <p class="description">Household information including members, occupants, expenses, and related data.</p>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Expenses</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="expenses" class="expandable">
-        <td class="field-name">expenses</td>
-        <td class="field-type">→ Expenses</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Household-level expense information (rent/mortgage/utilities). [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Health Insurance Plans</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="healthInsurancePlans" class="expandable">
-        <td class="field-name">healthInsurancePlans</td>
-        <td class="field-type">→ HealthInsurancePlans</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Health insurance plans available to household members, keyed by plan name. The key must match the plan&#039;s `planName` property.
- [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Member</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -18620,21 +14122,6 @@ Presence of a flag in an array indicates the condition is true.
 applicant (relationship=self). At least one member with relationship=self is required.
 </td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Other Occupant</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="otherOccupants">
         <td class="field-name">otherOccupants</td>
         <td class="field-type">List of → OtherOccupant</td>
@@ -18642,6 +14129,19 @@ applicant (relationship=self). At least one member with relationship=self is req
         <td class="field-notes">Other people living at the address who are not part of the household unit for
 benefits purposes (e.g., boarders, roomers).
 </td>
+      </tr>
+      <tr data-field="expenses" class="expandable">
+        <td class="field-name">expenses</td>
+        <td class="field-type">→ Expenses</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Household-level expense information (rent/mortgage/utilities). [Nested]</td>
+      </tr>
+      <tr data-field="healthInsurancePlans" class="expandable">
+        <td class="field-name">healthInsurancePlans</td>
+        <td class="field-type">→ HealthInsurancePlans</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Health insurance plans available to household members, keyed by plan name. The key must match the plan&#039;s `planName` property.
+ [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -18655,29 +14155,8 @@ benefits purposes (e.g., boarders, roomers).
     <h2>Signatures</h2>
   </div>
   <p class="description">Application signatures.</p>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Applicant Authorized Representative Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="applicantAuthorizedRepresentativeSignature" class="expandable">
-        <td class="field-name">applicantAuthorizedRepresentativeSignature</td>
-        <td class="field-type">→ ApplicantAuthorizedRepresentativeSignature</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Authorized representative signature for the applicant. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Applicant Signature</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -18694,47 +14173,23 @@ benefits purposes (e.g., boarders, roomers).
         <td class="field-required"></td>
         <td class="field-notes">Primary applicant signature. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Co Applicant Authorized Representative Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="coApplicantAuthorizedRepresentativeSignature" class="expandable">
-        <td class="field-name">coApplicantAuthorizedRepresentativeSignature</td>
-        <td class="field-type">→ CoApplicantAuthorizedRepresentativeSignature</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Authorized representative signature for the co-applicant. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Co Applicant Signature</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="coApplicantSignature" class="expandable">
         <td class="field-name">coApplicantSignature</td>
         <td class="field-type">→ CoApplicantSignature</td>
         <td class="field-required"></td>
         <td class="field-notes">Spouse/co-applicant signature if applicable. [Nested]</td>
+      </tr>
+      <tr data-field="applicantAuthorizedRepresentativeSignature" class="expandable">
+        <td class="field-name">applicantAuthorizedRepresentativeSignature</td>
+        <td class="field-type">→ ApplicantAuthorizedRepresentativeSignature</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Authorized representative signature for the applicant. [Nested]</td>
+      </tr>
+      <tr data-field="coApplicantAuthorizedRepresentativeSignature" class="expandable">
+        <td class="field-name">coApplicantAuthorizedRepresentativeSignature</td>
+        <td class="field-type">→ CoApplicantAuthorizedRepresentativeSignature</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Authorized representative signature for the co-applicant. [Nested]</td>
       </tr>
     </tbody>
   </table>
@@ -18988,8 +14443,8 @@ benefits purposes (e.g., boarders, roomers).
     <h2>EmploymentInfo</h2>
   </div>
   <p class="description">Employment and self-employment information.</p>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Job</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -19466,29 +14921,8 @@ benefits purposes (e.g., boarders, roomers).
     <h2>Expenses</h2>
   </div>
   <p class="description">Household-level expense information (rent/mortgage/utilities).</p>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Mortgage</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr data-field="mortgage" class="expandable">
-        <td class="field-name">mortgage</td>
-        <td class="field-type">→ Mortgage</td>
-        <td class="field-required"></td>
-        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Rent</h5>
+<div class="domain-group" style="--domain-color: #3498db; --domain-bg: #ebf5fb;">
+  <h5 class="domain-header"><span class="domain-indicator"></span>Fields</h5>
   <table class="property-table">
     <thead>
       <tr>
@@ -19505,21 +14939,12 @@ benefits purposes (e.g., boarders, roomers).
         <td class="field-required"></td>
         <td class="field-notes">Rent expenses and settings. [Nested]</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Utilities</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
+      <tr data-field="mortgage" class="expandable">
+        <td class="field-name">mortgage</td>
+        <td class="field-type">→ Mortgage</td>
+        <td class="field-required"></td>
+        <td class="field-notes">Mortgage expenses and settings. [Nested]</td>
       </tr>
-    </thead>
-    <tbody>
       <tr data-field="utilities" class="expandable">
         <td class="field-name">utilities</td>
         <td class="field-type">→ <a href="#Utilities" class="type-link">Utilities</a></td>
@@ -19707,21 +15132,6 @@ benefits purposes (e.g., boarders, roomers).
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → Item</td>
@@ -19763,21 +15173,6 @@ benefits purposes (e.g., boarders, roomers).
         <td class="field-required"></td>
         <td class="field-notes">Options: section8, public housing</td>
       </tr>
-    </tbody>
-  </table>
-</div>
-<div class="domain-group" style="--domain-color: #566573; --domain-bg: #f2f3f4;">
-  <h5 class="domain-header"><span class="domain-indicator"></span>Item</h5>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>Field</th>
-        <th>Type</th>
-        <th>Req</th>
-        <th>Notes</th>
-      </tr>
-    </thead>
-    <tbody>
       <tr data-field="items" class="expandable">
         <td class="field-name">items</td>
         <td class="field-type">List of → Item</td>

--- a/packages/schemas/scripts/export-design-reference.js
+++ b/packages/schemas/scripts/export-design-reference.js
@@ -336,9 +336,8 @@ function formatEnumValues(schema) {
 
 /**
  * Get attribute category derived from property type and name
- * - Nested objects: use the referenced schema name (e.g., "→ ContactInfo" → "ContactInfo")
  * - System fields: group as "System"
- * - Other primitives: group as "Fields"
+ * - Everything else (primitives and nested objects): group as "Fields"
  */
 function getAttributeCategory(propName, propType) {
   // System fields
@@ -346,16 +345,7 @@ function getAttributeCategory(propName, propType) {
     return 'system';
   }
 
-  // Nested objects - derive from the referenced schema name
-  if (propType) {
-    // "→ ContactInfo" or "List of → ContactInfo"
-    const refMatch = propType.match(/→\s*(\w+)/);
-    if (refMatch) {
-      return refMatch[1]; // Return the schema name as the domain
-    }
-  }
-
-  // Default for primitives
+  // All other fields (including nested objects) go into 'fields'
   return 'fields';
 }
 


### PR DESCRIPTION
## Summary

- Add search functionality with dropdown showing field name, schema, type, and domain
- Click search results to jump directly to field with highlight animation
- Add "Used by" links showing parent schemas that reference each object
- Flatten attribute domains - all fields now in single "Fields" group instead of separate groups per nested object type
- Exclude CRUD operation schemas (*Create, *Update, *List) from reference

## Test plan

- [ ] Open the ORCA data explorer and verify search works
- [ ] Click a search result and verify it navigates to the correct field
- [ ] Verify fields are displayed in a single "Fields" group (not split by object type)
- [ ] Check "Used by" links on nested schemas like AbsentParent