### PR TITLE
Rename Communication to Communications and document event-driven design

### DIFF
--- a/docs/architecture/cross-cutting/communication.md
+++ b/docs/architecture/cross-cutting/communication.md
@@ -1,49 +1,94 @@
-# Communication (Cross-Cutting)
+# Communications (Cross-Cutting)
 
-> **Status: Work in progress** — High-level design. Detailed contract artifacts TBD.
+> **Status: Work in progress** — Architecture decided. Contract artifacts TBD.
 
 See [Domain Design Overview](../domain-design.md) for context and [Contract-Driven Architecture](../contract-driven-architecture.md) for the contract approach.
 
 ## Overview
 
-Communication is cross-cutting because notices and correspondence can originate from any domain:
+Communications is cross-cutting because notices and correspondence can originate from any domain:
 - **Intake**: "Application received"
 - **Eligibility**: "Approved", "Denied", "Request for information"
 - **Workflow**: "Documents needed", "Interview scheduled"
 - **Case Management**: "Case worker assigned"
 
+This maps to what IBM Curam calls **Communications Management** and the broader industry category of **Customer Communication Management (CCM)** — vendors like OpenText and Quadient serve this space. It covers both regulated client-facing correspondence (Notices of Action, eligibility letters) and internal operational alerts (supervisor escalation notifications, SLA warnings).
+
+## Event-driven trigger model
+
+Communications are triggered by domain events — not by direct calls from other domains or `notify` effects embedded in state machine transitions. When a workflow transition fires (e.g., `escalated`), it emits a domain event. The communications domain subscribes to those events and evaluates its own notification rules to determine what to send, to whom, and via which channel.
+
+This keeps each domain's contracts clean:
+- Workflow defines *what happened* (state transitions, events)
+- Communications defines *what to communicate* as a result (notification rules, templates, channels)
+
+States override communication behavior via overlay — swapping templates, adjusting recipients, suppressing or adding rules — without touching workflow contracts.
+
+## Notification rules contract
+
+Communication behavior is declared in a `communications-rules.yaml` (analogous to `workflow-rules.yaml`), evaluated by the communications rule engine when a subscribed event fires:
+
+```yaml
+# communications-rules.yaml (illustrative — schema TBD)
+domain: communications
+rules:
+  - id: escalation_alert
+    on:
+      domain: workflow
+      action: escalated
+    notify:
+      template: task_escalated
+      recipients:
+        - role:supervisor
+  - id: review_request
+    on:
+      domain: workflow
+      action: submitted_for_review
+    notify:
+      template: task_pending_review
+      recipients:
+        - role:supervisor
+  - id: awaiting_client_notice
+    on:
+      domain: workflow
+      action: awaiting_client
+    notify:
+      template: client_action_required
+      recipients:
+        - $object.clientId
+      channel: email
+```
+
+Recipients support: `$caller`, `$object.<field>`, `role:<name>` (all users with a given role).
+
 ## Entities
 
 | Entity | Purpose |
 |--------|---------|
-| **Notice** | Official communication (approval, denial, RFI, etc.) |
+| **Notice** | Official regulated communication (approval, denial, RFI, NOA) |
 | **Correspondence** | Other communications (client inquiries, worker notes, inter-agency) |
 | **DeliveryRecord** | Tracking of delivery status across channels |
 
-Detailed schemas will be defined in the OpenAPI spec as the domain is developed.
-
 ## Contract Artifacts
-
-Following the [contract-driven architecture](../contract-driven-architecture.md#contract-artifacts), Communication is a **behavior-shaped** domain — notices have a lifecycle (draft, review, approved, sent, delivered/failed) with guards, effects, and side effects. Expected contract artifacts:
 
 | Artifact | Status | Notes |
 |----------|--------|-------|
 | OpenAPI spec | TBD | REST APIs for notices, correspondence, and delivery records |
-| State machine YAML | TBD | Notice lifecycle — states, transitions, guards (e.g., supervisor approval), effects (e.g., initiate delivery, create audit event) |
-| Rules YAML | TBD | Routing rules (e.g., which notices require supervisor review, retry policies) |
+| State machine YAML | TBD | Notice lifecycle — states, transitions, guards (e.g., supervisor approval before send), effects (e.g., initiate delivery, audit event) |
+| Notification rules YAML | TBD | Event subscriptions → notify rules (template, recipients, channel) |
 | Metrics YAML | TBD | Delivery success rates, time-to-send, failed delivery tracking |
 
-## Key Design Questions
+## Open design questions
 
-- **Notice lifecycle** — What states and transitions does a notice go through? Which transitions require supervisor approval?
-- **Delivery channels** — How are multiple delivery methods (postal, email, portal) modeled? Per-notice or per-delivery-record?
-- **Template system** — How do notice templates connect to the field metadata or configuration artifacts?
-- **Event triggers** — How do other domains trigger notices? Direct RPC calls, or event-driven (e.g., an eligibility determination transition fires a `notify` effect)?
-- **Retry behavior** — How are failed deliveries retried? Automatic via state machine timeout, or manual via RPC operation?
+- **Notice lifecycle** — What states and transitions does a Notice go through? Which require supervisor approval before sending?
+- **Delivery channels** — How are multiple delivery methods (postal, email, portal) modeled? Per-notice or per-DeliveryRecord?
+- **Template system** — How do notice templates reference field values from the originating domain?
+- **Retry behavior** — How are failed deliveries retried? Automatic via state machine timeout, or manual RPC?
+- **Schema** — Define the `communications-rules.yaml` schema (`$schema`, `on`, `notify`, recipient expressions, channel enum).
 
 ## Related Documents
 
 | Document | Description |
 |----------|-------------|
-| [Domain Design](../domain-design.md) | Communication section in the domain overview |
+| [Domain Design](../domain-design.md) | Communications section in the domain overview |
 | [Contract-Driven Architecture](../contract-driven-architecture.md) | Contract artifacts and the adapter pattern |

--- a/docs/architecture/domain-design.md
+++ b/docs/architecture/domain-design.md
@@ -25,7 +25,7 @@ The Safety Net Benefits API is organized into 7 domains, with 5 cross-cutting co
 | **Document Management** | Not started | Files and uploads |
 
 **Cross-cutting concerns:**
-- **Communication** - Notices and correspondence can originate from any domain (application received, documents needed, eligibility determined, appointment scheduled, etc.)
+- **Communications** - Notices and correspondence can originate from any domain (application received, documents needed, eligibility determined, appointment scheduled, etc.)
 - **Reporting** - Each domain exposes data that reporting systems consume; audit events live where actions happen
 - **Configuration Management** - Business-configurable rules, thresholds, and settings that can be changed without code deployments
 - **Observability** - Health checks, metrics, logging, and tracing for operations staff
@@ -132,7 +132,7 @@ Work items, tasks, and SLA tracking. **[Details →](domains/workflow.md)**
 - VerificationTask connects Intake data → External Sources → Eligibility requirements
 - Tasks are assigned to CaseWorkers (connects to Case Management)
 
-#### Communication (Cross-Cutting)
+#### Communications (Cross-Cutting)
 
 Official notices and correspondence that can originate from any domain. **[Details →](cross-cutting/communication.md)**
 
@@ -143,12 +143,12 @@ Official notices and correspondence that can originate from any domain. **[Detai
 | **DeliveryRecord** | Tracking of delivery status |
 
 **Key decisions:**
-- Communication is cross-cutting because notices can be triggered by events in any domain:
+- Communications is cross-cutting because notices can be triggered by events in any domain:
   - Intake: "Application received"
   - Eligibility: "Approved", "Denied", "Request for information"
   - Workflow: "Documents needed", "Interview scheduled"
   - Case Management: "Case worker assigned"
-- Entities live in a Communication domain but are consumed/triggered by all domains
+- Entities live in a Communications domain but are consumed/triggered by all domains
 
 #### Search (Cross-Cutting)
 
@@ -176,7 +176,7 @@ Time-based coordination. **[Details →](domains/scheduling.md)**
 
 **Key decisions:**
 - **Interview** is modeled as an `appointmentType` value, not a standalone entity — FHIR has no separate Interview resource
-- **Reminder** belongs in the Communication cross-cutting domain — FHIR handles notifications via Communication resources
+- **Reminder** belongs in the Communications cross-cutting domain — FHIR handles notifications via Communication resources
 
 #### Document Management
 
@@ -193,7 +193,7 @@ Files and uploads.
 
 ```
 ╔══════════════════════════════════════════════════════════════════════════════════════╗
-║  CROSS-CUTTING: Communication, Search, Reporting, Configuration Mgmt, Observability  ║
+║  CROSS-CUTTING: Communications, Search, Reporting, Configuration Mgmt, Observability  ║
 ╚══════════════════════════════════════════════════════════════════════════════════════╝
 
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -297,7 +297,7 @@ Domain-specific design has been moved to separate files:
 | Workflow | [domains/workflow.md](domains/workflow.md) |
 | Case Management | [domains/case-management.md](domains/case-management.md) |
 | Scheduling | [domains/scheduling.md](domains/scheduling.md) |
-| Communication | [cross-cutting/communication.md](cross-cutting/communication.md) |
+| Communications | [cross-cutting/communication.md](cross-cutting/communication.md) |
 | Search | [cross-cutting/search.md](cross-cutting/search.md) |
 
 *Note: Client Management, Intake, Eligibility, and Document Management will be added as those domains are designed. Reporting aggregates data from other domains and doesn't have its own design doc.*


### PR DESCRIPTION
Closes #171

## Summary
- Renames the cross-cutting domain from "Communication" to "Communications" (plural, consistent with domain naming)
- Documents the architecture decision: communications are event-driven — workflow emits domain events, the communications domain subscribes and evaluates notification rules. No `notify` effect in workflow contracts.
- Adds illustrative `communications-rules.yaml` structure to the architecture doc
- Answers the open "Event triggers" design question in the doc
- Adds CCM/IBM Curam industry framing
- Updates all `domain-design.md` references to match

## Notes for reviewer
The original issue proposed adding `notify` as a state machine effect type. After discussing the design, we decided that's the wrong boundary — notifications are a cross-cutting concern that should subscribe to events rather than be embedded in workflow transitions. This PR documents that decision and sets up the architecture for the communications domain work that follows.