### PR TITLE
Add utilities path for packaging.

### DIFF
--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -4,7 +4,8 @@
   "description": "Generated API clients and collections for Safety Net APIs",
   "type": "module",
   "files": [
-    "scripts/"
+    "scripts/",
+    "utility/"
   ],
   "bin": {
     "safety-net-generate-clients": "./scripts/generate-clients-typescript.js",


### PR DESCRIPTION
I forgot to add the new clients/utility directory to the package file there. As a result, the search-helpers.ts script is still not included in the packed version of the workspace.

This PR adds the directory, so that the script is included in the package.