### PR TITLE
refactor: convert states/guards/requestBodies to arrays in behavioral YAMLs

### DIFF
--- a/docs/guides/state-setup-guide.md
+++ b/docs/guides/state-setup-guide.md
@@ -210,7 +210,10 @@ When multiple API versions exist (e.g., `applications.yaml` and `applications-v2
 
 ## Customizing behavioral artifacts
 
-Overlays customize OpenAPI specs (schemas, enums, endpoints). Behavioral artifacts — state machines, rules, metrics — use a different customization model: states provide their own YAML files that replace the baseline entirely.
+Overlays customize OpenAPI specs (schemas, enums, endpoints). Behavioral artifacts — state machines, rules, metrics — can be customized in two ways:
+
+1. **Targeted overlay actions**: Use overlay filter expressions to modify specific items without touching the rest. This is the preferred approach for small changes.
+2. **Replace entirely**: Place your own file with the same name in your state's resolved specs directory. It replaces the base file — useful when the state lifecycle diverges significantly.
 
 The mock server discovers behavioral artifacts by file naming convention in the specs directory:
 
@@ -220,17 +223,52 @@ The mock server discovers behavioral artifacts by file naming convention in the 
 | Rules | `{domain}-rules.yaml` | `workflow-rules.yaml` |
 | Metrics | `{domain}-metrics.yaml` | `workflow-metrics.yaml` (planned) |
 
-To customize, place your own file with the same name in your state's resolved specs directory. It replaces the base file entirely — there is no merge.
-
 ### State machine
 
-The base `workflow-state-machine.yaml` defines 3 states and 4 transitions. States can replace this with their own lifecycle — adding states, transitions, guards, and effects.
+The base `workflow-state-machine.yaml` defines states, guards, transitions, and request bodies. States can extend or replace this with their own lifecycle.
 
 **Common customizations:**
 - Add states (e.g., `awaiting_client`, `escalated`, `supervisor_review`)
 - Add transitions between states (each trigger becomes an RPC endpoint automatically)
 - Add or modify guards (preconditions for transitions)
 - Add effects to transitions (`set` fields, `create` audit events, `evaluate-rules`)
+
+**Behavioral YAML format:** `states`, `guards`, and `requestBodies` are arrays. Each item has an `id` field (or `trigger` for request bodies) that identifies it. This allows overlay filter expressions to target individual items.
+
+**Targeted overlay example** — add a state and guard without replacing the whole file:
+
+```yaml
+# openapi/overlays/<your-state>/modifications.yaml
+overlay: 1.0.0
+info:
+  title: My State Overlay
+  version: 1.0.0
+
+actions:
+  # Add a new state
+  - target: $.states
+    file: workflow-state-machine.yaml
+    description: Add supervisor_review state
+    append:
+      - id: supervisor_review
+        slaClock: running
+
+  # Add a new guard
+  - target: $.guards
+    file: workflow-state-machine.yaml
+    description: Add callerIsReviewer guard
+    append:
+      - id: callerIsReviewer
+        field: $caller.role
+        operator: equals
+        value: reviewer
+
+  # Modify an existing state's SLA clock behavior
+  - target: $.states[?(@.id == 'escalated')].slaClock
+    file: workflow-state-machine.yaml
+    description: Keep escalated clock paused in this state
+    update: paused
+```
 
 See the [Workflow domain](../architecture/domains/workflow.md#state-machine) for the full state machine architecture and effect types.
 

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -195,6 +195,63 @@ rpc_endpoints:
     - Pattern validator skips CRUD POST rules (request body, 201, Location header)
     - Detected by isActionPath(): paths with segments after the {id} parameter
 
+# =============================================================================
+# Behavioral YAML Conventions
+# =============================================================================
+# State machine, rules, metrics, and SLA type YAML files are collectively called
+# "behavioral artifacts". They follow these conventions:
+behavioral_yaml:
+  # Always use arrays for config item collections — never object-as-map.
+  # Each item carries an identity field (id or trigger) instead of being keyed
+  # by property name.
+  #
+  # Why: Arrays support overlay filter targeting (e.g., [?(@.id == 'foo')]).
+  # Consumers that need O(1) lookup by id build an index map at load time.
+  # Object-as-map is appropriate ONLY in OpenAPI schemas (properties:) where
+  # merge-by-key semantics are intentional and well-understood.
+  collection_format:
+    preferred: array with id/trigger field
+    avoid: object-as-map
+    rationale: |
+      Arrays allow overlay filter expressions to target individual items.
+      Consumers build index maps at load time when O(1) lookup is needed.
+    examples:
+      # Correct — arrays
+      states:
+        - id: pending
+          slaClock: running
+        - id: in_progress
+          slaClock: running
+      guards:
+        - id: callerIsAssignedWorker
+          field: assignedToId
+          operator: equals
+          value: $caller.id
+      requestBodies:
+        - trigger: complete
+          type: object
+          properties:
+            outcome:
+              type: string
+          required: [outcome]
+      # Incorrect — avoid
+      states_avoid:
+        pending:
+          slaClock: running
+      guards_avoid:
+        callerIsAssignedWorker:
+          field: assignedToId
+
+  # Identity field naming:
+  # - Use id: for items that represent named concepts (states, guards, slaTypes, metrics)
+  # - Use trigger: for requestBodies, which are keyed by transition trigger name
+  identity_fields:
+    states: id
+    guards: id
+    slaTypes: id
+    metrics: id
+    requestBodies: trigger
+
 # RPC endpoints (POST with action verbs) are generated from state machine triggers.
 # REST endpoints follow standard CRUD patterns below.
 crud_operations:

--- a/packages/contracts/schemas/state-machine-schema.yaml
+++ b/packages/contracts/schemas/state-machine-schema.yaml
@@ -34,10 +34,10 @@ properties:
     description: Filename of the associated OpenAPI spec.
 
   states:
-    type: object
-    description: Map of state names to state configuration.
-    minProperties: 1
-    additionalProperties:
+    type: array
+    description: List of states with their configuration.
+    minItems: 1
+    items:
       $ref: "#/$defs/State"
 
   initialState:
@@ -45,9 +45,9 @@ properties:
     description: The state an object starts in after creation.
 
   guards:
-    type: object
-    description: Named guard definitions, referenced by string in transitions.
-    additionalProperties:
+    type: array
+    description: Guard definitions, referenced by id in transitions.
+    items:
       $ref: "#/$defs/Guard"
 
   onCreate:
@@ -64,9 +64,9 @@ properties:
       $ref: "#/$defs/Transition"
 
   requestBodies:
-    type: object
-    description: Request body schemas keyed by trigger name.
-    additionalProperties:
+    type: array
+    description: Request body schemas, one per trigger.
+    items:
       $ref: "#/$defs/RequestBody"
 
   audit:
@@ -77,8 +77,12 @@ $defs:
     type: object
     description: Configuration for a single state.
     required:
+      - id
       - slaClock
     properties:
+      id:
+        type: string
+        description: State identifier, used as the status value on the resource.
       slaClock:
         type: string
         enum:
@@ -92,9 +96,13 @@ $defs:
     type: object
     description: A named condition that must be true for a transition to fire.
     required:
+      - id
       - field
       - operator
     properties:
+      id:
+        type: string
+        description: Guard identifier, referenced by name in transitions.
       field:
         type: string
         description: Field or variable reference to evaluate.
@@ -290,7 +298,12 @@ $defs:
   RequestBody:
     description: OpenAPI-style schema for a trigger's request body.
     type: object
+    required:
+      - trigger
     properties:
+      trigger:
+        type: string
+        description: Transition trigger name this body applies to.
       type:
         type: string
       properties:

--- a/packages/contracts/scripts/export-contract-tables.js
+++ b/packages/contracts/scripts/export-contract-tables.js
@@ -181,13 +181,13 @@ function renderTransitions(doc) {
 function renderGuards(doc) {
   const headers = ['Guard Name', 'Field', 'Operator', 'Value'];
   const rows = [];
-  for (const [name, g] of Object.entries(doc.guards || {})) {
+  for (const g of doc.guards || []) {
     // Only JSON.stringify objects/arrays; leave strings and numbers as-is
     let value = '';
     if (g.value != null) {
       value = typeof g.value === 'object' ? JSON.stringify(g.value) : String(g.value);
     }
-    rows.push([name, g.field || '', g.operator || '', value]);
+    rows.push([g.id, g.field || '', g.operator || '', value]);
   }
   return csvTable(headers, rows);
 }
@@ -195,8 +195,8 @@ function renderGuards(doc) {
 function renderSla(doc) {
   const headers = ['State', 'SLA Clock'];
   const rows = [];
-  for (const [name, state] of Object.entries(doc.states || {})) {
-    rows.push([name, state.slaClock || '']);
+  for (const state of doc.states || []) {
+    rows.push([state.id, state.slaClock || '']);
   }
   return csvTable(headers, rows);
 }
@@ -204,16 +204,16 @@ function renderSla(doc) {
 function renderRequestBodies(doc) {
   const headers = ['Trigger', 'Fields'];
   const rows = [];
-  for (const [trigger, body] of Object.entries(doc.requestBodies || {})) {
+  for (const body of doc.requestBodies || []) {
     if (!body || !body.properties) {
-      rows.push([trigger, '(none)']);
+      rows.push([body.trigger, '(none)']);
     } else {
       const required = new Set(body.required || []);
       const fields = Object.entries(body.properties).map(([name, prop]) => {
         const req = required.has(name) ? ' (required)' : '';
         return `${name}: ${prop.type || 'any'}${req}`;
       });
-      rows.push([trigger, fields.join('; ')]);
+      rows.push([body.trigger, fields.join('; ')]);
     }
   }
   return csvTable(headers, rows);
@@ -435,11 +435,11 @@ function renderOverview(smDoc, rulesDoc) {
   lines.push('');
   lines.push('| State | SLA Clock |');
   lines.push('|-------|-----------|');
-  for (const [name, state] of Object.entries(smDoc.states || {})) {
+  for (const state of smDoc.states || []) {
     const clock = state.slaClock
       ? state.slaClock.charAt(0).toUpperCase() + state.slaClock.slice(1)
       : '';
-    lines.push(`| ${mdCell(name)} | ${mdCell(clock)} |`);
+    lines.push(`| ${mdCell(state.id)} | ${mdCell(clock)} |`);
   }
   lines.push('');
 
@@ -514,8 +514,8 @@ function renderOverview(smDoc, rulesDoc) {
   lines.push('');
   lines.push('| Guard | Condition |');
   lines.push('|-------|-----------|');
-  for (const [name, g] of Object.entries(smDoc.guards || {})) {
-    lines.push(`| \`${mdCell(name)}\` | ${mdCell(describeNamedGuard(g))} |`);
+  for (const g of smDoc.guards || []) {
+    lines.push(`| \`${mdCell(g.id)}\` | ${mdCell(describeNamedGuard(g))} |`);
   }
   lines.push('');
 
@@ -528,9 +528,9 @@ function renderOverview(smDoc, rulesDoc) {
   lines.push('');
   lines.push('| Trigger | Required | Optional |');
   lines.push('|---------|----------|----------|');
-  for (const [trigger, body] of Object.entries(smDoc.requestBodies || {})) {
+  for (const body of smDoc.requestBodies || []) {
     if (!body || !body.properties) {
-      lines.push(`| \`${trigger}\` | — | — |`);
+      lines.push(`| \`${body.trigger}\` | — | — |`);
     } else {
       const required = new Set(body.required || []);
       const reqFields = Object.entries(body.properties)
@@ -541,7 +541,7 @@ function renderOverview(smDoc, rulesDoc) {
         .filter(([n]) => !required.has(n))
         .map(([n, p]) => `\`${n}\` *(${p.type || 'any'})*`)
         .join(', ');
-      lines.push(`| \`${trigger}\` | ${reqFields || '—'} | ${optFields || '—'} |`);
+      lines.push(`| \`${body.trigger}\` | ${reqFields || '—'} | ${optFields || '—'} |`);
     }
   }
   lines.push('');

--- a/packages/contracts/scripts/generate-postman.js
+++ b/packages/contracts/scripts/generate-postman.js
@@ -163,7 +163,7 @@ function computeTransitionOrder(stateMachine) {
  * example's assignedToId or a generic test user ID.
  */
 function deriveCallerId(stateMachine, transitionOrder, fallback) {
-  const guardDefs = stateMachine.guards || {};
+  const guardDefs = Object.fromEntries((stateMachine.guards || []).map(g => [g.id, g]));
   const transitions = stateMachine.transitions || [];
 
   // Collect guard names referenced by the ordered transitions

--- a/packages/contracts/scripts/generate-rpc-overlay.js
+++ b/packages/contracts/scripts/generate-rpc-overlay.js
@@ -155,15 +155,17 @@ export function buildOperationId(trigger, objectName) {
  * @returns {Object|null} OpenAPI requestBody object, or null if no body needed
  */
 function buildRequestBody(bodyDef) {
-  if (!bodyDef || Object.keys(bodyDef).length === 0) {
-    return null;
-  }
+  if (!bodyDef) return null;
+
+  // Strip the trigger field; if nothing remains, no request body is needed
+  const { trigger: _trigger, ...schema } = bodyDef;
+  if (Object.keys(schema).length === 0) return null;
 
   return {
     required: true,
     content: {
       'application/json': {
-        schema: bodyDef
+        schema
       }
     }
   };
@@ -177,7 +179,7 @@ function buildRequestBody(bodyDef) {
  */
 export function generateOverlay(stateMachine, endpointInfo) {
   const { itemPath, paramRefs, tag, schemaRef } = endpointInfo;
-  const requestBodies = stateMachine.requestBodies || {};
+  const requestBodies = stateMachine.requestBodies || [];
 
   const pathsUpdate = {};
 
@@ -204,7 +206,7 @@ export function generateOverlay(stateMachine, endpointInfo) {
     }
 
     // Add request body if defined
-    const bodyDef = requestBodies[transition.trigger];
+    const bodyDef = requestBodies.find(rb => rb.trigger === transition.trigger);
     const requestBody = buildRequestBody(bodyDef);
     if (requestBody) {
       operation.requestBody = requestBody;

--- a/packages/contracts/scripts/import-contract-tables.js
+++ b/packages/contracts/scripts/import-contract-tables.js
@@ -285,14 +285,14 @@ function importTransitions(csvData, existingDoc) {
 
 function importGuards(csvData, existingDoc) {
   const doc = { ...existingDoc };
-  const guards = {};
+  const guards = [];
   for (const row of csvData.data) {
     const [name, field, operator, value] = row;
-    const guard = { field };
+    const guard = { id: name, field };
     if (operator) guard.operator = operator;
     const parsed = parseJsonField(value);
     if (parsed !== undefined && parsed !== '') guard.value = parsed;
-    guards[name] = guard;
+    guards.push(guard);
   }
   doc.guards = guards;
   return doc;
@@ -300,13 +300,14 @@ function importGuards(csvData, existingDoc) {
 
 function importSla(csvData, existingDoc) {
   const doc = { ...existingDoc };
-  const states = { ...(existingDoc.states || {}) };
+  const existingStates = existingDoc.states || [];
+  const states = [];
   for (const row of csvData.data) {
     const [name, slaClock] = row;
-    if (!states[name]) states[name] = {};
-    if (slaClock) {
-      states[name] = { ...states[name], slaClock };
-    }
+    const existing = existingStates.find(s => s.id === name) || {};
+    const state = { ...existing, id: name };
+    if (slaClock) state.slaClock = slaClock;
+    states.push(state);
   }
   doc.states = states;
   return doc;
@@ -314,14 +315,17 @@ function importSla(csvData, existingDoc) {
 
 function importRequestBodies(csvData, existingDoc) {
   const doc = { ...existingDoc };
-  const requestBodies = {};
+  const existingBodies = existingDoc.requestBodies || [];
+  const requestBodies = [];
   for (const row of csvData.data) {
     const [trigger, fields] = row;
     if (fields === '(none)' || !fields) {
-      requestBodies[trigger] = {};
+      requestBodies.push({ trigger });
     } else {
       // Preserve existing request body structure — the CSV is lossy for full schemas
-      requestBodies[trigger] = existingDoc.requestBodies?.[trigger] || {};
+      const existing = existingBodies.find(rb => rb.trigger === trigger) || {};
+      const { trigger: _t, ...rest } = existing;
+      requestBodies.push({ trigger, ...rest });
     }
   }
   doc.requestBodies = requestBodies;
@@ -535,10 +539,7 @@ function createStateMachineSkeleton(domain, resource, csvs, schemaRef) {
     }
   }
 
-  const statesObj = {};
-  for (const s of states) {
-    statesObj[s] = {};
-  }
+  const statesArr = [...states].map(s => ({ id: s }));
 
   return {
     $schema: schemaRef,
@@ -546,11 +547,11 @@ function createStateMachineSkeleton(domain, resource, csvs, schemaRef) {
     object: resource,
     domain,
     apiSpec: `${domain}-openapi.yaml`,
-    states: statesObj,
+    states: statesArr,
     initialState: initialState || 'pending',
-    guards: {},
+    guards: [],
     transitions: [],
-    requestBodies: {},
+    requestBodies: [],
   };
 }
 

--- a/packages/contracts/tests/unit/generate-rpc-overlay.test.js
+++ b/packages/contracts/tests/unit/generate-rpc-overlay.test.js
@@ -39,34 +39,40 @@ const sampleStateMachine = {
   domain: 'workflow',
   object: 'Task',
   apiSpec: 'workflow-openapi.yaml',
-  states: { pending: {}, in_progress: {}, completed: {} },
+  states: [
+    { id: 'pending' },
+    { id: 'in_progress' },
+    { id: 'completed' }
+  ],
   initialState: 'pending',
-  guards: {
-    taskIsUnassigned: { field: 'assignedToId', operator: 'is_null' },
-    callerIsAssignedWorker: { field: 'assignedToId', operator: 'equals', value: '$caller.id' }
-  },
+  guards: [
+    { id: 'taskIsUnassigned', field: 'assignedToId', operator: 'is_null' },
+    { id: 'callerIsAssignedWorker', field: 'assignedToId', operator: 'equals', value: '$caller.id' }
+  ],
   transitions: [
     { trigger: 'claim', from: 'pending', to: 'in_progress', guards: ['taskIsUnassigned'], effects: [{ type: 'set', field: 'assignedToId', value: '$caller.id' }] },
     { trigger: 'complete', from: 'in_progress', to: 'completed', guards: ['callerIsAssignedWorker'], effects: [] },
     { trigger: 'release', from: 'in_progress', to: 'pending', guards: ['callerIsAssignedWorker'], effects: [{ type: 'set', field: 'assignedToId', value: null }] }
   ],
-  requestBodies: {
-    claim: {},
-    complete: {
+  requestBodies: [
+    { trigger: 'claim' },
+    {
+      trigger: 'complete',
       type: 'object',
       properties: {
         outcome: { type: 'string', description: 'Completion outcome' }
       },
       required: ['outcome']
     },
-    release: {
+    {
+      trigger: 'release',
       type: 'object',
       properties: {
         reason: { type: 'string', description: 'Why the task is being released' }
       },
       required: ['reason']
     }
-  }
+  ]
 };
 
 const sampleEndpointInfo = {

--- a/packages/contracts/tests/unit/resolve.test.js
+++ b/packages/contracts/tests/unit/resolve.test.js
@@ -696,12 +696,12 @@ test('resolve-overlay tests', async (t) => {
         domain: 'test',
         object: 'Item',
         apiSpec: 'test-openapi.yaml',
-        states: { draft: {}, published: {} },
+        states: [{ id: 'draft' }, { id: 'published' }],
         initialState: 'draft',
         transitions: [
           { trigger: 'publish', from: 'draft', to: 'published' }
         ],
-        requestBodies: { publish: {} }
+        requestBodies: [{ trigger: 'publish' }]
       });
 
       // Collect yaml files the same way resolve.js does
@@ -763,13 +763,13 @@ test('resolve-overlay tests', async (t) => {
         domain: 'test',
         object: 'Item',
         apiSpec: 'test-openapi.yaml',
-        states: { draft: {}, published: {} },
+        states: [{ id: 'draft' }, { id: 'published' }],
         initialState: 'draft',
         transitions: [
           { trigger: 'publish', from: 'draft', to: 'published' },
           { trigger: 'archive', from: 'published', to: 'draft' }
         ],
-        requestBodies: { publish: {}, archive: {} }
+        requestBodies: [{ trigger: 'publish' }, { trigger: 'archive' }]
       });
 
       const yamlFiles = [
@@ -842,10 +842,10 @@ test('resolve-overlay tests', async (t) => {
         domain: 'test',
         object: 'Item',
         apiSpec: 'test-openapi.yaml',
-        states: { draft: {}, published: {} },
+        states: [{ id: 'draft' }, { id: 'published' }],
         initialState: 'draft',
         transitions: [{ trigger: 'publish', from: 'draft', to: 'published' }],
-        requestBodies: { publish: {} }
+        requestBodies: [{ trigger: 'publish' }]
       });
 
       const yamlFiles = [{

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -4,36 +4,36 @@ object: Task
 domain: workflow
 apiSpec: workflow-openapi.yaml
 states:
-  pending:
+  - id: pending
     slaClock: running
-  in_progress:
+  - id: in_progress
     slaClock: running
-  completed:
+  - id: completed
     slaClock: stopped
-  escalated:
+  - id: escalated
     slaClock: running
-  cancelled:
+  - id: cancelled
     slaClock: stopped
-  awaiting_client:
+  - id: awaiting_client
     slaClock: paused
-  awaiting_verification:
+  - id: awaiting_verification
     slaClock: paused
-  pending_review:
+  - id: pending_review
     slaClock: running
 initialState: pending
 guards:
-  taskIsUnassigned:
+  - id: taskIsUnassigned
     field: assignedToId
     operator: is_null
-  callerIsAssignedWorker:
+  - id: callerIsAssignedWorker
     field: assignedToId
     operator: equals
     value: $caller.id
-  callerIsSupervisor:
+  - id: callerIsSupervisor
     field: $caller.role
     operator: equals
     value: supervisor
-  callerIsSystem:
+  - id: callerIsSystem
     field: $caller.role
     operator: equals
     value: system
@@ -415,8 +415,8 @@ onUpdate:
       ruleType: assignment
       description: Re-evaluate assignment when queue or program type changes
 requestBodies:
-  claim: {}
-  complete:
+  - trigger: claim
+  - trigger: complete
     type: object
     properties:
       outcome:
@@ -430,7 +430,7 @@ requestBodies:
         description: When true, a follow-up task is automatically created
     required:
       - outcome
-  release:
+  - trigger: release
     type: object
     properties:
       reason:
@@ -438,7 +438,7 @@ requestBodies:
         description: Why the task is being released
     required:
       - reason
-  escalate:
+  - trigger: escalate
     type: object
     properties:
       reason:
@@ -446,13 +446,13 @@ requestBodies:
         description: Why the task is being escalated
     required:
       - reason
-  de-escalate:
+  - trigger: de-escalate
     type: object
     properties:
       notes:
         type: string
         description: Optional notes about the de-escalation
-  cancel:
+  - trigger: cancel
     type: object
     properties:
       reason:
@@ -460,7 +460,7 @@ requestBodies:
         description: Why the task is being cancelled
     required:
       - reason
-  reopen:
+  - trigger: reopen
     type: object
     properties:
       reason:
@@ -468,20 +468,20 @@ requestBodies:
         description: Why the cancelled task is being reopened
     required:
       - reason
-  await-client:
+  - trigger: await-client
     type: object
     properties:
       notes:
         type: string
         description: Optional context about what action is being awaited from the client
-  await-verification:
+  - trigger: await-verification
     type: object
     properties:
       notes:
         type: string
         description: Optional context about what external verification is pending
-  resume: {}
-  system-resume:
+  - trigger: resume
+  - trigger: system-resume
     type: object
     properties:
       source:
@@ -492,8 +492,8 @@ requestBodies:
         description: Summary of the verification result
     required:
       - source
-  submit-for-review: {}
-  approve:
+  - trigger: submit-for-review
+  - trigger: approve
     type: object
     properties:
       outcome:
@@ -504,7 +504,7 @@ requestBodies:
         description: Optional notes from the supervisor
     required:
       - outcome
-  return-to-worker:
+  - trigger: return-to-worker
     type: object
     properties:
       reason:

--- a/packages/mock-server/src/handlers/transition-handler.js
+++ b/packages/mock-server/src/handlers/transition-handler.js
@@ -60,9 +60,10 @@ export function createTransitionHandler(resourceName, stateMachine, trigger, par
         now
       };
 
+      const guardsMap = Object.fromEntries((stateMachine.guards || []).map(g => [g.id, g]));
       const guardResult = evaluateGuards(
         transition.guards,
-        stateMachine.guards || {},
+        guardsMap,
         resource,
         context
       );


### PR DESCRIPTION
## Summary

- `states:`, `guards:`, and `requestBodies:` in `workflow-state-machine.yaml` now use arrays with `id:`/`trigger:` identity fields instead of object-as-map format
- `state-machine-schema.yaml` updated to reflect the new array types; `State` requires `id:`, `Guard` requires `id:`, `RequestBody` requires `trigger:`
- All consuming code updated: `transition-handler.js`, `generate-rpc-overlay.js`, `generate-postman.js`, `export-contract-tables.js`, `import-contract-tables.js`
- `generate-rpc-overlay.js`: also strips the `trigger` field from request body schemas passed to OpenAPI
- Test fixtures in `generate-rpc-overlay.test.js` and `resolve.test.js` updated
- `api-patterns.yaml`: new `behavioral_yaml` section documenting the array-over-map convention and identity field naming
- `state-setup-guide.md`: updated "Customizing behavioral artifacts" section to show targeted overlay approach using filter expressions on arrays

**Why:** Arrays support overlay filter expressions (e.g., `$.states[?(@.id == 'escalated')]`), which enables targeted customization without replacing entire behavioral files. This is a prerequisite for #175 (`x-enum-source` injection), which needs `states[].id` and `slaTypes[].id` to work uniformly.

## How to validate

```bash
# Run all checks
npm run preflight

# Confirm the state machine still validates
npm run validate

# Confirm mock server still handles transitions correctly
npm run mock:start
# POST /tasks/{id}/claim with X-Caller-Id header — should still work
```

Or review the diff directly — consuming code now calls `.find(rb => rb.trigger === ...)` and `Object.fromEntries((guards || []).map(g => [g.id, g]))` instead of direct object key lookups.