### PR TITLE
Add behavioral contract YAML format and schema validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "validate": "npm run validate -w @codeforamerica/safety-net-blueprint-contracts",
     "validate:syntax": "npm run validate:syntax -w @codeforamerica/safety-net-blueprint-contracts",
     "validate:patterns": "npm run validate:patterns -w @codeforamerica/safety-net-blueprint-contracts",
+    "validate:schemas": "npm run validate:schemas -w @codeforamerica/safety-net-blueprint-contracts",
 "api:new": "npm run api:new -w @codeforamerica/safety-net-blueprint-contracts",
     "overlay:resolve": "node packages/contracts/scripts/resolve-overlay.js",
     "clients:typescript": "node packages/clients/scripts/generate-clients-typescript.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "prepack": "npm run design:reference && node ../../scripts/build-package-readme.js",
     "test": "node --test tests/unit/*.test.js",
-    "validate": "npm run validate:syntax && npm run validate:patterns",
+    "validate": "npm run validate:syntax && npm run validate:patterns && npm run validate:schemas",
+    "validate:schemas": "node scripts/validate-schemas.js --specs=.",
     "validate:syntax": "node scripts/validate-openapi.js --specs=.",
     "validate:lint": "npx spectral lint '*-openapi.yaml' --ignore-unknown-format",
     "validate:patterns": "node scripts/validate-patterns.js --specs=.",

--- a/packages/contracts/schemas/metrics-schema.yaml
+++ b/packages/contracts/schemas/metrics-schema.yaml
@@ -1,0 +1,125 @@
+# JSON Schema for Metrics YAML
+# Validates structural correctness. Cross-artifact references
+# (e.g., states/triggers matching state machine) are validated by the validation script.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Metrics
+description: Schema for behavioral contract metrics YAML files.
+type: object
+required:
+  - version
+  - domain
+  - stateMachine
+  - metrics
+additionalProperties: false
+
+properties:
+  version:
+    type: string
+    description: Schema version for change tracking.
+
+  domain:
+    type: string
+    description: Domain namespace (e.g., workflow).
+
+  stateMachine:
+    type: string
+    description: Filename of the associated state machine YAML.
+
+  metrics:
+    type: array
+    description: Metrics definitions.
+    items:
+      $ref: "#/$defs/Metric"
+    minItems: 1
+
+$defs:
+  Metric:
+    type: object
+    description: A single metric definition with source and targets.
+    required:
+      - id
+      - name
+      - description
+      - source
+      - targets
+    properties:
+      id:
+        type: string
+        description: Unique identifier (e.g., task_time_to_claim).
+      name:
+        type: string
+        description: Human-readable metric name.
+      description:
+        type: string
+        description: What this metric measures.
+      source:
+        $ref: "#/$defs/MetricSource"
+      targets:
+        type: array
+        items:
+          $ref: "#/$defs/MetricTarget"
+        minItems: 1
+    additionalProperties: false
+
+  MetricSource:
+    type: object
+    description: Where the metric data comes from — linked to state machine states/transitions.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - duration
+          - state_count
+          - transition_count
+        description: >
+          Source type: duration (time between states), state_count (objects in a state),
+          transition_count (how often a trigger fires).
+      from:
+        type: string
+        description: Source state (for duration metrics).
+      to:
+        type: string
+        description: Target state (for duration metrics).
+      trigger:
+        type: string
+        description: Transition trigger name (for duration or transition_count metrics).
+      state:
+        type: string
+        description: State to count objects in (for state_count metrics).
+      relativeTo:
+        type: string
+        description: Denominator for ratio metrics (e.g., "total" for rate calculations).
+    additionalProperties: false
+
+  MetricTarget:
+    type: object
+    description: A threshold or goal for the metric.
+    required:
+      - stat
+    properties:
+      stat:
+        type: string
+        description: >
+          Statistic type: p50, p95, p99, avg, max, trend, ratio, count.
+      operator:
+        type: string
+        enum:
+          - "<"
+          - "<="
+          - ">"
+          - ">="
+          - "=="
+        description: Comparison operator for the target value.
+      value:
+        type: string
+        description: Human-readable target value (e.g., "4h", "10%").
+      direction:
+        type: string
+        enum:
+          - up
+          - down
+        description: Desired trend direction (for trend-type targets).
+    additionalProperties: false

--- a/packages/contracts/schemas/rules-schema.yaml
+++ b/packages/contracts/schemas/rules-schema.yaml
@@ -1,0 +1,99 @@
+# JSON Schema for Rules YAML
+# Validates structural correctness. Cross-artifact references
+# (e.g., context variables resolving to real fields) are validated by the validation script.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Rules
+description: Schema for behavioral contract rules YAML files.
+type: object
+required:
+  - version
+  - domain
+  - context
+  - ruleSets
+additionalProperties: false
+
+properties:
+  version:
+    type: string
+    description: Schema version for change tracking.
+
+  domain:
+    type: string
+    description: Domain namespace (e.g., workflow).
+
+  context:
+    type: array
+    description: Variable bindings available to rule conditions (e.g., "task.*").
+    items:
+      type: string
+    minItems: 1
+
+  ruleSets:
+    type: array
+    description: Grouped sets of rules, filterable by ruleType.
+    items:
+      $ref: "#/$defs/RuleSet"
+    minItems: 1
+
+$defs:
+  RuleSet:
+    type: object
+    description: A group of rules with a shared type and evaluation strategy.
+    required:
+      - id
+      - ruleType
+      - evaluation
+      - rules
+    properties:
+      id:
+        type: string
+        description: Unique identifier for overlay targeting.
+      ruleType:
+        type: string
+        description: Rule category (e.g., assignment, priority, escalation, alert).
+      evaluation:
+        type: string
+        enum:
+          - first-match-wins
+        description: How rules are evaluated — first match stops.
+      rules:
+        type: array
+        items:
+          $ref: "#/$defs/Rule"
+        minItems: 1
+    additionalProperties: false
+
+  Rule:
+    type: object
+    description: A single rule with a condition and action.
+    required:
+      - id
+      - order
+      - condition
+      - action
+    properties:
+      id:
+        type: string
+        description: Unique identifier for overlay targeting.
+      order:
+        type: integer
+        description: Evaluation order within the ruleSet.
+        minimum: 1
+      condition:
+        description: >
+          JSON Logic expression evaluated against context variables.
+          Use `true` for catch-all/default rules.
+      action:
+        type: object
+        description: Type-specific action map (e.g., assignToQueue, setPriority).
+        minProperties: 1
+        additionalProperties: true
+      fallbackAction:
+        type: object
+        description: Action to take if the primary action fails (e.g., queue not found).
+        additionalProperties: true
+      description:
+        type: string
+        description: Human-readable description of what this rule does.
+    additionalProperties: false

--- a/packages/contracts/schemas/state-machine-schema.yaml
+++ b/packages/contracts/schemas/state-machine-schema.yaml
@@ -1,0 +1,257 @@
+# JSON Schema for State Machine YAML
+# Validates structural correctness. Cross-artifact references
+# (e.g., states matching OpenAPI enums) are validated by the validation script.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: State Machine
+description: Schema for behavioral contract state machine YAML files.
+type: object
+required:
+  - version
+  - object
+  - domain
+  - apiSpec
+  - states
+  - initialState
+  - transitions
+additionalProperties: false
+
+properties:
+  version:
+    type: string
+    description: Schema version for change tracking.
+
+  object:
+    type: string
+    description: The governed entity type (e.g., Task).
+
+  domain:
+    type: string
+    description: Domain namespace (e.g., workflow).
+
+  apiSpec:
+    type: string
+    description: Filename of the associated OpenAPI spec.
+
+  states:
+    type: object
+    description: Map of state names to state configuration.
+    minProperties: 1
+    additionalProperties:
+      $ref: "#/$defs/State"
+
+  initialState:
+    type: string
+    description: The state an object starts in after creation.
+
+  guards:
+    type: object
+    description: Named guard definitions, referenced by string in transitions.
+    additionalProperties:
+      $ref: "#/$defs/Guard"
+
+  onCreate:
+    $ref: "#/$defs/OnCreate"
+
+  transitions:
+    type: array
+    description: Ordered list of valid state transitions.
+    minItems: 1
+    items:
+      $ref: "#/$defs/Transition"
+
+  requestBodies:
+    type: object
+    description: Request body schemas keyed by trigger name.
+    additionalProperties:
+      $ref: "#/$defs/RequestBody"
+
+  audit:
+    $ref: "#/$defs/Audit"
+
+$defs:
+  State:
+    type: object
+    description: Configuration for a single state.
+    properties:
+      slaClock:
+        type: string
+        enum:
+          - running
+          - stopped
+          - paused
+        description: SLA clock behavior while in this state.
+    additionalProperties: true
+
+  Guard:
+    type: object
+    description: A named condition that must be true for a transition to fire.
+    required:
+      - field
+      - operator
+    properties:
+      field:
+        type: string
+        description: Field or variable reference to evaluate.
+      operator:
+        type: string
+        enum:
+          - is_null
+          - is_not_null
+          - equals
+          - not_equals
+          - contains_all
+          - contains_any
+        description: Comparison operator.
+      value:
+        description: Value to compare against (omit for is_null/is_not_null).
+    additionalProperties: false
+
+  OnCreate:
+    type: object
+    description: Effects that run when the object is created (no "from" state).
+    required:
+      - effects
+    properties:
+      actors:
+        type: array
+        items:
+          type: string
+        description: Who can create the object.
+      effects:
+        type: array
+        items:
+          $ref: "#/$defs/Effect"
+        minItems: 1
+    additionalProperties: false
+
+  Transition:
+    type: object
+    description: A valid state change with guards and effects.
+    required:
+      - trigger
+      - from
+      - to
+    properties:
+      trigger:
+        type: string
+        description: Action name — becomes the RPC endpoint.
+      from:
+        type: string
+        description: Source state.
+      to:
+        type: string
+        description: Target state.
+      actors:
+        type: array
+        items:
+          type: string
+        description: Roles that can trigger this transition.
+      guards:
+        type: array
+        items:
+          type: string
+        description: Guard names that must all pass.
+      effects:
+        type: array
+        items:
+          $ref: "#/$defs/Effect"
+        description: Side effects that occur when the transition fires.
+    additionalProperties: false
+
+  Effect:
+    type: object
+    description: A side effect that occurs during a transition or onCreate.
+    required:
+      - type
+    properties:
+      type:
+        type: string
+        enum:
+          - set
+          - create
+          - lookup
+          - evaluate-rules
+          - event
+        description: Effect type discriminator.
+      field:
+        type: string
+        description: Target field (for set effects).
+      value:
+        description: Value to set, or payload template.
+      entity:
+        type: string
+        description: Target entity (for create/lookup effects).
+      fields:
+        type: object
+        description: Field values for created records.
+        additionalProperties: true
+      lookupField:
+        type: string
+        description: Field to look up by (for lookup effects).
+      bindTo:
+        type: string
+        description: Variable to bind lookup results to.
+      relativeTo:
+        type: string
+        description: Reference point for relative values (e.g., $now).
+      name:
+        type: string
+        description: Event name (for event effects).
+      schema:
+        type: string
+        description: Event payload schema name (for event effects).
+      payload:
+        type: object
+        description: Event payload template (for event effects).
+        additionalProperties: true
+      ruleTypes:
+        type: array
+        items:
+          type: string
+        description: Rule types to evaluate (for evaluate-rules effects).
+      when:
+        description: JSON Logic condition — effect only fires when true.
+      description:
+        type: string
+        description: Human-readable description of what this effect does.
+    additionalProperties: false
+
+  RequestBody:
+    description: OpenAPI-style schema for a trigger's request body.
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        type: object
+        additionalProperties: true
+      required:
+        type: array
+        items:
+          type: string
+    additionalProperties: true
+
+  Audit:
+    type: object
+    description: Declarative audit requirements for validation.
+    required:
+      - entity
+      - scope
+      - requiredFields
+    properties:
+      entity:
+        type: string
+        description: The audit record entity type.
+      scope:
+        type: string
+        enum:
+          - all
+          - transitions-only
+        description: Whether audit covers all transitions + onCreate, or transitions only.
+      requiredFields:
+        type: array
+        items:
+          type: string
+        description: Fields that must be present on every audit record.
+    additionalProperties: false

--- a/packages/contracts/scripts/validate-schemas.js
+++ b/packages/contracts/scripts/validate-schemas.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Schema Validation Script
+ * Discovers YAML files with a $schema field and validates them against the declared schema.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'js-yaml';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Recursively find all .yaml files in a directory, excluding node_modules.
+ */
+function findYamlFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue;
+    const fullPath = resolve(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      results.push(...findYamlFiles(fullPath));
+    } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log('Schema Validator\n');
+    console.log('Usage: node scripts/validate-schemas.js --specs=<dir>\n');
+    console.log('Discovers YAML files with a $schema field and validates them');
+    console.log('against the declared JSON Schema.\n');
+    console.log('Flags:');
+    console.log('  --specs=<dir>  Path to specs directory (required)');
+    console.log('  -h, --help     Show this help message');
+    process.exit(0);
+  }
+
+  const specsArg = args.find(a => a.startsWith('--specs='));
+  if (!specsArg) {
+    console.error('Error: --specs=<dir> is required.\n');
+    console.error('Usage: node scripts/validate-schemas.js --specs=<dir>');
+    process.exit(1);
+  }
+  const specsDir = resolve(specsArg.split('=')[1]);
+
+  console.log('='.repeat(70));
+  console.log('Schema Validator');
+  console.log('='.repeat(70));
+
+  console.log(`\nDiscovering YAML files with $schema declarations...`);
+  console.log(`  Directory: ${specsDir}`);
+
+  const yamlFiles = findYamlFiles(specsDir);
+  const filesToValidate = [];
+
+  for (const filePath of yamlFiles) {
+    try {
+      const content = readFileSync(filePath, 'utf8');
+      const doc = yaml.load(content);
+      if (doc && typeof doc === 'object' && doc.$schema && !doc.$schema.startsWith('http')) {
+        const schemaPath = resolve(dirname(filePath), doc.$schema);
+        filesToValidate.push({ filePath, schemaPath, doc });
+      }
+    } catch {
+      // Skip files that fail to parse — they'll be caught by other validators
+    }
+  }
+
+  if (filesToValidate.length === 0) {
+    console.log('\n  No files with $schema declarations found. Nothing to validate.\n');
+    process.exit(0);
+  }
+
+  console.log(`  Found ${filesToValidate.length} file(s) to validate\n`);
+
+  const ajv = new Ajv2020({ strict: false, allErrors: true });
+  let hasErrors = false;
+  const results = [];
+
+  for (const { filePath, schemaPath, doc } of filesToValidate) {
+    const relFile = relative(specsDir, filePath);
+    const relSchema = relative(specsDir, schemaPath);
+
+    try {
+      const schemaContent = readFileSync(schemaPath, 'utf8');
+      const schema = yaml.load(schemaContent);
+      const validate = ajv.compile(schema);
+
+      // Remove $schema from doc before validating (it's metadata, not part of the data)
+      const { $schema, ...data } = doc;
+      const valid = validate(data);
+
+      if (valid) {
+        results.push({ relFile, relSchema, valid: true });
+      } else {
+        hasErrors = true;
+        results.push({ relFile, relSchema, valid: false, errors: validate.errors });
+      }
+    } catch (err) {
+      hasErrors = true;
+      results.push({ relFile, relSchema, valid: false, errors: [{ message: err.message }] });
+    }
+  }
+
+  // Display results
+  console.log('Validation Results:\n');
+  for (const r of results) {
+    if (r.valid) {
+      console.log(`  ✓ ${r.relFile}`);
+      console.log(`    schema: ${r.relSchema}`);
+    } else {
+      console.log(`  ✗ ${r.relFile}`);
+      console.log(`    schema: ${r.relSchema}`);
+      for (const err of r.errors) {
+        const path = err.instancePath || '(root)';
+        console.log(`    - ${path}: ${err.message}`);
+      }
+    }
+  }
+
+  console.log('\n' + '─'.repeat(60));
+  console.log(`\n  Total: ${results.length} file(s), ${results.filter(r => !r.valid).length} error(s)\n`);
+
+  if (hasErrors) {
+    console.log('✗ Schema validation failed\n');
+    process.exit(1);
+  } else {
+    console.log('✓ All schema validations passed!\n');
+    process.exit(0);
+  }
+}
+
+main();

--- a/packages/contracts/workflow-metrics.yaml
+++ b/packages/contracts/workflow-metrics.yaml
@@ -1,0 +1,44 @@
+# Workflow Metrics
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/metrics-schema.yaml
+
+version: "1.0"
+domain: workflow
+stateMachine: workflow-state-machine.yaml
+
+metrics:
+  - id: task_time_to_claim
+    name: Task time to claim
+    description: Time from task creation to first claim
+    source:
+      type: duration
+      from: pending
+      to: in_progress
+      trigger: claim
+    targets:
+      - stat: p95
+        operator: "<"
+        value: 4h
+
+  - id: tasks_in_queue
+    name: Tasks in queue
+    description: Tasks waiting to be claimed
+    source:
+      type: state_count
+      state: pending
+    targets:
+      - stat: trend
+        direction: down
+
+  - id: release_rate
+    name: Release rate
+    description: Rate of tasks being released back to queue
+    source:
+      type: transition_count
+      trigger: release
+      relativeTo: total
+    targets:
+      - stat: ratio
+        operator: "<"
+        value: 10%

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -1,0 +1,50 @@
+# Workflow Decision Rules
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/rules-schema.yaml
+
+version: "1.0"
+domain: workflow
+
+# Context variables available to rules.
+# The state machine binds the governed entity — in workflow, this is the task.
+context:
+  - "task.*"
+
+ruleSets:
+  - id: task-assignment
+    ruleType: assignment
+    evaluation: first-match-wins
+    rules:
+      - id: assign-snap-to-snap-intake
+        order: 1
+        condition:
+          "==":
+            - var: task.programType
+            - snap
+        action:
+          assignToQueue: snap-intake
+        fallbackAction:
+          assignToQueue: general-intake
+        description: Route SNAP tasks to the snap-intake queue, fall back to general-intake
+
+      - id: assign-default-to-general-intake
+        order: 2
+        condition: true
+        action:
+          assignToQueue: general-intake
+        description: Route all other tasks to general-intake (catch-all)
+
+  - id: task-priority
+    ruleType: priority
+    evaluation: first-match-wins
+    rules:
+      - id: expedited-tasks-get-expedited-priority
+        order: 1
+        condition:
+          "==":
+            - var: task.isExpedited
+            - true
+        action:
+          setPriority: expedited
+        description: Expedited tasks get expedited priority

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -1,0 +1,210 @@
+# Workflow Task State Machine
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/state-machine-schema.yaml
+
+version: "1.0"
+object: Task
+domain: workflow
+apiSpec: workflow-openapi.yaml
+
+# States — map keyed by state name for overlay targeting (e.g., $.states.pending.slaClock)
+states:
+  pending:
+    slaClock: running
+  in_progress:
+    slaClock: running
+  completed:
+    slaClock: stopped
+
+initialState: pending
+
+# Guards — named map, referenced by string in transitions. Reusable across transitions.
+guards:
+  taskIsUnassigned:
+    field: assignedToId
+    operator: is_null
+  workerHasRequiredSkills:
+    field: $caller.skills
+    operator: contains_all
+    value: $object.requiredSkills
+  callerIsAssignedWorker:
+    field: assignedToId
+    operator: equals
+    value: $caller.id
+
+# Effects that run when a Task is created (not a state transition — no "from" state).
+onCreate:
+  actors:
+    - supervisor
+    - system
+  effects:
+    - type: lookup
+      entity: SLAType
+      lookupField: slaTypeCode
+      bindTo: $bound.slaType
+      description: Load SLA configuration by task's slaTypeCode
+    - type: set
+      field: dueDate
+      value: $bound.slaType.durationDays
+      relativeTo: $now
+      description: Compute SLA deadline from SLAType duration
+    - type: set
+      field: slaInfo
+      value:
+        slaStatus: on_track
+        clockStartDate: $now
+        slaDeadline: $bound.slaType.durationDays
+      description: Initialize SLA tracking info
+    - type: evaluate-rules
+      ruleTypes:
+        - assignment
+        - priority
+      description: Route task to queue and set priority
+    - type: create
+      entity: TaskAuditEvent
+      fields:
+        taskId: $object.id
+        eventType: created
+        previousValue: null
+        newValue: pending
+        performedById: $caller.id
+        occurredAt: $now
+      description: Audit record for task creation
+
+# Transitions — ordered array of valid state changes
+transitions:
+  - trigger: claim
+    from: pending
+    to: in_progress
+    actors:
+      - caseworker
+    guards:
+      - taskIsUnassigned
+      - workerHasRequiredSkills
+    effects:
+      - type: set
+        field: assignedToId
+        value: $caller.id
+        description: Assign task to the claiming worker
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: assigned
+          previousValue: pending
+          newValue: in_progress
+          performedById: $caller.id
+          occurredAt: $now
+        description: Audit record for task claim
+      - type: event
+        name: task.claimed
+        schema: TaskClaimedEvent
+        payload:
+          taskId: $object.id
+          claimedById: $caller.id
+          queueId: $object.queueId
+          claimedAt: $now
+        description: Emit task claimed domain event
+
+  - trigger: complete
+    from: in_progress
+    to: completed
+    actors:
+      - caseworker
+    guards:
+      - callerIsAssignedWorker
+    effects:
+      - type: set
+        field: outcomeInfo
+        value:
+          outcome: $request.outcome
+          notes: $request.notes
+        description: Record completion outcome from request
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: completed
+          previousValue: in_progress
+          newValue: completed
+          performedById: $caller.id
+          occurredAt: $now
+        description: Audit record for task completion
+      - type: create
+        entity: Task
+        fields:
+          programType: $object.programType
+          slaTypeCode: $object.slaTypeCode
+          applicationId: $object.applicationId
+          caseId: $object.caseId
+          status: pending
+        when:
+          "==":
+            - var: $request.createFollowUp
+            - true
+        description: Create follow-up task when requested
+
+  - trigger: release
+    from: in_progress
+    to: pending
+    actors:
+      - caseworker
+    guards:
+      - callerIsAssignedWorker
+    effects:
+      - type: set
+        field: assignedToId
+        value: null
+        description: Clear assignment so task returns to queue
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: returned_to_queue
+          previousValue: in_progress
+          newValue: pending
+          performedById: $caller.id
+          reason: $request.reason
+          occurredAt: $now
+        description: Audit record for task release
+      - type: evaluate-rules
+        ruleTypes:
+          - assignment
+        description: Re-evaluate routing rules for released task
+
+# Request bodies — what each RPC endpoint accepts
+requestBodies:
+  claim: {}
+  complete:
+    type: object
+    properties:
+      outcome:
+        type: string
+        description: Completion outcome (e.g., approved, denied)
+      notes:
+        type: string
+        description: Optional notes about the completion
+      createFollowUp:
+        type: boolean
+        description: Whether to create a follow-up task
+    required:
+      - outcome
+  release:
+    type: object
+    properties:
+      reason:
+        type: string
+        description: Why the task is being released
+    required:
+      - reason
+
+# Audit — declarative requirements validated by the validation script
+audit:
+  entity: TaskAuditEvent
+  scope: all
+  requiredFields:
+    - taskId
+    - eventType
+    - performedById
+    - occurredAt


### PR DESCRIPTION
## Summary

Closes #87. Defines the YAML schema for three behavioral contract types — state machines, decision rules, and metrics — and adds auto-discovery schema validation to the preflight pipeline.

- **State machine** (`workflow-state-machine.yaml`): 3 states, 3 guards, 3 transitions + onCreate, 5 effect types, request bodies, audit block
- **Rules** (`workflow-rules.yaml`): 2 ruleSets (assignment + priority), JSON Logic conditions, first-match-wins evaluation
- **Metrics** (`workflow-metrics.yaml`): 3 metrics covering duration, state_count, and transition_count source types
- **JSON Schemas** (`schemas/`): structural validation for each contract type
- **Schema validator** (`validate-schemas.js`): auto-discovers YAML files with a `$schema` field and validates them — no hardcoded file list
- **Architecture doc**: added behavioral contract standards alignment section (Statecharts/SCXML, WS-HumanTask, DMN, OpenTelemetry, etc.)

## Test plan

- [x] `npm run validate` passes (syntax + patterns + schemas)
- [x] `npm run preflight` passes (all 7 checks)
- [ ] Review state machine YAML against workflow prototype tables
- [ ] Review JSON Schemas for completeness
- [ ] Verify standards alignment section accuracy