### PR TITLE
Refactor domain event emission to CloudEvents format

### DIFF
--- a/docs/architecture/inter-domain-communication.md
+++ b/docs/architecture/inter-domain-communication.md
@@ -31,6 +31,42 @@ Event contracts for each domain live in two artifacts:
 
 AsyncAPI specs are generated from these two sources. State partners do not author AsyncAPI directly — they overlay the source artifacts and regenerate.
 
+### Event emission model
+
+Two complementary patterns determine when events are emitted:
+
+**1. CRUD auto-emit (REST handlers)**
+
+Every REST resource emits three lifecycle events automatically — no state machine declaration required:
+
+| Trigger | Event action | Payload (`data`) |
+|---------|-------------|------------------|
+| `POST /resources` | `{object}.created` | Full resource snapshot |
+| `PATCH /resources/{id}` | `{object}.updated` | `{ changes: [{ field, before, after }] }` |
+| `DELETE /resources/{id}` | `{object}.deleted` | `null` |
+
+The `before` and `after` values in `updated` events record field-level changes so consumers can react to specific mutations without fetching the full resource.
+
+**2. Declarative state machine events (RPC transitions)**
+
+Transitions declare their own events explicitly in the state machine YAML. Each `type: event` effect specifies the action verb and any payload fields to include — typically context values from `$request.*` or `$caller.*`:
+
+```yaml
+- type: event
+  action: claimed
+  data:
+    assignedToId: $caller.id
+```
+
+All events — both auto-emitted and declarative — use the same `emitEvent()` utility, which constructs the CloudEvents envelope, persists it to the shared `/platform/events` log, and broadcasts it over the SSE stream.
+
+The `type` field is always derived implicitly: `org.codeforamerica.safety-net-blueprint.{domain}.{object}.{action}`. There is no ambiguity about what constitutes a valid type — it always reflects a real operation on a real resource.
+
+**What does not emit events**
+
+- `GET` requests (read operations) never emit events — only state-changing operations do
+- Events are not emitted by the state machine at creation time — the REST create handler handles this universally
+
 ---
 
 ## `/events` Endpoint

--- a/docs/architecture/inter-domain-communication.md
+++ b/docs/architecture/inter-domain-communication.md
@@ -86,7 +86,13 @@ GET /events?subject=00000004-0000-4000-8000-000000000001
 
 Filtering by `type` or `source` narrows results to a specific domain or event kind.
 
-For causal chain tracing, the `traceparent` attribute propagates the W3C Trace Context from the triggering request or event. The trace ID it carries is stable across the entire chain — every downstream event shares the same trace ID, so the full causal chain is recoverable in a single query filtered by trace ID.
+#### Distributed tracing
+
+Conforming implementations must propagate the W3C Trace Context `traceparent` header from each inbound HTTP request to every event emitted during that request's lifecycle. The `traceparent` value is included as a CloudEvents extension attribute (per the [CloudEvents Distributed Tracing extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md)) and must not be modified — it carries a trace ID (stable across the full causal chain) and a parent span ID (the immediate parent operation).
+
+Clients must forward the `traceparent` header on all requests to enable end-to-end tracing. When an inbound request carries no `traceparent`, the implementation omits the attribute from emitted events rather than generating a synthetic value.
+
+The trace ID is stable across the entire chain — every event emitted from a single HTTP request shares the same trace ID, so the complete causal trail for any operation is recoverable by filtering events on `traceparent` prefix or by querying an OTLP-compatible backend.
 
 ---
 

--- a/docs/contract-tables/workflow/overview.md
+++ b/docs/contract-tables/workflow/overview.md
@@ -44,7 +44,6 @@ Tasks move through a defined set of states. The **SLA clock** tracks time toward
 
 The following effects run automatically when a task is first created:
 
-- Emit `created` event
 - Re-evaluate assignment rules
 - Re-evaluate priority rules
 

--- a/docs/contract-tables/workflow/transitions.csv
+++ b/docs/contract-tables/workflow/transitions.csv
@@ -1,5 +1,5 @@
 From,To,Trigger,On,After,RelativeTo,CalendarType,Actors,Guards,Effects
-(create),pending,create,,,,,,,event; evaluate-rules; evaluate-rules
+(create),pending,create,,,,,,,evaluate-rules; evaluate-rules
 pending,in_progress,claim,,,,,caseworker; supervisor,taskIsUnassigned,set assignedToId = $caller.id; event
 in_progress,completed,complete,,,,,caseworker; supervisor,callerIsAssignedWorker,set completedAt = $now; set outcome = $request.outcome; set completionNotes = $request.notes; event; create
 in_progress,pending,release,,,,,caseworker; supervisor,callerIsAssignedWorker,set assignedToId = null; event; evaluate-rules; evaluate-rules

--- a/packages/clients/scripts/generate-clients-typescript.js
+++ b/packages/clients/scripts/generate-clients-typescript.js
@@ -191,9 +191,14 @@ async function main() {
   }
   mkdirSync(outputDir, { recursive: true });
 
-  // Discover all OpenAPI spec files (match *-openapi.yaml convention)
+  // Discover all OpenAPI spec files (match *-openapi.yaml convention), skipping deprecated specs
   const specFiles = readdirSync(specsDir).filter(f => {
-    return f.endsWith('-openapi.yaml');
+    if (!f.endsWith('-openapi.yaml')) return false;
+    try {
+      return !readFileSync(join(specsDir, f), 'utf8').includes('x-status: deprecated');
+    } catch {
+      return true;
+    }
   });
 
   if (specFiles.length === 0) {

--- a/packages/contracts/components/events.yaml
+++ b/packages/contracts/components/events.yaml
@@ -1,66 +1,59 @@
-# Shared domain event schema
+# Shared event payload schemas for CloudEvents 1.0 domain events.
 #
-# DomainEvent is the unified audit trail record emitted whenever a state machine
-# transition fires or an object is created. All domains write to the same events
-# collection; domain + resource + action identify the event type.
+# These schemas define the standard data payloads for CRUD lifecycle events
+# that are emitted automatically by all REST handlers. Domain-specific
+# transition events define their own payload schemas locally.
 #
-# Used by: workflow-openapi.yaml
+# FieldChange and ResourceUpdatedEvent are shared because the updated event
+# shape (field, before, after) is identical across all domains and resources.
+# ResourceDeletedEvent is shared because deleted events carry no payload.
+#
+# ResourceCreatedEvent is intentionally NOT defined here — its payload is
+# the full resource snapshot, which varies by domain. Each domain defines
+# a {Resource}CreatedEvent that $ref's its own resource schema.
+#
+# Used by: workflow-openapi.yaml, and any domain OpenAPI spec that emits
+# CRUD lifecycle events.
 
-DomainEvent:
+FieldChange:
   type: object
-  description: |
-    An immutable record of a state transition or significant lifecycle event.
-    Emitted by the state machine engine whenever a transition fires or an object
-    is first created.
+  description: A single field change recorded in an updated event.
   additionalProperties: false
   required:
-    - id
-    - domain
-    - resource
-    - action
-    - resourceId
-    - performedById
-    - occurredAt
-    - createdAt
-    - updatedAt
+    - field
+    - before
+    - after
   properties:
-    id:
+    field:
       type: string
-      format: uuid
-      description: Unique identifier for the event.
-      readOnly: true
-    domain:
-      type: string
-      description: Domain that owns the event (e.g., workflow).
-    resource:
-      type: string
-      description: Resource type the event relates to (e.g., task).
-    action:
-      type: string
-      description: The action that occurred (e.g., created, claimed, completed).
-    resourceId:
-      type: string
-      format: uuid
-      description: Identifier of the resource that generated the event.
-    performedById:
-      type: string
-      format: uuid
-      description: User who triggered the event.
-    occurredAt:
-      type: string
-      format: date-time
-      description: When the event occurred.
-    data:
-      type: object
-      description: Transition-specific payload. Schema varies by action.
-      additionalProperties: true
-    createdAt:
-      type: string
-      format: date-time
-      description: Timestamp when the event record was created.
-      readOnly: true
-    updatedAt:
-      type: string
-      format: date-time
-      description: Timestamp when the event record was last updated.
-      readOnly: true
+      description: Name of the changed field.
+    before:
+      description: Value of the field before the update.
+    after:
+      description: Value of the field after the update.
+
+ResourceUpdatedEvent:
+  type: object
+  description: |
+    Payload for a CRUD-emitted updated event. Contains a field-level diff
+    recording which fields changed and their before/after values.
+
+    Emitted automatically by the mock server on every PATCH request.
+    Consumers can react to specific field mutations without fetching the
+    full resource.
+  required:
+    - changes
+  properties:
+    changes:
+      type: array
+      description: List of fields that changed, with before and after values.
+      items:
+        $ref: "#/FieldChange"
+
+ResourceDeletedEvent:
+  type: object
+  description: |
+    Payload for a CRUD-emitted deleted event. Carries no data — the entity
+    no longer exists and consumers should treat the subject ID as permanently
+    removed.
+  properties: {}

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -397,6 +397,54 @@ x_events:
       - org.codeforamerica.safety-net-blueprint.intake.application.submitted
       - org.codeforamerica.safety-net-blueprint.intake.application.submitted.v2
 
+  auto_emit:
+    description: |
+      Every REST resource emits three standard lifecycle events automatically.
+      These do not require any state machine declaration — the mock server emits
+      them for every POST, PATCH, and DELETE, regardless of whether a state
+      machine is defined.
+
+      All three events must be declared in x-events and have corresponding
+      payload schemas. This is enforced by convention; api:new scaffolds them
+      automatically.
+
+    events:
+      - trigger: POST /resources
+        action: "{object}.created"
+        payload: Full resource snapshot (same shape as the main resource schema)
+        schema: "{Resource}CreatedEvent — $ref to the resource schema itself"
+
+      - trigger: PATCH /resources/{id}
+        action: "{object}.updated"
+        payload: Field-level diff listing changed fields with before/after values
+        schema: "$ref: ./components/events.yaml#/ResourceUpdatedEvent (shared)"
+
+      - trigger: DELETE /resources/{id}
+        action: "{object}.deleted"
+        payload: null
+        schema: "$ref: ./components/events.yaml#/ResourceDeletedEvent (shared)"
+
+    payload_schemas:
+      created: |
+        Domain-specific. $ref the resource schema directly:
+          {Resource}CreatedEvent:
+            description: Snapshot of the newly created {resource} resource.
+            $ref: "#/components/schemas/{Resource}"
+      updated: |
+        Shared across all domains. Use:
+          {Resource}UpdatedEvent:
+            $ref: "./components/events.yaml#/ResourceUpdatedEvent"
+      deleted: |
+        Shared across all domains. Use:
+          {Resource}DeletedEvent:
+            $ref: "./components/events.yaml#/ResourceDeletedEvent"
+
+    traceparent:
+      description: |
+        The triggering request's traceparent header is propagated to all emitted
+        events. Consumers can reconstruct the full causal chain by filtering the
+        event log by trace ID (extracted from traceparent).
+
 # =============================================================================
 # Behavioral YAML Conventions
 # =============================================================================

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -441,9 +441,22 @@ x_events:
 
     traceparent:
       description: |
-        The triggering request's traceparent header is propagated to all emitted
-        events. Consumers can reconstruct the full causal chain by filtering the
-        event log by trace ID (extracted from traceparent).
+        W3C Trace Context propagation. Implementations must forward the
+        `traceparent` HTTP request header to all events emitted during that
+        request's lifecycle, including events from state machine transitions
+        and CRUD lifecycle effects triggered by the same call.
+
+        When no `traceparent` is present on the inbound request, the attribute
+        must be omitted from emitted events — implementations must not generate
+        a synthetic value.
+
+        Clients must include `traceparent` on all requests to enable end-to-end
+        tracing. The trace ID component is stable across the full causal chain,
+        so filtering events by trace ID reconstructs the complete set of
+        operations triggered by a single originating request.
+
+        The `traceparent` attribute in CloudEvents follows the CloudEvents
+        Distributed Tracing extension specification.
 
 # =============================================================================
 # Behavioral YAML Conventions

--- a/packages/contracts/scripts/generate-api.js
+++ b/packages/contracts/scripts/generate-api.js
@@ -148,6 +148,10 @@ function generateApiSpec(name, resource, componentsPrefix = './components') {
   const resourcePluralLower = resourcePlural.toLowerCase();
   const resourceIdParam = `${toCamelCase(resource)}Id`;
 
+  const resourceLower = resource.toLowerCase();
+  const resourceKebab = toKebabCase(resource);
+  const domain = toKebabCase(name);
+
   return `openapi: 3.1.0
 info:
   title: ${resource} API
@@ -166,6 +170,22 @@ servers:
 tags:
 - name: ${resourcePlural}
   description: Manage ${resourcePluralLower}.
+x-events:
+  ${resourceKebab}.created:
+    type: org.codeforamerica.safety-net-blueprint.${domain}.${resourceKebab}.created
+    summary: Emitted when a ${resourceLower} is created
+    payload:
+      $ref: "#/components/schemas/${resource}CreatedEvent"
+  ${resourceKebab}.updated:
+    type: org.codeforamerica.safety-net-blueprint.${domain}.${resourceKebab}.updated
+    summary: Emitted when a ${resourceLower} is updated via PATCH
+    payload:
+      $ref: "#/components/schemas/${resource}UpdatedEvent"
+  ${resourceKebab}.deleted:
+    type: org.codeforamerica.safety-net-blueprint.${domain}.${resourceKebab}.deleted
+    summary: Emitted when a ${resourceLower} is deleted
+    payload:
+      $ref: "#/components/schemas/${resource}DeletedEvent"
 paths:
   "/${resourcePluralLower}":
     get:
@@ -382,13 +402,24 @@ components:
           type: boolean
           description: Indicates whether more ${resourcePluralLower} are available beyond the current page.
 
+    # Event payload schemas — referenced by x-events section above
+    ${resource}CreatedEvent:
+      description: Snapshot of the newly created ${resourceLower} resource.
+      $ref: "#/components/schemas/${resource}"
+
+    ${resource}UpdatedEvent:
+      $ref: "${componentsPrefix}/events.yaml#/ResourceUpdatedEvent"
+
+    ${resource}DeletedEvent:
+      $ref: "${componentsPrefix}/events.yaml#/ResourceDeletedEvent"
+
   examples:
     ${resource}Example1:
       summary: Example ${resource} record
       value:
         id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         name: "Example ${resource} 1"
-        description: "This is an example ${resource.toLowerCase()}."
+        description: "This is an example ${resourceLower}."
         status: "active"
         createdAt: "2024-01-15T10:30:00Z"
         updatedAt: "2024-01-15T10:30:00Z"

--- a/packages/contracts/scripts/resolve.js
+++ b/packages/contracts/scripts/resolve.js
@@ -130,6 +130,7 @@ function collectYamlFiles(sourceDir, baseDir = sourceDir) {
     } else if (file.name.endsWith('.yaml')) {
       const relativePath = relative(baseDir, sourcePath);
       const content = readFileSync(sourcePath, 'utf8');
+      if (content.includes('x-status: deprecated')) continue;
       const spec = yaml.load(content);
       yamlFiles.push({ relativePath, sourcePath, spec });
     }

--- a/packages/contracts/workflow-openapi.yaml
+++ b/packages/contracts/workflow-openapi.yaml
@@ -911,24 +911,6 @@ components:
             - down
           description: Desired trend direction (for trend-type targets).
 
-    # Shared utility schemas
-
-    FieldChange:
-      type: object
-      description: A single field change recorded in an update event.
-      required:
-        - field
-        - before
-        - after
-      properties:
-        field:
-          type: string
-          description: Name of the changed field.
-        before:
-          description: Value before the update.
-        after:
-          description: Value after the update.
-
     # Event payload schemas — referenced by x-events section above
     TaskCreatedEvent:
       description: Snapshot of the newly created task resource.
@@ -1014,8 +996,7 @@ components:
       properties: {}
 
     TaskDeletedEvent:
-      type: object
-      properties: {}
+      $ref: "./components/events.yaml#/ResourceDeletedEvent"
 
     TaskAwaitingClientEvent:
       type: object
@@ -1089,16 +1070,7 @@ components:
             - sla_deadline_exceeded
 
     TaskUpdatedEvent:
-      type: object
-      description: Describes which fields changed during a PATCH update.
-      required:
-        - changes
-      properties:
-        changes:
-          type: array
-          description: List of fields that changed, with before and after values.
-          items:
-            $ref: "#/components/schemas/FieldChange"
+      $ref: "./components/events.yaml#/ResourceUpdatedEvent"
 
   examples:
     QueueExample1:

--- a/packages/contracts/workflow-openapi.yaml
+++ b/packages/contracts/workflow-openapi.yaml
@@ -123,6 +123,16 @@ x-events:
     summary: Emitted when a task exceeds its SLA deadline
     payload:
       $ref: "#/components/schemas/TaskSlaBreachedEvent"
+  task.updated:
+    type: org.codeforamerica.safety-net-blueprint.workflow.task.updated
+    summary: Emitted when a task is updated via PATCH
+    payload:
+      $ref: "#/components/schemas/TaskUpdatedEvent"
+  task.deleted:
+    type: org.codeforamerica.safety-net-blueprint.workflow.task.deleted
+    summary: Emitted when a task is deleted
+    payload:
+      $ref: "#/components/schemas/TaskDeletedEvent"
 
 paths:
   "/queues":
@@ -901,10 +911,28 @@ components:
             - down
           description: Desired trend direction (for trend-type targets).
 
+    # Shared utility schemas
+
+    FieldChange:
+      type: object
+      description: A single field change recorded in an update event.
+      required:
+        - field
+        - before
+        - after
+      properties:
+        field:
+          type: string
+          description: Name of the changed field.
+        before:
+          description: Value before the update.
+        after:
+          description: Value after the update.
+
     # Event payload schemas — referenced by x-events section above
     TaskCreatedEvent:
-      type: object
-      properties: {}
+      description: Snapshot of the newly created task resource.
+      $ref: "#/components/schemas/Task"
 
     TaskAssignedEvent:
       type: object
@@ -926,7 +954,15 @@ components:
 
     TaskClaimedEvent:
       type: object
-      properties: {}
+      required:
+        - assignedToId
+      properties:
+        assignedToId:
+          type: string
+          format: uuid
+          description: ID of the caseworker who claimed the task.
+          x-relationship:
+            resource: User
 
     TaskReleasedEvent:
       type: object
@@ -974,6 +1010,10 @@ components:
           description: Why the task was escalated.
 
     TaskDeEscalatedEvent:
+      type: object
+      properties: {}
+
+    TaskDeletedEvent:
       type: object
       properties: {}
 
@@ -1047,6 +1087,18 @@ components:
           description: The SLA breach reason.
           enum:
             - sla_deadline_exceeded
+
+    TaskUpdatedEvent:
+      type: object
+      description: Describes which fields changed during a PATCH update.
+      required:
+        - changes
+      properties:
+        changes:
+          type: array
+          description: List of fields that changed, with before and after values.
+          items:
+            $ref: "#/components/schemas/FieldChange"
 
   examples:
     QueueExample1:

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -489,7 +489,7 @@ transitions:
         description: Emit a domain event recording the priority change
 onCreate:
   actors: []
-  effects: []
+  effects:
     - type: evaluate-rules
       ruleType: assignment
       description: Evaluate assignment rules to route task to a queue

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -55,7 +55,9 @@ transitions:
         description: Assign task to the claiming worker
       - type: event
         action: claimed
-        description: Emit a domain event recording the claim
+        data:
+          assignedToId: $caller.id
+        description: Emit a domain event recording the claim and who claimed the task
   - trigger: complete
     from: in_progress
     to: completed
@@ -487,10 +489,7 @@ transitions:
         description: Emit a domain event recording the priority change
 onCreate:
   actors: []
-  effects:
-    - type: event
-      action: created
-      description: Emit a domain event when a task is first created
+  effects: []
     - type: evaluate-rules
       ruleType: assignment
       description: Evaluate assignment rules to route task to a queue

--- a/packages/mock-server/seed/platform.yaml
+++ b/packages/mock-server/seed/platform.yaml
@@ -1,0 +1,64 @@
+# Seed data for platform — domain events in CloudEvents 1.0 format.
+# These represent historical events that pre-populate the event log for testing.
+
+EventExample1:
+  id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  specversion: "1.0"
+  type: org.codeforamerica.safety-net-blueprint.workflow.task.created
+  source: /workflow
+  subject: cf4d9294-3827-5c92-8c66-b53fa6cf44bb
+  time: "2024-01-01T00:00:00.000Z"
+  datacontenttype: application/json
+  traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+  data:
+    id: cf4d9294-3827-5c92-8c66-b53fa6cf44bb
+    name: Opal Hartmann
+    description: Communis video allatus vacuus minus aduro utique.
+    status: pending
+    programType: snap
+    isExpedited: true
+    queueId: ae5ed10f-657d-55f3-b53c-b381ec583a1e
+    priority: expedited
+
+EventExample2:
+  id: b2c3d4e5-f6a7-8901-bcde-f12345678901
+  specversion: "1.0"
+  type: org.codeforamerica.safety-net-blueprint.workflow.task.claimed
+  source: /workflow
+  subject: cf4d9294-3827-5c92-8c66-b53fa6cf44bb
+  time: "2024-01-01T01:00:00.000Z"
+  datacontenttype: application/json
+  traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+  data:
+    assignedToId: c076fe9f-2209-52c4-967c-6d0172469fea
+
+EventExample3:
+  id: c3d4e5f6-a7b8-9012-cdef-123456789012
+  specversion: "1.0"
+  type: org.codeforamerica.safety-net-blueprint.workflow.task.created
+  source: /workflow
+  subject: 52a109fb-4667-5e67-a1b3-860ec6865af3
+  time: "2024-01-31T00:00:00.000Z"
+  datacontenttype: application/json
+  traceparent: null
+  data:
+    id: 52a109fb-4667-5e67-a1b3-860ec6865af3
+    name: Naomie Hoeger
+    description: Expedita amiculum adipisci quasi traho adsidue theologus.
+    status: pending
+    programType: tanf
+    isExpedited: false
+    queueId: f46c5c87-b1fe-55c2-9166-873c2748d4f4
+    priority: high
+
+EventExample4:
+  id: d4e5f6a7-b8c9-0123-defa-234567890123
+  specversion: "1.0"
+  type: org.codeforamerica.safety-net-blueprint.workflow.task.claimed
+  source: /workflow
+  subject: 52a109fb-4667-5e67-a1b3-860ec6865af3
+  time: "2024-01-31T01:00:00.000Z"
+  datacontenttype: application/json
+  traceparent: null
+  data:
+    assignedToId: b637ec01-7c66-5587-9592-7bbee3509a36

--- a/packages/mock-server/src/emit-event.js
+++ b/packages/mock-server/src/emit-event.js
@@ -1,0 +1,49 @@
+/**
+ * Shared utility for emitting CloudEvents 1.0 domain events.
+ *
+ * Constructs the CloudEvents envelope, persists it to the shared events
+ * collection, and broadcasts it over the SSE event bus.
+ *
+ * Event type follows the convention:
+ *   org.codeforamerica.safety-net-blueprint.{domain}.{object}.{action}
+ */
+
+import { randomUUID } from 'crypto';
+import { create } from './database-manager.js';
+import { eventBus } from './event-bus.js';
+
+/**
+ * Emit a domain event.
+ *
+ * @param {Object} options
+ * @param {string} options.domain      - Domain name (e.g., 'workflow')
+ * @param {string} options.object      - Object name, singular lowercase (e.g., 'task')
+ * @param {string} options.action      - Action verb (e.g., 'created', 'claimed')
+ * @param {string} options.resourceId  - UUID of the affected resource
+ * @param {string} options.source      - Domain base path (e.g., '/workflow')
+ * @param {Object|null} [options.data] - Event payload. Defaults to null.
+ * @param {string|null} [options.callerId]    - X-Caller-Id from request header
+ * @param {string|null} [options.traceparent] - W3C traceparent header, if present
+ * @param {string|null} [options.now]  - ISO timestamp. Defaults to current time.
+ * @returns {Object} The stored event record
+ */
+export function emitEvent({ domain, object, action, resourceId, source, data = null, callerId = null, traceparent = null, now = null }) {
+  const timestamp = now || new Date().toISOString();
+  const type = `org.codeforamerica.safety-net-blueprint.${domain}.${object}.${action}`;
+
+  const envelope = {
+    specversion: '1.0',
+    id: randomUUID(),
+    type,
+    source: source || `/${domain}`,
+    subject: resourceId,
+    time: timestamp,
+    datacontenttype: 'application/json',
+    traceparent: traceparent || null,
+    data: data ?? null,
+  };
+
+  const stored = create('events', envelope);
+  eventBus.emit('domain-event', stored);
+  return stored;
+}

--- a/packages/mock-server/src/handlers/create-handler.js
+++ b/packages/mock-server/src/handlers/create-handler.js
@@ -7,7 +7,7 @@ import { validate, createErrorResponse } from '../validator.js';
 import { applyEffects } from '../state-machine-engine.js';
 import { initializeSlaInfo } from '../sla-engine.js';
 import { processRuleEvaluations } from './rule-evaluation.js';
-import { eventBus } from '../event-bus.js';
+import { emitEvent } from '../emit-event.js';
 
 /**
  * Create create handler for a resource
@@ -46,11 +46,14 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
       // Create resource in database
       const resource = create(endpoint.collectionName, req.body);
 
-      // Execute onCreate effects if this resource has a state machine
-      if (stateMachine?.onCreate?.effects) {
-        const callerId = req.headers['x-caller-id'] || 'system';
-        const now = new Date().toISOString();
+      const callerId = req.headers['x-caller-id'] || 'system';
+      const now = new Date().toISOString();
+      const traceparent = req.headers['traceparent'] || null;
+      const domain = apiMetadata.serverBasePath.replace(/^\//, '');
+      const object = endpoint.collectionName.replace(/s$/, '');
 
+      // Execute onCreate effects if this resource has a state machine
+      if (stateMachine?.onCreate) {
         // Parse caller roles from header (comma-separated)
         const callerRoles = req.headers['x-caller-roles']
           ? req.headers['x-caller-roles'].split(',').map(r => r.trim()).filter(Boolean)
@@ -66,31 +69,40 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
           }
         }
 
-        const context = {
-          caller: {
-            id: callerId,
-            roles: callerRoles
-          },
-          object: { ...resource },
-          request: req.body || {},
-          now
-        };
+        const effects = stateMachine.onCreate.effects || [];
 
-        const { pendingCreates, pendingRuleEvaluations, pendingEvents } = applyEffects(
-          stateMachine.onCreate.effects,
-          resource,
-          context
-        );
+        if (effects.length > 0) {
+          const context = {
+            caller: {
+              id: callerId,
+              roles: callerRoles
+            },
+            object: { ...resource },
+            request: req.body || {},
+            now
+          };
 
-        // Process rule evaluations (sets queueId, priority, etc.)
-        processRuleEvaluations(pendingRuleEvaluations, resource, rules, stateMachine.domain);
+          const { pendingCreates, pendingRuleEvaluations } = applyEffects(effects, resource, context);
+
+          // Process rule evaluations (sets queueId, priority, etc.)
+          processRuleEvaluations(pendingRuleEvaluations, resource, rules, stateMachine.domain);
+
+          // Execute pending creates
+          for (const { entity, data } of pendingCreates) {
+            try {
+              create(entity, data);
+            } catch (createError) {
+              console.error(`Failed to create ${entity}:`, createError.message);
+            }
+          }
+        }
 
         // Initialize SLA info if SLA types are configured
-      if (slaTypes.length > 0) {
-        initializeSlaInfo(resource, slaTypes, now);
-      }
+        if (slaTypes.length > 0) {
+          initializeSlaInfo(resource, slaTypes, now);
+        }
 
-      // Persist rule-driven mutations back to DB
+        // Persist rule-driven and SLA mutations back to DB
         const diff = {};
         const original = JSON.parse(JSON.stringify(resource));
         for (const [key, value] of Object.entries(resource)) {
@@ -104,33 +116,23 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
           // Refresh resource with updated timestamps
           Object.assign(resource, diff);
         }
+      }
 
-        // Execute pending creates
-        for (const { entity, data } of pendingCreates) {
-          try {
-            create(entity, data);
-          } catch (createError) {
-            console.error(`Failed to create ${entity}:`, createError.message);
-          }
-        }
-
-        // Emit pending domain events
-        for (const event of pendingEvents) {
-          try {
-            const stored = create('events', {
-              domain: stateMachine.domain,
-              resource: stateMachine.object.toLowerCase(),
-              action: event.action,
-              resourceId: resource.id,
-              performedById: callerId,
-              occurredAt: now,
-              data: event.data
-            });
-            eventBus.emit('domain-event', stored);
-          } catch (eventError) {
-            console.error(`Failed to emit event "${event.action}":`, eventError.message);
-          }
-        }
+      // Auto-emit created event with full resource snapshot (after effects applied)
+      try {
+        emitEvent({
+          domain,
+          object,
+          action: 'created',
+          resourceId: resource.id,
+          source: apiMetadata.serverBasePath,
+          data: { ...resource },
+          callerId,
+          traceparent,
+          now,
+        });
+      } catch (eventError) {
+        console.error('Failed to emit created event:', eventError.message);
       }
 
       // Build Location header

--- a/packages/mock-server/src/handlers/create-handler.js
+++ b/packages/mock-server/src/handlers/create-handler.js
@@ -71,6 +71,9 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
 
         const effects = stateMachine.onCreate.effects || [];
 
+        // Snapshot before any effects mutate resource (for DB diff later)
+        const original = JSON.parse(JSON.stringify(resource));
+
         if (effects.length > 0) {
           const context = {
             caller: {
@@ -104,7 +107,6 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
 
         // Persist rule-driven and SLA mutations back to DB
         const diff = {};
-        const original = JSON.parse(JSON.stringify(resource));
         for (const [key, value] of Object.entries(resource)) {
           if (original[key] !== value && key !== 'id' && key !== 'createdAt' && key !== 'updatedAt') {
             diff[key] = value;

--- a/packages/mock-server/src/handlers/delete-handler.js
+++ b/packages/mock-server/src/handlers/delete-handler.js
@@ -3,6 +3,7 @@
  */
 
 import { findById, deleteResource } from '../database-manager.js';
+import { emitEvent } from '../emit-event.js';
 
 /**
  * Create delete handler for a resource
@@ -27,7 +28,26 @@ export function createDeleteHandler(apiMetadata, endpoint) {
       
       // Delete the resource
       deleteResource(endpoint.collectionName, resourceId);
-      
+
+      // Auto-emit deleted event
+      try {
+        const domain = apiMetadata.serverBasePath.replace(/^\//, '');
+        const object = endpoint.collectionName.replace(/s$/, '');
+        emitEvent({
+          domain,
+          object,
+          action: 'deleted',
+          resourceId,
+          source: apiMetadata.serverBasePath,
+          data: null,
+          callerId: req.headers['x-caller-id'] || null,
+          traceparent: req.headers['traceparent'] || null,
+          now: new Date().toISOString(),
+        });
+      } catch (eventError) {
+        console.error('Failed to emit deleted event:', eventError.message);
+      }
+
       res.status(204).send();
     } catch (error) {
       console.error('Delete handler error:', error);

--- a/packages/mock-server/src/handlers/transition-handler.js
+++ b/packages/mock-server/src/handlers/transition-handler.js
@@ -6,7 +6,7 @@ import { findById, findAll, update, create } from '../database-manager.js';
 import { findTransition, evaluateGuards, applyEffects } from '../state-machine-engine.js';
 import { updateSlaInfo } from '../sla-engine.js';
 import { processRuleEvaluations } from './rule-evaluation.js';
-import { eventBus } from '../event-bus.js';
+import { emitEvent } from '../emit-event.js';
 
 /**
  * Create a transition handler for an RPC endpoint.
@@ -129,19 +129,24 @@ export function createTransitionHandler(resourceName, stateMachine, trigger, par
         }
       }
 
-      // Emit pending domain events
+      // Emit pending domain events via shared utility
+      const domain = stateMachine.domain;
+      const object = stateMachine.object.toLowerCase();
+      const source = `/${domain}`;
+      const traceparent = req.headers['traceparent'] || null;
       for (const event of pendingEvents) {
         try {
-          const stored = create('events', {
-            domain: stateMachine.domain,
-            resource: stateMachine.object.toLowerCase(),
+          emitEvent({
+            domain,
+            object,
             action: event.action,
             resourceId: resource.id,
-            performedById: callerId,
-            occurredAt: now,
-            data: event.data
+            source,
+            data: event.data || null,
+            callerId,
+            traceparent,
+            now,
           });
-          eventBus.emit('domain-event', stored);
         } catch (eventError) {
           console.error(`Failed to emit event "${event.action}":`, eventError.message);
         }

--- a/packages/mock-server/src/handlers/update-handler.js
+++ b/packages/mock-server/src/handlers/update-handler.js
@@ -6,6 +6,7 @@ import { findById, update } from '../database-manager.js';
 import { validate, createErrorResponse } from '../validator.js';
 import { applyEffects } from '../state-machine-engine.js';
 import { processRuleEvaluations } from './rule-evaluation.js';
+import { emitEvent } from '../emit-event.js';
 
 /**
  * Create update handler for a resource
@@ -15,7 +16,7 @@ import { processRuleEvaluations } from './rule-evaluation.js';
  * @param {Array} rules - Rules for rule evaluation effects
  * @returns {Function} Express handler
  */
-export function createUpdateHandler(apiMetadata, endpoint, stateMachine = null, rules = []) {
+export function createUpdateHandler(apiMetadata, endpoint, stateMachine = null, rules = [], slaTypes = []) {
   const paramName = extractPathParam(endpoint.path);
   return (req, res) => {
     try {
@@ -65,8 +66,39 @@ export function createUpdateHandler(apiMetadata, endpoint, stateMachine = null, 
         }
       }
 
+      // Compute field-level diff (before values for the updated event)
+      const changedFields = Object.keys(req.body);
+      const beforeValues = {};
+      for (const field of changedFields) {
+        beforeValues[field] = existing[field] ?? null;
+      }
+
       // Update in database (database manager handles deep merge and updatedAt timestamp)
       const updated = update(endpoint.collectionName, resourceId, req.body);
+
+      // Build changes array for the updated event
+      const changes = changedFields
+        .filter(field => updated[field] !== existing[field])
+        .map(field => ({ field, before: beforeValues[field], after: updated[field] ?? null }));
+
+      // Auto-emit updated event with field-level diff
+      try {
+        const domain = apiMetadata.serverBasePath.replace(/^\//, '');
+        const object = endpoint.collectionName.replace(/s$/, '');
+        emitEvent({
+          domain,
+          object,
+          action: 'updated',
+          resourceId,
+          source: apiMetadata.serverBasePath,
+          data: { changes },
+          callerId: req.headers['x-caller-id'] || null,
+          traceparent: req.headers['traceparent'] || null,
+          now: updated.updatedAt,
+        });
+      } catch (eventError) {
+        console.error('Failed to emit updated event:', eventError.message);
+      }
 
       // Fire onUpdate effects if any watched fields changed
       if (stateMachine?.onUpdate?.effects?.length > 0) {

--- a/packages/mock-server/src/handlers/update-handler.js
+++ b/packages/mock-server/src/handlers/update-handler.js
@@ -9,6 +9,54 @@ import { processRuleEvaluations } from './rule-evaluation.js';
 import { emitEvent } from '../emit-event.js';
 
 /**
+ * Deep equality check for change detection.
+ * Handles scalars, arrays, and objects so unchanged non-scalar fields
+ * are not falsely reported as changed.
+ * @param {*} a
+ * @param {*} b
+ * @returns {boolean}
+ */
+export function deepEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (typeof a === 'object' && !Array.isArray(a)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every(k => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Build a field-level changes array by comparing two snapshots.
+ * Excludes system-managed fields (id, createdAt, updatedAt).
+ * Uses deep equality so unchanged arrays/objects are not reported.
+ * @param {Object} before - Snapshot before mutations
+ * @param {Object} after - Snapshot after all mutations have settled
+ * @returns {Array<{ field: string, before: *, after: * }>}
+ */
+export function buildChanges(before, after) {
+  const excluded = new Set(['id', 'createdAt', 'updatedAt']);
+  const allFields = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const changes = [];
+  for (const field of allFields) {
+    if (excluded.has(field)) continue;
+    const beforeVal = before[field] ?? null;
+    const afterVal = after[field] ?? null;
+    if (!deepEqual(beforeVal, afterVal)) {
+      changes.push({ field, before: beforeVal, after: afterVal });
+    }
+  }
+  return changes;
+}
+
+/**
  * Create update handler for a resource
  * @param {Object} apiMetadata - API metadata from OpenAPI spec
  * @param {Object} endpoint - Endpoint metadata
@@ -66,46 +114,20 @@ export function createUpdateHandler(apiMetadata, endpoint, stateMachine = null, 
         }
       }
 
-      // Compute field-level diff (before values for the updated event)
-      const changedFields = Object.keys(req.body);
-      const beforeValues = {};
-      for (const field of changedFields) {
-        beforeValues[field] = existing[field] ?? null;
-      }
+      // Snapshot existing state before any mutations
+      const existingSnapshot = { ...existing };
 
       // Update in database (database manager handles deep merge and updatedAt timestamp)
       const updated = update(endpoint.collectionName, resourceId, req.body);
 
-      // Build changes array for the updated event
-      const changes = changedFields
-        .filter(field => updated[field] !== existing[field])
-        .map(field => ({ field, before: beforeValues[field], after: updated[field] ?? null }));
-
-      // Auto-emit updated event with field-level diff
-      try {
-        const domain = apiMetadata.serverBasePath.replace(/^\//, '');
-        const object = endpoint.collectionName.replace(/s$/, '');
-        emitEvent({
-          domain,
-          object,
-          action: 'updated',
-          resourceId,
-          source: apiMetadata.serverBasePath,
-          data: { changes },
-          callerId: req.headers['x-caller-id'] || null,
-          traceparent: req.headers['traceparent'] || null,
-          now: updated.updatedAt,
-        });
-      } catch (eventError) {
-        console.error('Failed to emit updated event:', eventError.message);
-      }
-
-      // Fire onUpdate effects if any watched fields changed
+      // Fire onUpdate effects if any watched fields changed.
+      // Must run before emitting so rule-driven mutations (e.g. priority re-scored
+      // because isExpedited changed) are included in the event's changes array.
       if (stateMachine?.onUpdate?.effects?.length > 0) {
         const watchedFields = stateMachine.onUpdate.fields;
-        const changedFields = Object.keys(req.body);
+        const patchedFields = Object.keys(req.body);
         const shouldFire = !watchedFields || watchedFields.length === 0
-          || changedFields.some(f => watchedFields.includes(f));
+          || patchedFields.some(f => watchedFields.includes(f));
 
         if (shouldFire) {
           const callerRoles = req.headers['x-caller-roles']
@@ -123,6 +145,28 @@ export function createUpdateHandler(apiMetadata, endpoint, stateMachine = null, 
           const { pendingRuleEvaluations } = applyEffects(stateMachine.onUpdate.effects, updated, context);
           processRuleEvaluations(pendingRuleEvaluations, updated, rules, stateMachine.domain);
         }
+      }
+
+      // Build changes diff after all mutations have settled (PATCH fields + any rule-driven mutations)
+      const changes = buildChanges(existingSnapshot, updated);
+
+      // Emit updated event with complete field-level diff
+      try {
+        const domain = apiMetadata.serverBasePath.replace(/^\//, '');
+        const object = endpoint.collectionName.replace(/s$/, '');
+        emitEvent({
+          domain,
+          object,
+          action: 'updated',
+          resourceId,
+          source: apiMetadata.serverBasePath,
+          data: { changes },
+          callerId: req.headers['x-caller-id'] || null,
+          traceparent: req.headers['traceparent'] || null,
+          now: updated.updatedAt,
+        });
+      } catch (eventError) {
+        console.error('Failed to emit updated event:', eventError.message);
       }
 
       res.json(updated);

--- a/packages/mock-server/tests/integration/integration.test.js
+++ b/packages/mock-server/tests/integration/integration.test.js
@@ -1071,25 +1071,25 @@ async function runTests() {
       }
     }
 
-    // RULE-4: Verify "created" domain event from onCreate effects
+    // RULE-4: Verify "created" domain event auto-emitted by create handler
     if (snapTaskId) {
       try {
-        console.log('\n  RULE-4. Verify "created" domain event from onCreate effects');
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${snapTaskId}`);
+        console.log('\n  RULE-4. Verify "created" domain event auto-emitted by create handler');
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${snapTaskId}`);
         const listData = await listResponse.json();
 
-        const createdEvents = listData.items?.filter(e => e.action === 'created') || [];
+        const createdEvents = listData.items?.filter(e => e.type?.endsWith('.created')) || [];
         if (createdEvents.length >= 1) {
           const event = createdEvents[0];
-          if (event.resourceId === snapTaskId && event.occurredAt) {
-            console.log('     ✓ PASS: "created" domain event exists with correct fields');
+          if (event.subject === snapTaskId && event.time && event.specversion === '1.0') {
+            console.log('     ✓ PASS: "created" CloudEvent exists with correct fields');
             totalPassed++;
           } else {
-            console.log(`     ✗ FAIL: Domain event fields incorrect: ${JSON.stringify(event)}`);
+            console.log(`     ✗ FAIL: CloudEvent fields incorrect: ${JSON.stringify(event)}`);
             totalFailed++;
           }
         } else {
-          console.log(`     ✗ FAIL: Expected "created" domain event, got ${createdEvents.length}`);
+          console.log(`     ✗ FAIL: Expected "created" CloudEvent, got ${createdEvents.length}`);
           totalFailed++;
         }
         totalTests++;
@@ -1215,16 +1215,16 @@ async function runTests() {
     if (supTaskId) {
       try {
         console.log(`\n  SUP-5. Verify assigned and priority_changed events emitted`);
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${supTaskId}`);
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${supTaskId}`);
         const listData = await listResponse.json();
-        const actions = (listData.items || []).map(e => e.action);
-        const hasAssigned = actions.includes('assigned');
-        const hasPriorityChanged = actions.includes('priority_changed');
+        const types = (listData.items || []).map(e => e.type?.split('.').pop());
+        const hasAssigned = types.includes('assigned');
+        const hasPriorityChanged = types.includes('priority_changed');
         if (hasAssigned && hasPriorityChanged) {
-          console.log(`     ✓ PASS: Events found — ${actions.join(', ')}`);
+          console.log(`     ✓ PASS: Events found — ${types.join(', ')}`);
           totalPassed++;
         } else {
-          console.log(`     ✗ FAIL: Missing events. Found: ${actions.join(', ')}`);
+          console.log(`     ✗ FAIL: Missing events. Found: ${types.join(', ')}`);
           totalFailed++;
         }
         totalTests++;

--- a/packages/mock-server/tests/integration/integration.test.js
+++ b/packages/mock-server/tests/integration/integration.test.js
@@ -800,16 +800,16 @@ async function runTests() {
           headers: { 'Content-Type': 'application/json', 'X-Caller-Id': 'worker-audit-1', 'X-Caller-Roles': 'caseworker' }
         });
 
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${auditTaskId}`);
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${auditTaskId}`);
         const listData = await listResponse.json();
 
         if (listData.items && listData.items.length === 2) {
-          const event = listData.items.find(e => e.action === 'claimed');
-          if (event && event.resourceId === auditTaskId && event.performedById === 'worker-audit-1') {
-            console.log('     ✓ PASS: "claimed" domain event created with correct fields');
+          const event = listData.items.find(e => e.type?.endsWith('.claimed'));
+          if (event && event.subject === auditTaskId && event.specversion === '1.0') {
+            console.log('     ✓ PASS: "claimed" CloudEvent created with correct fields');
             totalPassed++;
           } else {
-            console.log(`     ✗ FAIL: Domain event fields incorrect: ${JSON.stringify(event)}`);
+            console.log(`     ✗ FAIL: CloudEvent fields incorrect: ${JSON.stringify(event)}`);
             totalFailed++;
           }
         } else {
@@ -834,16 +834,16 @@ async function runTests() {
           body: JSON.stringify({ reason: 'Testing domain events' })
         });
 
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${auditTaskId}`);
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${auditTaskId}`);
         const listData = await listResponse.json();
 
         if (listData.items && listData.items.length === 3) {
-          const actions = listData.items.map(e => e.action).sort();
-          if (actions.includes('claimed') && actions.includes('created') && actions.includes('released')) {
+          const types = listData.items.map(e => e.type?.split('.').pop()).sort();
+          if (types.includes('claimed') && types.includes('created') && types.includes('released')) {
             console.log('     ✓ PASS: 3 domain events (created + claimed + released)');
             totalPassed++;
           } else {
-            console.log(`     ✗ FAIL: Unexpected event actions: ${actions.join(', ')}`);
+            console.log(`     ✗ FAIL: Unexpected event types: ${types.join(', ')}`);
             totalFailed++;
           }
         } else {
@@ -872,16 +872,16 @@ async function runTests() {
           body: JSON.stringify({ outcome: 'approved' })
         });
 
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${auditTaskId}`);
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${auditTaskId}`);
         const listData = await listResponse.json();
 
         if (listData.items && listData.items.length === 5) {
-          const actions = listData.items.map(e => e.action).sort();
-          if (['claimed', 'completed', 'created', 'released'].every(a => actions.includes(a))) {
+          const types = listData.items.map(e => e.type?.split('.').pop()).sort();
+          if (['claimed', 'completed', 'created', 'released'].every(a => types.includes(a))) {
             console.log('     ✓ PASS: 5 domain events total');
             totalPassed++;
           } else {
-            console.log(`     ✗ FAIL: Unexpected event actions: ${actions.join(', ')}`);
+            console.log(`     ✗ FAIL: Unexpected event types: ${types.join(', ')}`);
             totalFailed++;
           }
         } else {
@@ -900,7 +900,7 @@ async function runTests() {
     if (auditTaskId) {
       try {
         console.log(`\n  EVENT-5. GET single domain event by ID`);
-        const listResponse = await fetch(`${BASE_URL}/platform/events?q=resourceId:${auditTaskId}`);
+        const listResponse = await fetch(`${BASE_URL}/platform/events?subject=${auditTaskId}`);
         const listData = await listResponse.json();
 
         if (listData.items && listData.items.length > 0) {
@@ -909,11 +909,11 @@ async function runTests() {
 
           if (getResponse.status === 200) {
             const event = await getResponse.json();
-            if (event.id === eventId && event.resourceId === auditTaskId && event.occurredAt) {
-              console.log(`     ✓ PASS: GET /platform/events/${eventId} returns correct event`);
+            if (event.id === eventId && event.subject === auditTaskId && event.time && event.specversion === '1.0') {
+              console.log(`     ✓ PASS: GET /platform/events/${eventId} returns correct CloudEvent`);
               totalPassed++;
             } else {
-              console.log(`     ✗ FAIL: Event fields incorrect`);
+              console.log(`     ✗ FAIL: CloudEvent fields incorrect`);
               totalFailed++;
             }
           } else {

--- a/packages/mock-server/tests/unit/emit-event.test.js
+++ b/packages/mock-server/tests/unit/emit-event.test.js
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for emitEvent utility
+ * Tests CloudEvents envelope construction and persistence
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { emitEvent } from '../../src/emit-event.js';
+import { findAll, clearAll } from '../../src/database-manager.js';
+
+test('emitEvent', async (t) => {
+
+  // ==========================================================================
+  // Envelope structure
+  // ==========================================================================
+
+  await t.test('produces a valid CloudEvents 1.0 envelope', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'created',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: { status: 'pending' },
+      callerId: 'user-1',
+      traceparent: null,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.specversion, '1.0');
+    assert.match(stored.type, /^org\.codeforamerica\.safety-net-blueprint\./);
+    assert.strictEqual(stored.type, 'org.codeforamerica.safety-net-blueprint.workflow.task.created');
+    assert.strictEqual(stored.source, '/workflow');
+    assert.strictEqual(stored.subject, 'abc123');
+    assert.strictEqual(stored.time, '2024-01-01T00:00:00.000Z');
+    assert.strictEqual(stored.datacontenttype, 'application/json');
+    assert.ok(stored.id, 'Should have a generated UUID');
+    console.log('  ✓ Produces valid CloudEvents 1.0 envelope');
+  });
+
+  await t.test('derives type from domain + object + action', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'intake',
+      object: 'application',
+      action: 'submitted',
+      resourceId: 'res-1',
+      source: '/intake',
+      data: null,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.type, 'org.codeforamerica.safety-net-blueprint.intake.application.submitted');
+    console.log('  ✓ Derives type from domain + object + action');
+  });
+
+  await t.test('generates a unique id for each event', () => {
+    clearAll('events');
+    const e1 = emitEvent({ domain: 'x', object: 'y', action: 'z', resourceId: '1', source: '/x', data: null, now: '2024-01-01T00:00:00.000Z' });
+    const e2 = emitEvent({ domain: 'x', object: 'y', action: 'z', resourceId: '1', source: '/x', data: null, now: '2024-01-01T00:00:00.000Z' });
+
+    assert.notStrictEqual(e1.id, e2.id);
+    console.log('  ✓ Generates a unique id for each event');
+  });
+
+  // ==========================================================================
+  // Traceparent propagation
+  // ==========================================================================
+
+  await t.test('includes traceparent when provided', () => {
+    clearAll('events');
+    const traceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'claimed',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: { assignedToId: 'user-1' },
+      callerId: 'user-1',
+      traceparent,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.traceparent, traceparent);
+    console.log('  ✓ Includes traceparent when provided');
+  });
+
+  await t.test('sets traceparent to null when not provided', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'created',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: null,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.traceparent, null);
+    console.log('  ✓ Sets traceparent to null when not provided');
+  });
+
+  // ==========================================================================
+  // Persistence
+  // ==========================================================================
+
+  await t.test('persists event to the events collection', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'created',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: { status: 'pending' },
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    const result = findAll('events', {});
+    assert.strictEqual(result.items.length, 1);
+    assert.strictEqual(result.items[0].id, stored.id);
+    console.log('  ✓ Persists event to the events collection');
+  });
+
+  await t.test('multiple calls produce multiple stored events', () => {
+    clearAll('events');
+    emitEvent({ domain: 'a', object: 'b', action: 'c', resourceId: '1', source: '/a', data: null, now: '2024-01-01T00:00:00.000Z' });
+    emitEvent({ domain: 'a', object: 'b', action: 'd', resourceId: '1', source: '/a', data: null, now: '2024-01-01T00:00:00.000Z' });
+
+    const result = findAll('events', {});
+    assert.strictEqual(result.items.length, 2);
+    console.log('  ✓ Multiple calls produce multiple stored events');
+  });
+
+  // ==========================================================================
+  // Data payload
+  // ==========================================================================
+
+  await t.test('stores null data when not provided', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'deleted',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: null,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.data, null);
+    console.log('  ✓ Stores null data when not provided');
+  });
+
+  await t.test('stores event payload in data field', () => {
+    clearAll('events');
+    const payload = { outcome: 'approved', notes: 'looks good' };
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'completed',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: payload,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.deepStrictEqual(stored.data, payload);
+    console.log('  ✓ Stores event payload in data field');
+  });
+
+  // ==========================================================================
+  // Default now
+  // ==========================================================================
+
+  await t.test('defaults time to current timestamp when now is not provided', () => {
+    clearAll('events');
+    const before = new Date().toISOString();
+    const stored = emitEvent({
+      domain: 'workflow',
+      object: 'task',
+      action: 'created',
+      resourceId: 'abc123',
+      source: '/workflow',
+      data: null,
+    });
+    const after = new Date().toISOString();
+
+    assert.ok(stored.time >= before && stored.time <= after, 'time should be current timestamp');
+    console.log('  ✓ Defaults time to current timestamp when now not provided');
+  });
+
+});
+
+console.log('\n✓ All emitEvent tests passed\n');

--- a/packages/mock-server/tests/unit/update-handler.test.js
+++ b/packages/mock-server/tests/unit/update-handler.test.js
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for update handler utilities
+ * Tests deepEqual and buildChanges — the building blocks for the updated event's changes array.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { deepEqual, buildChanges } from '../../src/handlers/update-handler.js';
+
+// =============================================================================
+// deepEqual
+// =============================================================================
+
+test('deepEqual — identical scalars are equal', () => {
+  assert.ok(deepEqual(1, 1));
+  assert.ok(deepEqual('snap', 'snap'));
+  assert.ok(deepEqual(true, true));
+  assert.ok(deepEqual(null, null));
+});
+
+test('deepEqual — different scalars are not equal', () => {
+  assert.ok(!deepEqual(1, 2));
+  assert.ok(!deepEqual('snap', 'medicaid'));
+  assert.ok(!deepEqual(true, false));
+  assert.ok(!deepEqual(null, 0));
+});
+
+test('deepEqual — identical arrays are equal', () => {
+  assert.ok(deepEqual(['snap', 'medicaid'], ['snap', 'medicaid']));
+  assert.ok(deepEqual([], []));
+});
+
+test('deepEqual — arrays with different elements are not equal', () => {
+  assert.ok(!deepEqual(['snap'], ['medicaid']));
+  assert.ok(!deepEqual(['snap', 'medicaid'], ['snap']));
+  assert.ok(!deepEqual([], ['snap']));
+});
+
+test('deepEqual — array order matters', () => {
+  assert.ok(!deepEqual(['snap', 'medicaid'], ['medicaid', 'snap']));
+});
+
+test('deepEqual — identical objects are equal', () => {
+  assert.ok(deepEqual({ a: 1, b: 2 }, { a: 1, b: 2 }));
+  assert.ok(deepEqual({}, {}));
+});
+
+test('deepEqual — objects with different values are not equal', () => {
+  assert.ok(!deepEqual({ a: 1 }, { a: 2 }));
+  assert.ok(!deepEqual({ a: 1 }, { b: 1 }));
+  assert.ok(!deepEqual({ a: 1, b: 2 }, { a: 1 }));
+});
+
+test('deepEqual — nested structures', () => {
+  assert.ok(deepEqual({ tags: ['snap'], meta: { county: 'alameda' } }, { tags: ['snap'], meta: { county: 'alameda' } }));
+  assert.ok(!deepEqual({ tags: ['snap'] }, { tags: ['medicaid'] }));
+});
+
+// =============================================================================
+// buildChanges
+// =============================================================================
+
+test('buildChanges — reports changed scalar fields', () => {
+  const before = { id: '1', createdAt: 'x', updatedAt: 'y', priority: 'normal', status: 'pending' };
+  const after  = { id: '1', createdAt: 'x', updatedAt: 'z', priority: 'expedited', status: 'pending' };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 1);
+  assert.deepStrictEqual(changes[0], { field: 'priority', before: 'normal', after: 'expedited' });
+});
+
+test('buildChanges — excludes id, createdAt, updatedAt', () => {
+  const before = { id: '1', createdAt: 'x', updatedAt: 'y', name: 'old' };
+  const after  = { id: '2', createdAt: 'a', updatedAt: 'b', name: 'new' };
+  const changes = buildChanges(before, after);
+  const fields = changes.map(c => c.field);
+  assert.ok(!fields.includes('id'));
+  assert.ok(!fields.includes('createdAt'));
+  assert.ok(!fields.includes('updatedAt'));
+  assert.ok(fields.includes('name'));
+});
+
+test('buildChanges — unchanged arrays are not reported', () => {
+  const before = { id: '1', updatedAt: 'y', programs: ['snap', 'medicaid'] };
+  const after  = { id: '1', updatedAt: 'z', programs: ['snap', 'medicaid'] };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 0);
+});
+
+test('buildChanges — changed arrays are reported with full before/after', () => {
+  const before = { id: '1', updatedAt: 'y', programs: ['snap'] };
+  const after  = { id: '1', updatedAt: 'z', programs: ['snap', 'medicaid'] };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 1);
+  assert.deepStrictEqual(changes[0], { field: 'programs', before: ['snap'], after: ['snap', 'medicaid'] });
+});
+
+test('buildChanges — unchanged objects are not reported', () => {
+  const before = { id: '1', updatedAt: 'y', address: { city: 'Oakland', state: 'CA' } };
+  const after  = { id: '1', updatedAt: 'z', address: { city: 'Oakland', state: 'CA' } };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 0);
+});
+
+test('buildChanges — captures rule-driven mutations not in the original PATCH', () => {
+  // Simulates: PATCH sets isExpedited=true, onUpdate rule re-scores priority to "expedited"
+  const before = { id: '1', updatedAt: 'y', isExpedited: false, priority: 'normal' };
+  const after  = { id: '1', updatedAt: 'z', isExpedited: true,  priority: 'expedited' };
+  const changes = buildChanges(before, after);
+  const fields = changes.map(c => c.field).sort();
+  assert.deepStrictEqual(fields, ['isExpedited', 'priority']);
+});
+
+test('buildChanges — field added after update is reported (before is null)', () => {
+  const before = { id: '1', updatedAt: 'y' };
+  const after  = { id: '1', updatedAt: 'z', queueId: 'snap-intake' };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 1);
+  assert.deepStrictEqual(changes[0], { field: 'queueId', before: null, after: 'snap-intake' });
+});
+
+test('buildChanges — empty when nothing changed (excluding system fields)', () => {
+  const before = { id: '1', createdAt: 'x', updatedAt: 'y', status: 'pending' };
+  const after  = { id: '1', createdAt: 'x', updatedAt: 'z', status: 'pending' };
+  const changes = buildChanges(before, after);
+  assert.strictEqual(changes.length, 0);
+});


### PR DESCRIPTION
Closes #210

## Summary
- Added `emit-event.js` shared utility that builds and persists CloudEvents 1.0 envelopes, replacing ad-hoc event construction in each handler
- Refactored create, update, delete, and transition handlers to call `emitEvent()` — CRUD events auto-emit without requiring state machine declarations
- Updated `workflow-openapi.yaml` event schemas: `TaskUpdatedEvent` and `TaskDeletedEvent` now `$ref` shared schemas in `components/events.yaml`; removed `FieldChange` from the domain spec
- Removed the `type: event, action: created` effect from `workflow-state-machine.yaml` `onCreate` (now auto-emitted by the create handler)
- Added `x-events` scaffolding and event payload schemas to `generate-api.js` so new APIs get the standard pattern by default
- Documented the auto-emit model and declarative state machine events in `docs/architecture/inter-domain-communication.md`; added `traceparent` propagation as an implementer contract in the arch doc and `api-patterns.yaml`
- Fixed deprecated spec filtering in `resolve.js` and the TypeScript client generator
- Fixed rule evaluation results (priority, queueId) not persisting to DB on task create — the before-snapshot was captured after mutations, making the diff always empty
- Added seed events in `platform.yaml` and 10 unit tests for `emit-event.js`

## Notes for reviewer
Validation steps are in the issue — run them in order, they are stateful. Key things to observe: `before` values in `task.updated` events reflect the rule-evaluated priority set at create time, and the causation trail step shows all 5 events sharing the same `traceparent`.