### PR TITLE
Fix docs to use mock:start:all for Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install
 export STATE=<your-state>
 
 # Start mock server + Swagger UI
-npm start
+npm run mock:start:all
 ```
 
 Visit `http://localhost:3000` for interactive API docs.
@@ -50,7 +50,8 @@ Visit `http://localhost:3000` for interactive API docs.
 
 | Command | Description |
 |---------|-------------|
-| `npm start` | Start mock server + Swagger UI |
+| `npm start` | Start mock server |
+| `npm run mock:start:all` | Start mock server + Swagger UI |
 | `npm run validate` | Validate OpenAPI specs |
 | `npm run overlay:resolve` | Resolve state overlay (requires STATE) |
 | `npm run api:new` | Scaffold a new API spec |

--- a/docs/getting-started/backend-developers.md
+++ b/docs/getting-started/backend-developers.md
@@ -125,14 +125,14 @@ Today the mock server serves REST APIs (CRUD endpoints from OpenAPI specs). The 
 
 ```bash
 # Within this repository
-STATE=<your-state> npm start
+STATE=<your-state> npm run mock:start:all
 
 # Or in a state repository with resolved specs
 npm run mock:start
 ```
 
-- **Swagger UI:** http://localhost:3000 — browse endpoints
 - **Mock server:** http://localhost:1080 — API endpoints with in-memory database
+- **Swagger UI:** http://localhost:3000 — browse endpoints
 
 The target: adding a transition is a table row, not endpoint code.
 

--- a/docs/getting-started/frontend-developers.md
+++ b/docs/getting-started/frontend-developers.md
@@ -65,7 +65,7 @@ REACT_APP_API_URL=http://localhost:1080 npm start
 Browse all endpoints — REST and RPC — via Swagger UI:
 
 ```bash
-STATE=<your-state> npm start
+STATE=<your-state> npm run mock:start:all
 ```
 
 Visit http://localhost:3000 to see all endpoints and schemas.

--- a/docs/presentation/safety-net-openapi-overview.md
+++ b/docs/presentation/safety-net-openapi-overview.md
@@ -107,7 +107,7 @@ No more "I thought you were sending `firstName`, not `first_name`" conversations
 - Try API calls directly in your browser
 - No coding required to explore
 
-**Access:** `npm start` then visit `http://localhost:3000`
+**Access:** `npm run mock:start:all` then visit `http://localhost:3000`
 
 ---
 
@@ -562,7 +562,7 @@ npm install
 export STATE=california
 
 # Start exploring
-npm start
+npm run mock:start:all
 ```
 
 **Visit `http://localhost:3000` to browse the APIs**

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -8,7 +8,8 @@ All available npm scripts in the Safety Net APIs toolkit.
 
 | Command | Description |
 |---------|-------------|
-| `npm start` | Start mock server + Swagger UI |
+| `npm start` | Start mock server only |
+| `npm run mock:start:all` | Start mock server + Swagger UI |
 | `npm run validate` | Validate base specs |
 | `npm run mock:start` | Start mock server only |
 | `npm run mock:reset` | Reset database to example data |
@@ -121,10 +122,20 @@ The package is built using `@hey-api/openapi-ts` with the following plugins:
 
 ### `npm start`
 
-Starts both the mock server and Swagger UI.
+Starts the mock server only.
 
 ```bash
 STATE=<your-state> npm start
+```
+
+Default: http://localhost:1080
+
+### `npm run mock:start:all`
+
+Starts both the mock server and Swagger UI.
+
+```bash
+STATE=<your-state> npm run mock:start:all
 ```
 
 - Mock server: http://localhost:1080


### PR DESCRIPTION
I ran into trouble with the quick start because the command in the documentation appears to be incorrect.