### PR TITLE
Repo cleanup: line endings, test globs, API title template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce LF line endings everywhere (repo and working tree)
+* text=auto eol=lf

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -15,7 +15,7 @@
     "typescript": "node scripts/generate-clients-typescript.js",
     "json-schema": "node scripts/generate-clients-json-schema.js",
     "postman": "node scripts/generate-postman.js",
-    "test": "node --test tests/*.test.js"
+    "test": "node --test tests/"
   },
   "engines": {
     "node": ">=20.19.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "prepack": "npm run design:reference && node ../../scripts/build-package-readme.js",
-    "test": "node --test tests/unit/*.test.js",
+    "test": "node --test tests/unit/",
     "validate": "npm run validate:syntax && npm run validate:patterns && npm run validate:schemas",
     "validate:schemas": "node scripts/validate-schemas.js --specs=.",
     "validate:syntax": "node scripts/validate-openapi.js --specs=.",

--- a/packages/contracts/scripts/generate-api.js
+++ b/packages/contracts/scripts/generate-api.js
@@ -119,7 +119,7 @@ function generateApiSpec(name, resource) {
 
   return `openapi: 3.1.0
 info:
-  title: ${resource} Service API
+  title: ${resource} API
   version: 1.0.0
   description: |
     REST API for managing ${resourcePluralLower}. The specification defines CRUD operations


### PR DESCRIPTION
## Summary

- Add `.gitattributes` to enforce LF line endings across the repo
- Use directory-based test globs instead of file-pattern globs in clients and contracts packages
- Drop "Service" from generated API title template (`Service API` → `API`)

Extracted from `prototype/harness` branch — these are independent of the harness work.

## Test plan

- [ ] `npm test` passes
- [ ] `npm run api:new -- --name "x" --resource "X"` generates spec with corrected title