### PR TITLE
Extract pagination into shared component (#147)

### DIFF
--- a/docs/architecture/domain-design.md
+++ b/docs/architecture/domain-design.md
@@ -290,6 +290,16 @@ For operational concerns (Configuration Management, Observability), see [API Arc
 
 ---
 
+## 5. Shared Components
+
+### Pagination
+
+All list endpoints share a single `Pagination` schema ([`components/pagination.yaml`](../../packages/contracts/components/pagination.yaml)) composed into each `{Resource}List` schema via `allOf`. The default strategy uses offset-based pagination (`total`, `limit`, `offset`, `hasNext`).
+
+States can swap the pagination strategy (e.g., cursor-based) by applying a single overlay to the `Pagination` component. See [`overlays/example/cursor-pagination.yaml`](../../packages/contracts/overlays/example/cursor-pagination.yaml) for an example.
+
+---
+
 ## Related Documents
 
 | Document | Description |

--- a/packages/contracts/applications-openapi.yaml
+++ b/packages/contracts/applications-openapi.yaml
@@ -2031,32 +2031,15 @@ components:
           
           Note: id, createdAt, and updatedAt are server-generated (readOnly) and cannot be updated.
     ApplicationList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Application"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of applications available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of applications requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more applications are available beyond the current page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Application"
 

--- a/packages/contracts/case-management-openapi.yaml
+++ b/packages/contracts/case-management-openapi.yaml
@@ -250,31 +250,14 @@ components:
           Note: id, createdAt, and updatedAt are server-generated (readOnly) and cannot be updated.
         minProperties: 1
     CaseList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Case"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of cases available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of cases requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more cases are available beyond the current page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Case"

--- a/packages/contracts/components/pagination.yaml
+++ b/packages/contracts/components/pagination.yaml
@@ -1,0 +1,23 @@
+Pagination:
+  type: object
+  required:
+  - total
+  - limit
+  - offset
+  properties:
+    total:
+      type: integer
+      minimum: 0
+      description: Total number of items available.
+    limit:
+      type: integer
+      minimum: 1
+      maximum: 100
+      description: Maximum number of items requested.
+    offset:
+      type: integer
+      minimum: 0
+      description: Number of items skipped before the current page.
+    hasNext:
+      type: boolean
+      description: Whether more items are available beyond the current page.

--- a/packages/contracts/households-openapi.yaml
+++ b/packages/contracts/households-openapi.yaml
@@ -233,32 +233,14 @@ components:
           Note: id, createdAt, and updatedAt are server-generated (readOnly) and cannot be updated.
         minProperties: 1
     HouseholdList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Household"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of households available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of households requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more households are available beyond the current
-            page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Household"

--- a/packages/contracts/incomes-openapi.yaml
+++ b/packages/contracts/incomes-openapi.yaml
@@ -286,31 +286,17 @@ components:
           The `type` field cannot be changed after creation.
         minProperties: 1
     IncomeList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Income"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of income available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of income requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Income"
     Employer:
       type: object
       description: An employer of one or more people.

--- a/packages/contracts/overlays/example/cursor-pagination.yaml
+++ b/packages/contracts/overlays/example/cursor-pagination.yaml
@@ -1,0 +1,48 @@
+overlay: 1.0.0
+info:
+  title: Cursor-Based Pagination
+  version: 1.0.0
+  description: |
+    Example overlay that swaps the default offset-based pagination for
+    cursor-based pagination. Apply this overlay to replace the shared
+    Pagination component and the OffsetParam query parameter.
+
+    After applying:
+    - Response fields: total, cursor, hasNext (instead of total, limit, offset, hasNext)
+    - Query parameter: cursor (instead of offset)
+
+actions:
+  # Replace the shared Pagination schema with cursor-based fields.
+  # Because all list schemas compose Pagination via allOf, this single
+  # change propagates to every {Resource}List response.
+  - target: $.Pagination
+    file: components/pagination.yaml
+    description: Replace offset pagination with cursor-based pagination
+    update:
+      type: object
+      required:
+      - total
+      properties:
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of items available.
+        cursor:
+          type: string
+          nullable: true
+          description: Opaque cursor for the next page. Null when no more results.
+        hasNext:
+          type: boolean
+          description: Whether more items are available beyond the current page.
+
+  # Replace the offset query parameter with a cursor parameter.
+  # OffsetParam is in components/common-parameters.yaml (top-level).
+  - target: $.OffsetParam
+    file: components/common-parameters.yaml
+    description: Replace offset parameter with cursor parameter
+    update:
+      name: cursor
+      in: query
+      schema:
+        type: string
+      description: Opaque cursor returned from a previous page. Omit for the first page.

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -64,8 +64,13 @@ list_endpoints:
       name: offset
       description: Number of items to skip (default 0)
 
-  # Response schema must include these properties
+  # Response schema must include these properties.
+  # Pagination fields (total, limit, offset, hasNext) are defined in a shared
+  # component and composed into each list schema via allOf:
+  #   $ref: "./components/pagination.yaml#/Pagination"
+  # States can swap the pagination strategy with a single overlay on Pagination.
   response:
+    pagination_component: "./components/pagination.yaml#/Pagination"
     required_properties:
       - name: items
         type: array

--- a/packages/contracts/persons-openapi.yaml
+++ b/packages/contracts/persons-openapi.yaml
@@ -482,35 +482,17 @@ components:
           Note: id, createdAt, and updatedAt are server-generated (readOnly) and cannot be updated.
         minProperties: 1
     PersonList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Person"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of persons available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of persons requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more persons are available beyond the current
-            page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Person"
   responses:
     Conflict:
       description: A conflict occurred with the current state of the resource.

--- a/packages/contracts/scheduling-openapi.yaml
+++ b/packages/contracts/scheduling-openapi.yaml
@@ -247,31 +247,14 @@ components:
           Note: id, createdAt, and updatedAt are server-generated (readOnly) and cannot be updated.
         minProperties: 1
     AppointmentList:
-      type: object
-      additionalProperties: false
-      required:
-      - items
-      - total
-      - limit
-      - offset
-      properties:
-        items:
-          type: array
+      unevaluatedProperties: false
+      allOf:
+      - "$ref": "./components/pagination.yaml#/Pagination"
+      - type: object
+        required:
+        - items
+        properties:
           items:
-            "$ref": "#/components/schemas/Appointment"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of appointments available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of appointments requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more appointments are available beyond the current page.
+            type: array
+            items:
+              "$ref": "#/components/schemas/Appointment"

--- a/packages/contracts/src/validation/pattern-validator.js
+++ b/packages/contracts/src/validation/pattern-validator.js
@@ -98,7 +98,26 @@ export function validateListResponseSchema(path, operation, errors) {
     return;
   }
 
-  const properties = schema.properties || {};
+  // Collect properties from allOf branches (supports shared Pagination component)
+  let properties = schema.properties || {};
+  if (schema.allOf) {
+    properties = {};
+    for (const branch of schema.allOf) {
+      if (branch.properties) {
+        Object.assign(properties, branch.properties);
+      }
+      // Recognize $ref to pagination.yaml as providing pagination properties
+      if (branch.$ref && branch.$ref.includes('pagination.yaml')) {
+        Object.assign(properties, {
+          total: { type: 'integer' },
+          limit: { type: 'integer' },
+          offset: { type: 'integer' },
+          hasNext: { type: 'boolean' }
+        });
+      }
+    }
+  }
+
   const requiredProps = ['items', 'total', 'limit', 'offset'];
 
   for (const prop of requiredProps) {

--- a/packages/contracts/users-openapi.yaml
+++ b/packages/contracts/users-openapi.yaml
@@ -423,31 +423,15 @@ components:
           $ref: "#/components/schemas/UserPreferences"
 
     UserList:
-      type: object
       description: Paginated list of users.
-      required:
-        - items
-        - total
-        - limit
-        - offset
-      properties:
-        items:
-          type: array
-          items:
-            $ref: "#/components/schemas/User"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of users matching the query.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of users requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of users skipped.
-        hasNext:
-          type: boolean
-          description: Whether more users exist beyond this page.
+      unevaluatedProperties: false
+      allOf:
+        - $ref: "./components/pagination.yaml#/Pagination"
+        - type: object
+          required:
+            - items
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/User"

--- a/packages/contracts/workflow-openapi.yaml
+++ b/packages/contracts/workflow-openapi.yaml
@@ -360,63 +360,29 @@ components:
           readOnly: true
 
     TaskAuditEventList:
-      type: object
       description: Paginated list of task audit events.
-      additionalProperties: false
-      required:
-        - items
-        - total
-        - limit
-        - offset
-      properties:
-        items:
-          type: array
-          items:
-            $ref: "#/components/schemas/TaskAuditEvent"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of task audit events available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of task audit events requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more task audit events are available beyond the current page.
+      unevaluatedProperties: false
+      allOf:
+        - $ref: "./components/pagination.yaml#/Pagination"
+        - type: object
+          required:
+            - items
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/TaskAuditEvent"
 
     TaskList:
-      type: object
       description: Paginated list of tasks.
-      additionalProperties: false
-      required:
-        - items
-        - total
-        - limit
-        - offset
-      properties:
-        items:
-          type: array
-          items:
-            $ref: "#/components/schemas/Task"
-        total:
-          type: integer
-          minimum: 0
-          description: Total number of tasks available.
-        limit:
-          type: integer
-          minimum: 1
-          maximum: 100
-          description: Maximum number of tasks requested.
-        offset:
-          type: integer
-          minimum: 0
-          description: Number of items skipped before the current page.
-        hasNext:
-          type: boolean
-          description: Indicates whether more tasks are available beyond the current page.
+      unevaluatedProperties: false
+      allOf:
+        - $ref: "./components/pagination.yaml#/Pagination"
+        - type: object
+          required:
+            - items
+          properties:
+            items:
+              type: array
+              items:
+                $ref: "#/components/schemas/Task"


### PR DESCRIPTION
## Summary

- Extract duplicated pagination fields (`total`, `limit`, `offset`, `hasNext`) into a shared `Pagination` component (`components/pagination.yaml`)
- Refactor all 9 list schemas to compose `Pagination` via `allOf` with `unevaluatedProperties: false` — response shape is unchanged
- Update pattern validator to traverse `allOf` branches when checking list response properties
- Add example cursor-based pagination overlay showing how states can swap the strategy with a single overlay
- Document the shared component in `domain-design.md` and `api-patterns.yaml`

Closes #147

## How to validate

1. Check the response shape is unchanged:
   ```bash
   # Start mock server and hit any list endpoint
   npm run mock:start &
   curl -s http://localhost:1080/persons | jq 'keys'
   # Should still return: ["hasNext", "items", "limit", "offset", "total"]
   kill %1
   ```

2. Run the full preflight suite:
   ```bash
   npm run preflight
   ```

3. Review the shared component and one list schema to confirm the `allOf` composition:
   ```bash
   cat packages/contracts/components/pagination.yaml
   grep -A 12 'PersonList:' packages/contracts/persons-openapi.yaml
   ```

4. Review the example cursor overlay:
   ```bash
   cat packages/contracts/overlays/example/cursor-pagination.yaml
   ```

## For states adopting cursor-based pagination

To swap from offset to cursor pagination, add the example overlay to your overlay pipeline:

1. Copy `overlays/example/cursor-pagination.yaml` into your state overlay directory
2. Include it when resolving your specs (the overlay replaces the `Pagination` schema and `OffsetParam` in one shot)
3. Update your adapter's list handlers to return `cursor` instead of `limit`/`offset`
4. No changes needed to individual API specs — all 9 list schemas inherit the new pagination shape automatically