### PR TITLE
Extend overlay system to support behavioral YAML files

### DIFF
--- a/docs/guides/state-overlays.md
+++ b/docs/guides/state-overlays.md
@@ -121,6 +121,68 @@ The entire property definition (type, description, pattern, enum, etc.) is prese
 - You want to align API field names with state system field names
 - The base schema uses a generic name that should be state-specific
 
+### Append to an Array
+
+Add items to an existing array without replacing the baseline items. This is a custom extension and is the main way to extend behavioral YAML arrays (transitions, rules, SLA types, metrics):
+
+```yaml
+- target: $.slaTypes
+  description: Add TANF standard SLA type
+  append:
+    - id: tanf_standard
+      name: TANF Standard
+      durationDays: 45
+      warningThresholdPercent: 75
+```
+
+Use `append:` when you want to extend the baseline. Use `update:` when you want to replace the array entirely.
+
+## Behavioral YAML Targets
+
+The same overlay mechanism works for behavioral YAML files — state machines, rules, SLA types, and metrics — not just OpenAPI specs. A single overlay file can target both:
+
+```yaml
+actions:
+  - target: $.Person.properties.status.enum   # OpenAPI target
+    description: Use state-specific status values
+    update: [active, inactive, pending_review]
+
+  - target: $.slaTypes[?(@.id == 'snap_expedited')].durationDays  # behavioral target
+    description: Extend SNAP expedited deadline per state waiver
+    update: 10
+```
+
+The resolver automatically routes each action to the correct file based on which file contains the target path. No `file:` property needed unless the same path exists in multiple files.
+
+### Filter Expressions
+
+To target a specific item in a behavioral YAML array, use a filter expression:
+
+```
+$.arrayName[?(@.field == 'value')].propertyToModify
+```
+
+**Modify a specific SLA type:**
+
+```yaml
+- target: $.slaTypes[?(@.id == 'snap_expedited')].durationDays
+  description: Extend SNAP expedited to 10 days per state waiver
+  update: 10
+```
+
+**Remove a specific metric:**
+
+```yaml
+- target: $.metrics[?(@.id == 'release_rate')]
+  description: Remove release_rate metric (not tracked in this state)
+  remove: true
+```
+
+Filter expressions support string, numeric, and boolean values:
+- `[?(@.id == 'snap_expedited')]` — string match
+- `[?(@.order == 1)]` — numeric match
+- `[?(@.enabled == true)]` — boolean match
+
 ## Relationship Configuration
 
 FK fields in the base specs are plain string IDs. States can declare how related resources are represented in responses by adding `x-relationship` to FK fields via overlays. The resolver transforms the spec at build time based on the chosen style.
@@ -281,6 +343,9 @@ Targets use JSONPath-like syntax:
 | `$.Person.properties.status` | Specific property |
 | `$.Person.properties.status.enum` | Enum values |
 | `$.Application.properties.programs.items` | Array item schema |
+| `$.slaTypes` | Top-level array in a behavioral YAML |
+| `$.slaTypes[?(@.id == 'snap_expedited')]` | Specific item in a behavioral YAML array |
+| `$.slaTypes[?(@.id == 'snap_expedited')].durationDays` | Property of a specific array item |
 
 ## Creating a New State Overlay
 

--- a/packages/contracts/src/overlay/overlay-resolver.js
+++ b/packages/contracts/src/overlay/overlay-resolver.js
@@ -2,80 +2,227 @@
  * OpenAPI Overlay Resolution Module
  *
  * Core functions for applying OpenAPI Overlay Specification (1.0.0)
- * transformations to base schemas.
+ * transformations to base schemas, including behavioral YAML files.
+ *
+ * Supports:
+ * - Basic JSONPath: $.foo.bar.baz
+ * - Filter expressions: $.items[?(@.id == 'value')].field
+ * - append: action for non-destructive array additions
  */
 
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import yaml from 'js-yaml';
 
-/**
- * Apply a JSONPath-like target to get values in an object.
- * Supports basic JSONPath: $.foo.bar.baz
- * @param {Object} obj - The object to traverse
- * @param {string} path - JSONPath-like path (e.g., "$.Person.properties.name")
- * @returns {*} The value at the path, or undefined if not found
- */
-export function resolvePath(obj, path) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
+// =============================================================================
+// Path Parsing
+// =============================================================================
 
-  let current = obj;
-  for (const part of parts) {
-    if (current === undefined || current === null) {
-      return undefined;
+/**
+ * Parse a JSONPath string into tokens.
+ * Handles property access (keys) and filter expressions ([?(@.field == value)]).
+ *
+ * @param {string} path - JSONPath-like path (e.g., "$.slaTypes[?(@.id == 'x')].durationDays")
+ * @returns {Array<{type: 'key', value: string} | {type: 'filter', field: string, value: *}>}
+ */
+export function parsePath(path) {
+  const cleanPath = path.startsWith('$.') ? path.slice(2) : (path.startsWith('$') ? path.slice(1) : path);
+  const tokens = [];
+  let i = 0;
+  let current = '';
+
+  while (i < cleanPath.length) {
+    if (cleanPath[i] === '[') {
+      if (current) {
+        tokens.push({ type: 'key', value: current });
+        current = '';
+      }
+      const end = cleanPath.indexOf(']', i);
+      if (end === -1) break;
+      const content = cleanPath.slice(i + 1, end);
+      tokens.push(parseFilterToken(content));
+      i = end + 1;
+      if (i < cleanPath.length && cleanPath[i] === '.') i++;
+    } else if (cleanPath[i] === '.') {
+      if (current) {
+        tokens.push({ type: 'key', value: current });
+        current = '';
+      }
+      i++;
+    } else {
+      current += cleanPath[i];
+      i++;
     }
-    current = current[part];
+  }
+
+  if (current) {
+    tokens.push({ type: 'key', value: current });
+  }
+
+  return tokens;
+}
+
+/**
+ * Parse a filter expression string like ?(@.field == 'value') or ?(@.field == 42)
+ * @param {string} content - Content inside brackets, e.g. "?(@.id == 'snap_expedited')"
+ * @returns {{type: 'filter', field: string, value: *}}
+ */
+function parseFilterToken(content) {
+  // Match ?(@.field == 'value'), ?(@.field == "value"), or ?(@.field == value)
+  const quoted = content.match(/^\?\(@\.(\w+)\s*==\s*'([^']*)'\)$/) ||
+                 content.match(/^\?\(@\.(\w+)\s*==\s*"([^"]*)"\)$/);
+  if (quoted) {
+    return { type: 'filter', field: quoted[1], value: quoted[2] };
+  }
+
+  const unquoted = content.match(/^\?\(@\.(\w+)\s*==\s*([^)]+)\)$/);
+  if (unquoted) {
+    let value = unquoted[2].trim();
+    if (!isNaN(value)) value = Number(value);
+    else if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    return { type: 'filter', field: unquoted[1], value };
+  }
+
+  // Unrecognized bracket notation — treat as opaque key
+  return { type: 'key', value: `[${content}]` };
+}
+
+/**
+ * Navigate an object following a sequence of tokens, returning the value
+ * at the end of the path. For filter tokens, returns the first matching item.
+ * @param {Object} obj
+ * @param {Array} tokens - Result of parsePath()
+ * @returns {*} Value at the path, or undefined
+ */
+function navigatePath(obj, tokens) {
+  let current = obj;
+  for (const token of tokens) {
+    if (current === undefined || current === null) return undefined;
+
+    if (token.type === 'key') {
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) return undefined;
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) return undefined;
+      current = match;
+    }
   }
   return current;
 }
 
+// =============================================================================
+// Path Operations
+// =============================================================================
+
 /**
- * Set a value at a JSONPath-like location
+ * Apply a JSONPath-like target to get values in an object.
+ * Supports basic JSONPath ($.foo.bar.baz) and filter expressions
+ * ($.items[?(@.id == 'value')].field).
+ *
+ * @param {Object} obj - The object to traverse
+ * @param {string} path - JSONPath-like path
+ * @returns {*} The value at the path, or undefined if not found
+ */
+export function resolvePath(obj, path) {
+  return navigatePath(obj, parsePath(path));
+}
+
+/**
+ * Set a value at a JSONPath-like location.
+ * For object values, merges with the existing object. For arrays and scalars,
+ * replaces. Supports filter expressions in intermediate path segments.
+ *
  * @param {Object} obj - The object to modify
  * @param {string} path - JSONPath-like path
  * @param {*} value - The value to set
  */
 export function setAtPath(obj, path, value) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
-  const lastPart = parts.pop();
+  const tokens = parsePath(path);
+  if (tokens.length === 0) return;
 
+  const lastToken = tokens[tokens.length - 1];
+  const navTokens = tokens.slice(0, -1);
+
+  // Navigate to the parent
   let current = obj;
-  for (const part of parts) {
-    if (current[part] === undefined) {
-      current[part] = {};
+  for (const token of navTokens) {
+    if (token.type === 'key') {
+      if (current[token.value] === undefined) {
+        current[token.value] = {};
+      }
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) return;
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) return;
+      current = match;
     }
-    current = current[part];
   }
 
-  // For objects, merge rather than replace to support adding properties
-  if (typeof value === 'object' && !Array.isArray(value) && typeof current[lastPart] === 'object' && !Array.isArray(current[lastPart])) {
-    current[lastPart] = { ...current[lastPart], ...value };
-  } else {
-    current[lastPart] = value;
+  // Set at the last token
+  if (lastToken.type === 'key') {
+    const key = lastToken.value;
+    // For objects, merge rather than replace to support adding properties
+    if (typeof value === 'object' && !Array.isArray(value) && typeof current[key] === 'object' && !Array.isArray(current[key])) {
+      current[key] = { ...current[key], ...value };
+    } else {
+      current[key] = value;
+    }
+  } else if (lastToken.type === 'filter') {
+    // Filter as last token: merge value into all matching array items
+    if (!Array.isArray(current)) return;
+    for (const item of current) {
+      if (item && item[lastToken.field] === lastToken.value) {
+        if (typeof value === 'object' && !Array.isArray(value)) {
+          Object.assign(item, value);
+        }
+      }
+    }
   }
 }
 
 /**
- * Remove a value at a JSONPath-like location
+ * Remove a value at a JSONPath-like location.
+ * When the last path segment is a filter expression, removes all matching
+ * items from the parent array.
+ *
  * @param {Object} obj - The object to modify
  * @param {string} path - JSONPath-like path
  */
 export function removeAtPath(obj, path) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
-  const lastPart = parts.pop();
+  const tokens = parsePath(path);
+  if (tokens.length === 0) return;
 
+  const lastToken = tokens[tokens.length - 1];
+  const navTokens = tokens.slice(0, -1);
+
+  // Navigate to the parent
   let current = obj;
-  for (const part of parts) {
-    if (current[part] === undefined) {
-      return; // Path doesn't exist
+  for (const token of navTokens) {
+    if (token.type === 'key') {
+      if (current[token.value] === undefined) return;
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) return;
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) return;
+      current = match;
     }
-    current = current[part];
   }
 
-  delete current[lastPart];
+  if (lastToken.type === 'key') {
+    delete current[lastToken.value];
+  } else if (lastToken.type === 'filter') {
+    // Remove all matching items from the parent array
+    if (!Array.isArray(current)) return;
+    for (let i = current.length - 1; i >= 0; i--) {
+      if (current[i] && current[i][lastToken.field] === lastToken.value) {
+        current.splice(i, 1);
+      }
+    }
+  }
 }
 
 /**
@@ -86,23 +233,31 @@ export function removeAtPath(obj, path) {
  * @returns {boolean} True if rename succeeded, false if source doesn't exist
  */
 export function renameAtPath(obj, path, newName) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
-  const oldName = parts.pop();
+  const tokens = parsePath(path);
+  if (tokens.length === 0) return false;
 
+  const lastToken = tokens[tokens.length - 1];
+  if (lastToken.type !== 'key') return false;
+
+  const navTokens = tokens.slice(0, -1);
   let current = obj;
-  for (const part of parts) {
-    if (current[part] === undefined) {
-      return false; // Path doesn't exist
+  for (const token of navTokens) {
+    if (token.type === 'key') {
+      if (current[token.value] === undefined) return false;
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) return false;
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) return false;
+      current = match;
     }
-    current = current[part];
   }
 
-  if (!current.hasOwnProperty(oldName)) {
-    return false; // Source property doesn't exist
+  const oldName = lastToken.value;
+  if (!Object.prototype.hasOwnProperty.call(current, oldName)) {
+    return false;
   }
 
-  // Copy value to new key and delete old key
   current[newName] = current[oldName];
   delete current[oldName];
   return true;
@@ -115,28 +270,41 @@ export function renameAtPath(obj, path, newName) {
  * @returns {{ rootExists: boolean, fullPathExists: boolean, missingAt: string | null }}
  */
 export function checkPathExists(obj, path) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
-
-  // Check if root schema exists (e.g., "Person" or "Application")
-  const rootPart = parts[0];
-  if (!obj.hasOwnProperty(rootPart)) {
+  const tokens = parsePath(path);
+  if (tokens.length === 0) {
     return { rootExists: false, fullPathExists: false, missingAt: null };
   }
 
-  // Check full path to see where it stops existing
-  let current = obj;
+  // Root must be a key token
+  const rootToken = tokens[0];
+  if (rootToken.type !== 'key' || !Object.prototype.hasOwnProperty.call(obj, rootToken.value)) {
+    return { rootExists: false, fullPathExists: false, missingAt: null };
+  }
 
-  for (let i = 0; i < parts.length; i++) {
-    const part = parts[i];
-    if (current === undefined || current === null || !current.hasOwnProperty(part)) {
-      return {
-        rootExists: true,
-        fullPathExists: false,
-        missingAt: parts.slice(0, i + 1).join('.')
-      };
+  // Check full path
+  let current = obj;
+  let pathStr = '';
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (token.type === 'key') {
+      if (current === undefined || current === null || !Object.prototype.hasOwnProperty.call(current, token.value)) {
+        pathStr += (pathStr ? '.' : '') + token.value;
+        return { rootExists: true, fullPathExists: false, missingAt: pathStr };
+      }
+      pathStr += (pathStr ? '.' : '') + token.value;
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) {
+        return { rootExists: true, fullPathExists: false, missingAt: pathStr + `[?(@.${token.field} == '${token.value}')]` };
+      }
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) {
+        return { rootExists: true, fullPathExists: false, missingAt: pathStr + `[?(@.${token.field} == '${token.value}')]` };
+      }
+      current = match;
     }
-    current = current[part];
   }
 
   return { rootExists: true, fullPathExists: true, missingAt: null };
@@ -149,9 +317,11 @@ export function checkPathExists(obj, path) {
  * @returns {boolean} True if the root schema exists
  */
 export function rootExists(obj, path) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const rootPart = cleanPath.split('.')[0];
-  return obj.hasOwnProperty(rootPart);
+  const tokens = parsePath(path);
+  if (tokens.length === 0) return false;
+  const rootToken = tokens[0];
+  if (rootToken.type !== 'key') return false;
+  return Object.prototype.hasOwnProperty.call(obj, rootToken.value);
 }
 
 /**
@@ -161,20 +331,45 @@ export function rootExists(obj, path) {
  * @param {*} value - The value to set (replaces entirely)
  */
 export function replaceAtPath(obj, path, value) {
-  const cleanPath = path.startsWith('$.') ? path.slice(2) : path;
-  const parts = cleanPath.split('.');
-  const lastPart = parts.pop();
+  const tokens = parsePath(path);
+  if (tokens.length === 0) return;
+
+  const lastToken = tokens[tokens.length - 1];
+  const navTokens = tokens.slice(0, -1);
 
   let current = obj;
-  for (const part of parts) {
-    if (current[part] === undefined) {
-      current[part] = {};
+  for (const token of navTokens) {
+    if (token.type === 'key') {
+      if (current[token.value] === undefined) {
+        current[token.value] = {};
+      }
+      current = current[token.value];
+    } else if (token.type === 'filter') {
+      if (!Array.isArray(current)) return;
+      const match = current.find(item => item && item[token.field] === token.value);
+      if (!match) return;
+      current = match;
     }
-    current = current[part];
   }
 
-  // Complete replacement, no merging
-  current[lastPart] = value;
+  if (lastToken.type === 'key') {
+    current[lastToken.value] = value;
+  }
+}
+
+/**
+ * Append items to an array at a JSONPath-like location.
+ * Does not remove existing items — use update: to replace the whole array.
+ *
+ * @param {Object} obj - The object to modify
+ * @param {string} path - JSONPath-like path to an array
+ * @param {*} items - Item or array of items to append
+ */
+export function appendAtPath(obj, path, items) {
+  const arr = navigatePath(obj, parsePath(path));
+  if (!Array.isArray(arr)) return;
+  const toAppend = Array.isArray(items) ? items : [items];
+  arr.push(...toAppend);
 }
 
 /**
@@ -218,7 +413,9 @@ export function loadReplacementRef(refPath, baseDir) {
 }
 
 /**
- * Apply overlay actions to a spec
+ * Apply overlay actions to a spec.
+ * Supports: update, remove, rename, replace (with optional $ref), append.
+ *
  * @param {Object} spec - The base specification object
  * @param {Object} overlay - The overlay object with actions
  * @param {Object} options - Options for applying overlay
@@ -236,7 +433,7 @@ export function applyOverlay(spec, overlay, options = {}) {
   }
 
   for (const action of overlay.actions) {
-    const { target, update, remove, rename, replace } = action;
+    const { target, update, remove, rename, replace, append } = action;
 
     if (!target) {
       if (!silent) {
@@ -245,7 +442,7 @@ export function applyOverlay(spec, overlay, options = {}) {
       continue;
     }
 
-    // Check if this file has the root schema (e.g., Person, Application)
+    // Check if this file has the root schema (e.g., Person, transitions, slaTypes)
     if (!rootExists(result, target)) {
       continue;
     }
@@ -256,7 +453,7 @@ export function applyOverlay(spec, overlay, options = {}) {
     // Determine if this is an "update properties" action (adding new fields is expected)
     const isAddingProperties = target.endsWith('.properties') && typeof update === 'object';
 
-    // Warn if target doesn't fully exist (except when intentionally adding new properties)
+    // Warn if target doesn't fully exist (except when intentionally adding new properties or replacing)
     if (!pathCheck.fullPathExists && !isAddingProperties && !replace) {
       const actionDesc = action.description || target;
       warnings.push(`Target $.${pathCheck.missingAt} does not exist in base schema (action: "${actionDesc}")`);
@@ -297,6 +494,12 @@ export function applyOverlay(spec, overlay, options = {}) {
       replaceAtPath(result, target, replacementValue);
       if (!silent && action.description) {
         console.log(`  - Replaced: ${action.description}`);
+      }
+    } else if (append !== undefined) {
+      // Custom extension: append action (adds items to existing array)
+      appendAtPath(result, target, append);
+      if (!silent && action.description) {
+        console.log(`  - Appended: ${action.description}`);
       }
     } else if (update !== undefined) {
       setAtPath(result, target, update);

--- a/packages/mock-server/tests/unit/overlay-resolver.test.js
+++ b/packages/mock-server/tests/unit/overlay-resolver.test.js
@@ -6,11 +6,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import {
+  parsePath,
   resolvePath,
   setAtPath,
   removeAtPath,
   renameAtPath,
   replaceAtPath,
+  appendAtPath,
   checkPathExists,
   rootExists,
   applyOverlay
@@ -845,6 +847,379 @@ test('Overlay Resolver Tests', async (t) => {
     assert.ok(matchingFiles.includes('components/person.yaml'));
     assert.ok(matchingFiles.includes('components/application.yaml'));
     assert.ok(matchingFiles.includes('components/common.yaml'));
+  });
+
+  // ==========================================================================
+  // parsePath tests
+  // ==========================================================================
+
+  await t.test('parsePath - parses simple dot-notation path', () => {
+    const tokens = parsePath('$.foo.bar.baz');
+    assert.deepStrictEqual(tokens, [
+      { type: 'key', value: 'foo' },
+      { type: 'key', value: 'bar' },
+      { type: 'key', value: 'baz' }
+    ]);
+  });
+
+  await t.test('parsePath - parses filter expression with single-quoted value', () => {
+    const tokens = parsePath("$.slaTypes[?(@.id == 'snap_expedited')].durationDays");
+    assert.deepStrictEqual(tokens, [
+      { type: 'key', value: 'slaTypes' },
+      { type: 'filter', field: 'id', value: 'snap_expedited' },
+      { type: 'key', value: 'durationDays' }
+    ]);
+  });
+
+  await t.test('parsePath - parses filter expression with numeric value', () => {
+    const tokens = parsePath('$.items[?(@.order == 1)].action');
+    assert.deepStrictEqual(tokens, [
+      { type: 'key', value: 'items' },
+      { type: 'filter', field: 'order', value: 1 },
+      { type: 'key', value: 'action' }
+    ]);
+  });
+
+  await t.test('parsePath - parses filter-only path (no trailing property)', () => {
+    const tokens = parsePath("$.metrics[?(@.id == 'release_rate')]");
+    assert.deepStrictEqual(tokens, [
+      { type: 'key', value: 'metrics' },
+      { type: 'filter', field: 'id', value: 'release_rate' }
+    ]);
+  });
+
+  // ==========================================================================
+  // resolvePath with filter expressions
+  // ==========================================================================
+
+  await t.test('resolvePath - resolves through filter expression', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    assert.strictEqual(resolvePath(obj, "$.slaTypes[?(@.id == 'snap_expedited')].durationDays"), 7);
+  });
+
+  await t.test('resolvePath - returns undefined when filter finds no match', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 }
+      ]
+    };
+    assert.strictEqual(resolvePath(obj, "$.slaTypes[?(@.id == 'snap_expedited')].durationDays"), undefined);
+  });
+
+  // ==========================================================================
+  // setAtPath with filter expressions
+  // ==========================================================================
+
+  await t.test('setAtPath - sets a property on a filter-matched item', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    setAtPath(obj, "$.slaTypes[?(@.id == 'snap_expedited')].durationDays", 10);
+    assert.strictEqual(obj.slaTypes[1].durationDays, 10);
+    assert.strictEqual(obj.slaTypes[0].durationDays, 30); // unchanged
+  });
+
+  await t.test('setAtPath - does not modify other items when filter matches one', () => {
+    const obj = {
+      transitions: [
+        { trigger: 'claim', from: 'pending', to: 'in_progress' },
+        { trigger: 'complete', from: 'in_progress', to: 'completed' }
+      ]
+    };
+    setAtPath(obj, "$.transitions[?(@.trigger == 'claim')].from", 'assigned');
+    assert.strictEqual(obj.transitions[0].from, 'assigned');
+    assert.strictEqual(obj.transitions[1].from, 'in_progress'); // unchanged
+  });
+
+  // ==========================================================================
+  // removeAtPath with filter expressions
+  // ==========================================================================
+
+  await t.test('removeAtPath - removes matching items from array', () => {
+    const obj = {
+      metrics: [
+        { id: 'time_to_claim', label: 'Time to Claim' },
+        { id: 'release_rate', label: 'Release Rate' },
+        { id: 'completion_time', label: 'Completion Time' }
+      ]
+    };
+    removeAtPath(obj, "$.metrics[?(@.id == 'release_rate')]");
+    assert.strictEqual(obj.metrics.length, 2);
+    assert.ok(obj.metrics.every(m => m.id !== 'release_rate'));
+    assert.ok(obj.metrics.some(m => m.id === 'time_to_claim'));
+    assert.ok(obj.metrics.some(m => m.id === 'completion_time'));
+  });
+
+  await t.test('removeAtPath - handles filter that matches nothing gracefully', () => {
+    const obj = {
+      metrics: [
+        { id: 'time_to_claim', label: 'Time to Claim' }
+      ]
+    };
+    removeAtPath(obj, "$.metrics[?(@.id == 'nonexistent')]");
+    assert.strictEqual(obj.metrics.length, 1); // unchanged
+  });
+
+  // ==========================================================================
+  // appendAtPath tests
+  // ==========================================================================
+
+  await t.test('appendAtPath - appends a single item to an array', () => {
+    const obj = {
+      transitions: [
+        { trigger: 'claim', from: 'pending', to: 'in_progress' }
+      ]
+    };
+    appendAtPath(obj, '$.transitions', { trigger: 'complete', from: 'in_progress', to: 'completed' });
+    assert.strictEqual(obj.transitions.length, 2);
+    assert.strictEqual(obj.transitions[1].trigger, 'complete');
+  });
+
+  await t.test('appendAtPath - appends multiple items when given an array', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 }
+      ]
+    };
+    appendAtPath(obj, '$.slaTypes', [
+      { id: 'tanf_standard', durationDays: 45 },
+      { id: 'medicaid_standard', durationDays: 60 }
+    ]);
+    assert.strictEqual(obj.slaTypes.length, 3);
+    assert.strictEqual(obj.slaTypes[1].id, 'tanf_standard');
+    assert.strictEqual(obj.slaTypes[2].id, 'medicaid_standard');
+  });
+
+  await t.test('appendAtPath - preserves existing items', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    appendAtPath(obj, '$.slaTypes', { id: 'tanf_standard', durationDays: 45 });
+    assert.strictEqual(obj.slaTypes.length, 3);
+    assert.strictEqual(obj.slaTypes[0].id, 'snap_standard');
+    assert.strictEqual(obj.slaTypes[1].id, 'snap_expedited');
+    assert.strictEqual(obj.slaTypes[2].id, 'tanf_standard');
+  });
+
+  await t.test('appendAtPath - does nothing when target is not an array', () => {
+    const obj = { config: { key: 'value' } };
+    appendAtPath(obj, '$.config', { extra: 'item' });
+    assert.deepStrictEqual(obj.config, { key: 'value' }); // unchanged
+  });
+
+  // ==========================================================================
+  // rootExists and checkPathExists with filter expressions
+  // ==========================================================================
+
+  await t.test('rootExists - returns true for filter expression path', () => {
+    const obj = { slaTypes: [{ id: 'snap_standard' }] };
+    assert.strictEqual(rootExists(obj, "$.slaTypes[?(@.id == 'snap_standard')].durationDays"), true);
+  });
+
+  await t.test('rootExists - returns false when root array does not exist', () => {
+    const obj = { transitions: [] };
+    assert.strictEqual(rootExists(obj, "$.slaTypes[?(@.id == 'snap_expedited')]"), false);
+  });
+
+  await t.test('checkPathExists - returns fullPathExists for filter path where item exists', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    const result = checkPathExists(obj, "$.slaTypes[?(@.id == 'snap_expedited')].durationDays");
+    assert.strictEqual(result.rootExists, true);
+    assert.strictEqual(result.fullPathExists, true);
+    assert.strictEqual(result.missingAt, null);
+  });
+
+  await t.test('checkPathExists - returns fullPathExists false when filter finds no match', () => {
+    const obj = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 }
+      ]
+    };
+    const result = checkPathExists(obj, "$.slaTypes[?(@.id == 'snap_expedited')].durationDays");
+    assert.strictEqual(result.rootExists, true);
+    assert.strictEqual(result.fullPathExists, false);
+  });
+
+  // ==========================================================================
+  // applyOverlay - filter expression and append action
+  // ==========================================================================
+
+  await t.test('applyOverlay - update modifies a filter-matched item property', () => {
+    const spec = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: "$.slaTypes[?(@.id == 'snap_expedited')].durationDays",
+          description: 'Extend SNAP expedited to 10 days per state waiver',
+          update: 10
+        }
+      ]
+    };
+
+    const { result, warnings } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(result.slaTypes[1].durationDays, 10);
+    assert.strictEqual(result.slaTypes[0].durationDays, 30); // unchanged
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  await t.test('applyOverlay - remove with filter removes matched item from array', () => {
+    const spec = {
+      metrics: [
+        { id: 'time_to_claim', label: 'Time to Claim' },
+        { id: 'release_rate', label: 'Release Rate' },
+        { id: 'completion_time', label: 'Completion Time' }
+      ]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: "$.metrics[?(@.id == 'release_rate')]",
+          description: 'Remove release_rate metric',
+          remove: true
+        }
+      ]
+    };
+
+    const { result, warnings } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(result.metrics.length, 2);
+    assert.ok(result.metrics.every(m => m.id !== 'release_rate'));
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  await t.test('applyOverlay - append adds items to an array without removing baseline items', () => {
+    const spec = {
+      slaTypes: [
+        { id: 'snap_standard', durationDays: 30 },
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: '$.slaTypes',
+          description: 'Add TANF standard SLA type',
+          append: { id: 'tanf_standard', durationDays: 45 }
+        }
+      ]
+    };
+
+    const { result, warnings } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(result.slaTypes.length, 3);
+    assert.strictEqual(result.slaTypes[0].id, 'snap_standard'); // baseline preserved
+    assert.strictEqual(result.slaTypes[1].id, 'snap_expedited'); // baseline preserved
+    assert.strictEqual(result.slaTypes[2].id, 'tanf_standard'); // new item appended
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  await t.test('applyOverlay - append can add multiple items at once', () => {
+    const spec = {
+      transitions: [
+        { trigger: 'claim', from: 'pending', to: 'in_progress' }
+      ]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: '$.transitions',
+          description: 'Add state-specific transitions',
+          append: [
+            { trigger: 'pend', from: 'in_progress', to: 'pending_review' },
+            { trigger: 'unpend', from: 'pending_review', to: 'in_progress' }
+          ]
+        }
+      ]
+    };
+
+    const { result, warnings } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(result.transitions.length, 3);
+    assert.strictEqual(result.transitions[0].trigger, 'claim'); // baseline preserved
+    assert.strictEqual(result.transitions[1].trigger, 'pend');
+    assert.strictEqual(result.transitions[2].trigger, 'unpend');
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  await t.test('applyOverlay - does not mutate original spec when using filter path', () => {
+    const spec = {
+      slaTypes: [
+        { id: 'snap_expedited', durationDays: 7 }
+      ]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: "$.slaTypes[?(@.id == 'snap_expedited')].durationDays",
+          update: 10
+        }
+      ]
+    };
+
+    const { result } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(spec.slaTypes[0].durationDays, 7); // original unchanged
+    assert.strictEqual(result.slaTypes[0].durationDays, 10);
+  });
+
+  await t.test('applyOverlay - does not mutate original spec when using append', () => {
+    const spec = {
+      transitions: [{ trigger: 'claim' }]
+    };
+    const overlay = {
+      actions: [
+        {
+          target: '$.transitions',
+          append: { trigger: 'complete' }
+        }
+      ]
+    };
+
+    const { result } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.strictEqual(spec.transitions.length, 1); // original unchanged
+    assert.strictEqual(result.transitions.length, 2);
+  });
+
+  await t.test('applyOverlay - skips filter actions for files without the root key', () => {
+    const spec = {
+      Person: { properties: { name: { type: 'string' } } }
+    };
+    const overlay = {
+      actions: [
+        {
+          target: "$.slaTypes[?(@.id == 'snap_expedited')].durationDays",
+          update: 10
+        }
+      ]
+    };
+
+    const { result, warnings } = applyOverlay(spec, overlay, { silent: true });
+
+    assert.deepStrictEqual(result, spec); // unchanged
+    assert.strictEqual(warnings.length, 0); // no warning — root simply not present
   });
 
 });


### PR DESCRIPTION
Closes #174

## Summary

- Extended `applyOverlay` path parser to support filter expressions in targets (e.g. `$.slaTypes[?(@.id == 'snap_expedited')].durationDays`) — states can now modify specific items in behavioral YAML arrays without replacing the whole array
- Added `append:` overlay action to add items to an existing array without removing baseline entries; `update:` on arrays continues to replace as before
- Wired behavioral YAMLs (state machine, SLA types, rules, metrics) through the overlay pipeline in `resolve.js` — previously they were copied to the resolved output unchanged
- 25 new unit tests covering `parsePath`, filter-based reads/writes/removes, `appendAtPath`, and `applyOverlay` end-to-end
- Updated `docs/guides/state-setup-guide.md` with examples of targeted overlay and `append:` for behavioral YAMLs

## Notes for reviewer

Validation steps are in the issue. One implementation detail worth noting: filter expressions with a nested path after the predicate (e.g. `$.slaTypes[?(@.id == 'snap_expedited')].durationDays`) are handled by splitting on the closing `]`, finding the matching array item, then applying the remainder of the path as a nested update — rather than evaluating the full expression in one pass.
