### PR TITLE
Add workflow task lifecycle behavioral contracts

### DIFF
--- a/packages/contracts/workflow-metrics.yaml
+++ b/packages/contracts/workflow-metrics.yaml
@@ -1,0 +1,44 @@
+# Workflow Metrics
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/metrics-schema.yaml
+
+version: "1.0"
+domain: workflow
+stateMachine: workflow-state-machine.yaml
+
+metrics:
+  - id: task_time_to_claim
+    name: Task time to claim
+    description: Time from task creation to first claim
+    source:
+      type: duration
+      from: pending
+      to: in_progress
+      trigger: claim
+    targets:
+      - stat: p95
+        operator: "<"
+        value: 4h
+
+  - id: tasks_in_queue
+    name: Tasks in queue
+    description: Tasks waiting to be claimed
+    source:
+      type: state_count
+      state: pending
+    targets:
+      - stat: trend
+        direction: down
+
+  - id: release_rate
+    name: Release rate
+    description: Rate of tasks being released back to queue
+    source:
+      type: transition_count
+      trigger: release
+      relativeTo: total
+    targets:
+      - stat: ratio
+        operator: "<"
+        value: 10%

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -1,0 +1,50 @@
+# Workflow Decision Rules
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/rules-schema.yaml
+
+version: "1.0"
+domain: workflow
+
+# Context variables available to rules.
+# The state machine binds the governed entity — in workflow, this is the task.
+context:
+  - "task.*"
+
+ruleSets:
+  - id: task-assignment
+    ruleType: assignment
+    evaluation: first-match-wins
+    rules:
+      - id: assign-snap-to-snap-intake
+        order: 1
+        condition:
+          "==":
+            - var: task.programType
+            - snap
+        action:
+          assignToQueue: snap-intake
+        fallbackAction:
+          assignToQueue: general-intake
+        description: Route SNAP tasks to the snap-intake queue, fall back to general-intake
+
+      - id: assign-default-to-general-intake
+        order: 2
+        condition: true
+        action:
+          assignToQueue: general-intake
+        description: Route all other tasks to general-intake (catch-all)
+
+  - id: task-priority
+    ruleType: priority
+    evaluation: first-match-wins
+    rules:
+      - id: expedited-tasks-get-expedited-priority
+        order: 1
+        condition:
+          "==":
+            - var: task.isExpedited
+            - true
+        action:
+          setPriority: expedited
+        description: Expedited tasks get expedited priority

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -1,0 +1,210 @@
+# Workflow Task State Machine
+# Generated from spreadsheet tables — do not edit by hand.
+
+$schema: ./schemas/state-machine-schema.yaml
+
+version: "1.0"
+object: Task
+domain: workflow
+apiSpec: workflow-openapi.yaml
+
+# States — map keyed by state name for overlay targeting (e.g., $.states.pending.slaClock)
+states:
+  pending:
+    slaClock: running
+  in_progress:
+    slaClock: running
+  completed:
+    slaClock: stopped
+
+initialState: pending
+
+# Guards — named map, referenced by string in transitions. Reusable across transitions.
+guards:
+  taskIsUnassigned:
+    field: assignedToId
+    operator: is_null
+  workerHasRequiredSkills:
+    field: $caller.skills
+    operator: contains_all
+    value: $object.requiredSkills
+  callerIsAssignedWorker:
+    field: assignedToId
+    operator: equals
+    value: $caller.id
+
+# Effects that run when a Task is created (not a state transition — no "from" state).
+onCreate:
+  actors:
+    - supervisor
+    - system
+  effects:
+    - type: lookup
+      entity: SLAType
+      lookupField: slaTypeCode
+      bindTo: $bound.slaType
+      description: Load SLA configuration by task's slaTypeCode
+    - type: set
+      field: dueDate
+      value: $bound.slaType.durationDays
+      relativeTo: $now
+      description: Compute SLA deadline from SLAType duration
+    - type: set
+      field: slaInfo
+      value:
+        slaStatus: on_track
+        clockStartDate: $now
+        slaDeadline: $bound.slaType.durationDays
+      description: Initialize SLA tracking info
+    - type: evaluate-rules
+      ruleTypes:
+        - assignment
+        - priority
+      description: Route task to queue and set priority
+    - type: create
+      entity: TaskAuditEvent
+      fields:
+        taskId: $object.id
+        eventType: created
+        previousValue: null
+        newValue: pending
+        performedById: $caller.id
+        occurredAt: $now
+      description: Audit record for task creation
+
+# Transitions — ordered array of valid state changes
+transitions:
+  - trigger: claim
+    from: pending
+    to: in_progress
+    actors:
+      - caseworker
+    guards:
+      - taskIsUnassigned
+      - workerHasRequiredSkills
+    effects:
+      - type: set
+        field: assignedToId
+        value: $caller.id
+        description: Assign task to the claiming worker
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: assigned
+          previousValue: pending
+          newValue: in_progress
+          performedById: $caller.id
+          occurredAt: $now
+        description: Audit record for task claim
+      - type: event
+        name: task.claimed
+        schema: TaskClaimedEvent
+        payload:
+          taskId: $object.id
+          claimedById: $caller.id
+          queueId: $object.queueId
+          claimedAt: $now
+        description: Emit task claimed domain event
+
+  - trigger: complete
+    from: in_progress
+    to: completed
+    actors:
+      - caseworker
+    guards:
+      - callerIsAssignedWorker
+    effects:
+      - type: set
+        field: outcomeInfo
+        value:
+          outcome: $request.outcome
+          notes: $request.notes
+        description: Record completion outcome from request
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: completed
+          previousValue: in_progress
+          newValue: completed
+          performedById: $caller.id
+          occurredAt: $now
+        description: Audit record for task completion
+      - type: create
+        entity: Task
+        fields:
+          programType: $object.programType
+          slaTypeCode: $object.slaTypeCode
+          applicationId: $object.applicationId
+          caseId: $object.caseId
+          status: pending
+        when:
+          "==":
+            - var: $request.createFollowUp
+            - true
+        description: Create follow-up task when requested
+
+  - trigger: release
+    from: in_progress
+    to: pending
+    actors:
+      - caseworker
+    guards:
+      - callerIsAssignedWorker
+    effects:
+      - type: set
+        field: assignedToId
+        value: null
+        description: Clear assignment so task returns to queue
+      - type: create
+        entity: TaskAuditEvent
+        fields:
+          taskId: $object.id
+          eventType: returned_to_queue
+          previousValue: in_progress
+          newValue: pending
+          performedById: $caller.id
+          reason: $request.reason
+          occurredAt: $now
+        description: Audit record for task release
+      - type: evaluate-rules
+        ruleTypes:
+          - assignment
+        description: Re-evaluate routing rules for released task
+
+# Request bodies — what each RPC endpoint accepts
+requestBodies:
+  claim: {}
+  complete:
+    type: object
+    properties:
+      outcome:
+        type: string
+        description: Completion outcome (e.g., approved, denied)
+      notes:
+        type: string
+        description: Optional notes about the completion
+      createFollowUp:
+        type: boolean
+        description: Whether to create a follow-up task
+    required:
+      - outcome
+  release:
+    type: object
+    properties:
+      reason:
+        type: string
+        description: Why the task is being released
+    required:
+      - reason
+
+# Audit — declarative requirements validated by the validation script
+audit:
+  entity: TaskAuditEvent
+  scope: all
+  requiredFields:
+    - taskId
+    - eventType
+    - performedById
+    - occurredAt


### PR DESCRIPTION
## Summary

- State machine (`workflow-state-machine.yaml`): 3 states, 3 guards, 3 transitions + onCreate, 5 effect types, request bodies, audit block
- Rules (`workflow-rules.yaml`): 2 ruleSets (assignment + priority), JSON Logic conditions, first-match-wins evaluation
- Metrics (`workflow-metrics.yaml`): 3 metrics covering duration, state_count, and transition_count source types

Closes #88

## Test plan

- [ ] `npm run validate:schemas` passes
- [ ] Review state machine YAML against workflow prototype tables from #84
- [ ] Contracts are concise and readable (~200 lines total)