### PR TITLE
Rewrite workflow domain reference as design reference

### DIFF
--- a/docs/architecture/domains/workflow-industry-reference.md
+++ b/docs/architecture/domains/workflow-industry-reference.md
@@ -77,9 +77,9 @@ Federal law sets maximum processing timelines that begin at application receipt,
 | `completed` | stopped | Work finished; regulatory deadline no longer applies |
 | `cancelled` | stopped | Task abandoned; can be reopened by a supervisor, which resets routing via `pending` |
 
-All states have an explicit `slaClock` value — see [Decision 13](#decision-13-slaclock-required-on-every-state). The `awaiting_*` states use `paused` rather than `stopped` — see [Decision 14](#decision-14-awaiting-states-pause-the-sla-clock).
+All states have an explicit `slaClock` value — see [Decision 12](#decision-12-slaclock-required-on-every-state). The `awaiting_*` states use `paused` rather than `stopped` — see [Decision 13](#decision-13-awaiting-states-pause-the-sla-clock).
 
-Task-type-specific states (e.g., `hearing_scheduled` for fair hearing tasks) are added alongside these baseline states and are only reachable via transitions guarded on task type — see [Decision 10](#decision-10-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine).
+Task-type-specific states (e.g., `hearing_scheduled` for fair hearing tasks) are added alongside these baseline states and are only reachable via transitions guarded on task type — see [Decision 9](#decision-9-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine).
 
 ### Key transitions
 
@@ -87,17 +87,17 @@ Task-type-specific states (e.g., `hearing_scheduled` for fair hearing tasks) are
 - **`await-client`**: `in_progress` → `awaiting_client` — caseworker is waiting on the client; pauses SLA clock
 - **`await-verification`**: `in_progress` → `awaiting_verification` — caseworker waiting on a third-party data source; pauses SLA clock
 - **`resume`**: `awaiting_*` → `in_progress` — caseworker resumes after external input received; clock resumes
-- **`system-resume`**: `awaiting_verification` → `in_progress` — automated callback from a verification service; see [Decision 9](#decision-9-automated-verification-uses-a-dedicated-system-resume-trigger)
+- **`system-resume`**: `awaiting_verification` → `in_progress` — automated callback from a verification service; see [Decision 8](#decision-8-automated-verification-uses-a-dedicated-system-resume-trigger)
 - **`escalate`**: `pending` | `in_progress` → `escalated` — caseworker or timer escalates for supervisor attention; re-evaluates priority via rules engine
 - **`de-escalate`**: `escalated` → `pending` — supervisor resolves; returns to queue for re-claim (handles both assigned and unassigned origin states cleanly)
 - **`submit-for-review`**: `in_progress` → `pending_review` — caseworker requests supervisor sign-off
 - **`approve`**: `pending_review` → `completed` — supervisor approves; task closes
 - **`return-to-worker`**: `pending_review` → `in_progress` — supervisor returns for revision; keeps task with the same caseworker rather than re-queuing
 - **`complete`**: `in_progress` → `completed` — caseworker marks work done (no review required)
-- **`cancel`**: `pending` | `in_progress` | `escalated` → `cancelled` — supervisor-only; see [Decision 8](#decision-8-cancel-is-supervisor-only-no-notify-effect)
+- **`cancel`**: `pending` | `in_progress` | `escalated` → `cancelled` — supervisor-only; see [Decision 7](#decision-7-cancel-is-supervisor-only-no-notify-effect)
 - **`reopen`**: `cancelled` → `pending` — supervisor reinstates; clears assignment for fresh routing
 
-Timer-triggered transitions fire automatically when durations elapse. See [Decision 7](#decision-7-calendartype-is-explicit-per-timer-transition) for how calendar vs. business-hour deadlines are handled.
+Timer-triggered transitions fire automatically when durations elapse. See [Decision 6](#decision-6-calendartype-is-explicit-per-timer-transition) for how calendar vs. business-hour deadlines are handled.
 
 ### Lifecycle hooks
 
@@ -109,7 +109,7 @@ Timer-triggered transitions fire automatically when durations elapse. See [Decis
 
 ## SLA and deadline management
 
-Each task carries one `slaInfo` record per applicable SLA type. Multiple SLA types can apply simultaneously — a SNAP application initially filed as standard may later be determined to qualify for expedited processing, at which point both deadlines apply. See [Decision 16](#decision-16-multiple-sla-types-can-apply-per-task).
+Each task carries one `slaInfo` record per applicable SLA type. Multiple SLA types can apply simultaneously — a SNAP application initially filed as standard may later be determined to qualify for expedited processing, at which point both deadlines apply. See [Decision 15](#decision-15-multiple-sla-types-can-apply-per-task).
 
 SLA type definitions live in `*-sla-types.yaml`, separately from the state machine, and are independently replaceable per state. The baseline types derived from federal regulatory deadlines:
 
@@ -120,7 +120,7 @@ SLA type definitions live in `*-sla-types.yaml`, separately from the state machi
 | `medicaid_standard` | 45 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
 | `medicaid_disability` | 90 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
 
-All baseline durations are derived from federal regulations. See [Decision 15](#decision-15-sla-type-definitions-are-independently-replaceable).
+All baseline durations are derived from federal regulations. See [Decision 14](#decision-14-sla-type-definitions-are-independently-replaceable).
 
 ---
 
@@ -128,13 +128,13 @@ All baseline durations are derived from federal regulations. See [Decision 15](#
 
 Domain events serve two purposes: they are the audit trail required by federal and state regulations, and they are the integration surface for cross-domain communication. Other domains (communication, case management, eligibility) subscribe to workflow events rather than polling task state.
 
-The state machine YAML is the authoritative source for what events exist and what they carry — `event` effects declare the action name and data payload. The audit trail is immutable — events are never modified or deleted via the API. See [Decision 18](#decision-18-events-in-a-shared-collection-across-domains) and [Decision 19](#decision-19-the-audit-trail-is-immutable).
+The state machine YAML is the authoritative source for what events exist and what they carry — `event` effects declare the action name and data payload. The audit trail is immutable — events are never modified or deleted via the API. See [Decision 18](#decision-18-events-in-a-shared-collection-across-domains) and [Decision 17](#decision-17-the-audit-trail-is-immutable).
 
 ---
 
 ## Metrics
 
-Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, alongside the state machine — not in a proprietary GUI. This makes measurement definitions explicit, versionable, and portable across state implementations. See [Decision 20](#decision-20-metrics-as-yaml-contract-artifacts).
+Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, alongside the state machine — not in a proprietary GUI. This makes measurement definitions explicit, versionable, and portable across state implementations. See [Decision 18](#decision-18-metrics-as-yaml-contract-artifacts).
 
 ---
 
@@ -147,23 +147,21 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 | 3 | [`pending_review` as dedicated supervisor sign-off state](#decision-3-pending_review-as-a-dedicated-supervisor-sign-off-state) | QC regulations require structured supervisor approval before determination — distinct from escalation. |
 | 4 | [Named RPC transitions, not PATCH](#decision-4-named-rpc-transitions-not-patch) | Named triggers map cleanly to audit events, can carry request bodies, and can be independently guarded. |
 | 5 | [Effects declared in state machine YAML](#decision-5-effects-declared-in-state-machine-yaml) | The contract is the specification — implementations don't need to read source code to understand what a transition does. |
-| 6 | [`when` conditions use JSON Logic](#decision-6-when-conditions-use-json-logic) | One evaluator and one toolchain across guards, rules, metric filters, and conditional effects. |
-| 7 | [`calendarType` explicit per timer transition](#decision-7-calendartype-is-explicit-per-timer-transition) | Regulatory deadlines are calendar days; staffing SLAs are business hours — conflating them produces incorrect enforcement. |
-| 8 | [`cancel` is supervisor-only; no `notify` effect](#decision-8-cancel-is-supervisor-only-no-notify-effect) | Cancellation has federal reporting implications; notification is a consumer concern handled by event subscribers. |
-| 9 | [Automated verification uses a dedicated `system-resume` trigger](#decision-9-automated-verification-uses-a-dedicated-system-resume-trigger) | Keeps automated callbacks distinguishable from human actions in the audit trail — required for SNAP/Medicaid QC. |
-| 10 | [Guards on `taskType` enable multiple lifecycles per state machine](#decision-10-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine) | One API surface and shared infrastructure serving multiple task types without separate state machines or endpoints. |
-| 11 | [`workflow-rules.yaml` is independently replaceable](#decision-11-workflow-rulesyaml-is-independently-replaceable) | Routing logic varies significantly across states — decoupling it from the state machine lets each change independently. |
-| 12 | [`first-match-wins` rule evaluation](#decision-12-first-match-wins-rule-evaluation) | Simple and predictable; multi-factor weighted scoring is a known gap. |
-| 13 | [`slaClock` required on every state](#decision-13-slaclock-required-on-every-state) | No default prevents silent regressions when new states are added. |
-| 14 | [`awaiting_*` states pause the SLA clock](#decision-14-awaiting-states-pause-the-sla-clock) | Federal SNAP regulations treat client-caused delays as excluded time — pausing preserves the original deadline rather than granting a fresh one. |
-| 15 | [SLA type definitions are independently replaceable](#decision-15-sla-type-definitions-are-independently-replaceable) | Deadline values vary by program mix — states replace the file without touching lifecycle logic. |
-| 16 | [Multiple SLA types can apply per task](#decision-16-multiple-sla-types-can-apply-per-task) | A SNAP task may become expedited after initial creation — both deadlines must apply simultaneously. |
-| 17 | [`pauseWhen`/`resumeWhen` per SLA type, not a hardcoded state list](#decision-17-pausewhenresumewhen-per-sla-type) | Different SLA types can pause on different conditions — a state might pause `snap_standard` but not `snap_expedited` during `awaiting_client`. |
-| 18 | [Events in a shared collection across domains](#decision-18-events-in-a-shared-collection-across-domains) | Cross-domain queries without joining separate stores — consistent with the cross-cutting audit domain approach. |
-| 19 | [The audit trail is immutable](#decision-19-the-audit-trail-is-immutable) | Federal QC reviews and fair hearings depend on an unaltered history — mutations undermine the regulatory function. |
-| 20 | [Metrics as YAML contract artifacts](#decision-20-metrics-as-yaml-contract-artifacts) | Metric definitions are explicit, versionable, and portable — unlike proprietary GUI dashboards. |
-| 21 | [Duration metrics via event pairs, not pre-computed fields](#decision-21-duration-metrics-via-event-pairs) | Declarative model lets metric authors define new measurements without schema changes. |
-| 22 | [Pre-aggregation is an adapter-layer concern](#decision-22-pre-aggregation-is-an-adapter-layer-concern) | On-demand computation is simpler and always current for the baseline; states add pre-aggregation in their adapters. |
+| 6 | [`calendarType` explicit per timer transition](#decision-6-calendartype-is-explicit-per-timer-transition) | Regulatory deadlines are calendar days; staffing SLAs are business hours — conflating them produces incorrect enforcement. |
+| 7 | [`cancel` is supervisor-only; no `notify` effect](#decision-7-cancel-is-supervisor-only-no-notify-effect) | Cancellation has federal reporting implications; notification is a consumer concern handled by event subscribers. |
+| 8 | [Automated verification uses a dedicated `system-resume` trigger](#decision-8-automated-verification-uses-a-dedicated-system-resume-trigger) | Keeps automated callbacks distinguishable from human actions in the audit trail — required for SNAP/Medicaid QC. |
+| 9 | [Guards on `taskType` enable multiple lifecycles per state machine](#decision-9-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine) | One API surface and shared infrastructure serving multiple task types without separate state machines or endpoints. |
+| 10 | [`workflow-rules.yaml` is independently replaceable](#decision-10-workflow-rulesyaml-is-independently-replaceable) | Routing logic varies significantly across states — decoupling it from the state machine lets each change independently. |
+| 11 | [`first-match-wins` rule evaluation](#decision-11-first-match-wins-rule-evaluation) | Simple and predictable; multi-factor weighted scoring is a known gap. |
+| 12 | [`slaClock` required on every state](#decision-12-slaclock-required-on-every-state) | No default prevents silent regressions when new states are added. |
+| 13 | [`awaiting_*` states pause the SLA clock](#decision-13-awaiting-states-pause-the-sla-clock) | Federal SNAP regulations treat client-caused delays as excluded time — pausing preserves the original deadline rather than granting a fresh one. |
+| 14 | [SLA type definitions are independently replaceable](#decision-14-sla-type-definitions-are-independently-replaceable) | Deadline values vary by program mix — states replace the file without touching lifecycle logic. |
+| 15 | [Multiple SLA types can apply per task](#decision-15-multiple-sla-types-can-apply-per-task) | A SNAP task may become expedited after initial creation — both deadlines must apply simultaneously. |
+| 16 | [`pauseWhen`/`resumeWhen` per SLA type, not a hardcoded state list](#decision-16-pausewhenresumewhen-per-sla-type) | Different SLA types can pause on different conditions — a state might pause `snap_standard` but not `snap_expedited` during `awaiting_client`. |
+| 17 | [The audit trail is immutable](#decision-17-the-audit-trail-is-immutable) | Federal QC reviews and fair hearings depend on an unaltered history — mutations undermine the regulatory function. |
+| 18 | [Metrics as YAML contract artifacts](#decision-18-metrics-as-yaml-contract-artifacts) | Metric definitions are explicit, versionable, and portable — unlike proprietary GUI dashboards. |
+| 19 | [Duration metrics via event pairs, not pre-computed fields](#decision-19-duration-metrics-via-event-pairs) | Declarative model lets metric authors define new measurements without schema changes. |
+| 20 | [Pre-aggregation is an adapter-layer concern](#decision-20-pre-aggregation-is-an-adapter-layer-concern) | On-demand computation is simpler and always current for the baseline; states add pre-aggregation in their adapters. |
 
 ---
 
@@ -266,21 +264,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 6: `when` conditions use JSON Logic
-
-**Status:** Decided
-
-**What's being decided:** The expression language for conditional effects on transitions.
-
-**Considerations:**
-- JSON Logic is already used for guard conditions, routing rules, SLA auto-assign conditions, and metric filters. Using it for `when` conditions too means one evaluator, one toolchain, and no additional learning curve for state implementers.
-- The alternative — a separate condition language — would introduce a second evaluator and second set of tooling for state customizers.
-
-**Decision:** `when` conditions use JSON Logic — the same evaluator used across the rest of the contract system.
-
----
-
-### Decision 7: `calendarType` is explicit per timer transition
+### Decision 6: `calendarType` is explicit per timer transition
 
 **Status:** Decided
 
@@ -313,7 +297,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 8: `cancel` is supervisor-only; no `notify` effect
+### Decision 7: `cancel` is supervisor-only; no `notify` effect
 
 **Status:** Decided
 
@@ -329,7 +313,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 9: Automated verification uses a dedicated `system-resume` trigger
+### Decision 8: Automated verification uses a dedicated `system-resume` trigger
 
 **Status:** Decided
 
@@ -343,7 +327,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 10: Guards on `taskType` enable multiple lifecycles per state machine
+### Decision 9: Guards on `taskType` enable multiple lifecycles per state machine
 
 **Status:** Decided
 
@@ -361,7 +345,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 11: `workflow-rules.yaml` is independently replaceable
+### Decision 10: `workflow-rules.yaml` is independently replaceable
 
 **Status:** Decided
 
@@ -385,7 +369,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 12: `first-match-wins` rule evaluation
+### Decision 11: `first-match-wins` rule evaluation
 
 **Status:** Decided
 
@@ -400,7 +384,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 13: `slaClock` required on every state
+### Decision 12: `slaClock` required on every state
 
 **Status:** Decided
 
@@ -414,7 +398,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 14: `awaiting_*` states pause the SLA clock
+### Decision 13: `awaiting_*` states pause the SLA clock
 
 **Status:** Decided
 
@@ -435,7 +419,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 15: SLA type definitions are independently replaceable
+### Decision 14: SLA type definitions are independently replaceable
 
 **Status:** Decided
 
@@ -451,7 +435,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 16: Multiple SLA types can apply per task
+### Decision 15: Multiple SLA types can apply per task
 
 **Status:** Decided
 
@@ -471,7 +455,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 17: `pauseWhen`/`resumeWhen` per SLA type
+### Decision 16: `pauseWhen`/`resumeWhen` per SLA type
 
 **Status:** Decided
 
@@ -488,24 +472,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 18: Events in a shared collection across domains
-
-**Status:** Decided
-
-**What's being decided:** Whether domain events are stored per-domain or in a shared collection.
-
-**Considerations:**
-- Siloed event stores per domain would require joining them for cross-domain queries — "all events for this person across case management and workflow" would require joining separate stores.
-- A shared collection enables cross-domain queries from one place, consistent with the cross-cutting audit domain approach (see intake [Decision 8](intake-design-reference.md#decision-8-application-data-mutability-and-audit-trail)).
-- JSM, ServiceNow, and Camunda each maintain separate audit logs per system — cross-system queries require custom reporting.
-
-**Decision:** Events are stored in a shared collection across all domains, identified by `domain`, `resource`, and `action`.
-
-**Customization:** States can add additional `event` effects to transitions via overlay.
-
----
-
-### Decision 19: The audit trail is immutable
+### Decision 17: The audit trail is immutable
 
 **Status:** Decided
 
@@ -524,7 +491,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 20: Metrics as YAML contract artifacts
+### Decision 18: Metrics as YAML contract artifacts
 
 **Status:** Decided
 
@@ -548,7 +515,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 21: Duration metrics via event pairs
+### Decision 19: Duration metrics via event pairs
 
 **Status:** Decided
 
@@ -562,7 +529,7 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 ---
 
-### Decision 22: Pre-aggregation is an adapter-layer concern
+### Decision 20: Pre-aggregation is an adapter-layer concern
 
 **Status:** Decided
 

--- a/docs/architecture/domains/workflow-industry-reference.md
+++ b/docs/architecture/domains/workflow-industry-reference.md
@@ -1,375 +1,586 @@
-# Workflow Domain: Industry Reference
+# Workflow Domain: Design Reference
 
-A capability-by-capability comparison of the workflow contract architecture against major workflow and case management platforms. For each capability, this document describes how comparable systems handle the problem, the blueprint's specific approach and the trade-offs behind it, and where states are expected to customize via overlays.
+Industry research and design decisions for the workflow domain, covering task lifecycle, SLA and deadline management, routing, events, and metrics. Informed by how major workflow and case management platforms handle benefits casework, and by the federal regulations that govern processing timelines and quality control.
 
-See [Workflow Domain](workflow.md) for the architecture overview and [Contract-Driven Architecture](../contract-driven-architecture.md) for the adapter pattern.
+See [Workflow Domain](workflow.md) for the architecture overview and [Contract-Driven Architecture](../contract-driven-architecture.md) for the contract approach.
 
-## Features
+**Systems compared:** Atlassian Jira Service Management (JSM), ServiceNow, IBM Cúram, Salesforce Government Cloud, Pegasystems (Pega), Appian, Camunda, WS-HumanTask
 
-**Workflow engine core**
-- [State machine](#state-machine)
-  - [States](#states)
-  - [Transitions and effects](#transitions-and-effects)
-  - [Timer-triggered transitions](#timer-triggered-transitions)
-  - [Lifecycle hooks](#lifecycle-hooks-oncreate-onupdate)
-- [Guards and access control](#guards-and-access-control)
-- [Rules engine](#rules-engine)
-
-**SLA and deadline tracking**
-- [SLA and deadline management](#sla-and-deadline-management)
-  - [SLA clock behavior by state](#sla-clock-behavior-by-state)
-  - [SLA type definitions](#sla-type-definitions)
-
-**Observability**
-- [Domain events](#domain-events)
-- [Metrics](#metrics)
-
----
-- [Known gaps and future considerations](#known-gaps-and-future-considerations)
-- [References](#references)
+**Regulatory standards referenced:** 7 CFR Part 273 (SNAP), 42 CFR Part 435 (Medicaid/MAGI)
 
 ---
 
-## State machine
+## Overview
+
+The workflow domain manages caseworker tasks — the units of work assigned to staff during benefits processing. It owns task creation, assignment, state transitions, SLA tracking, and the domain events that drive cross-domain coordination. It does not determine eligibility, manage case data, or send notices — those are other domain concerns.
+
+**Entities owned by this domain:**
+
+- **Task** — a unit of work assigned to a caseworker or queue
+- **Queue** — a named pool of tasks routed by program type, geography, or workload
+- **SLA** — deadline and clock-pause rules attached to a task based on program type
+
+**What this domain produces:** state transitions, domain events, and SLA tracking that allow supervisors to monitor workload and regulatory compliance, and that trigger downstream actions (notice generation, case creation) via event subscription.
+
+All major platforms have equivalent concepts — task/work item, queue/team, SLA/deadline. The blueprint follows the same model while making the state machine and routing rules independently configurable per state.
+
+---
+
+## What happens during workflow
+
+The workflow lifecycle spans from task creation through completion. The key activities and their sequence:
+
+1. **Task creation** — when a triggering event occurs (e.g., an application is submitted), a caseworker task is created and assigned to the appropriate queue; the regulatory processing clock starts
+2. **Queue assignment and routing** — the task is routed to the appropriate queue based on program type, geography, workload, and agency-configured rules; routing logic is fully replaceable per state
+3. **Caseworker claim** — a caseworker claims the task from the queue and begins active work
+4. **Active processing** — the caseworker reviews submitted data, conducts the required interview, requests and reviews documents, and updates application data
+5. **Blocking for external input** — if the caseworker is waiting for the client to respond or a third-party to verify information, the task enters a waiting state; client-caused delays are excluded from the agency's processing clock under federal regulations
+6. **Expedited screening** — for SNAP, the caseworker must determine within 1 business day whether the household qualifies for the 7-day expedited track; if so, the task is escalated to a higher-priority SLA track
+7. **Escalation** — when a deadline approaches or supervisor involvement is needed, the task is escalated; escalation does not pause the agency's regulatory clock — the deadline continues running
+8. **Supervisor review** — for determinations requiring quality control sign-off (SNAP, Medicaid), the caseworker submits for supervisor review; the supervisor either approves or returns the task for revision
+9. **Completion** — the task is marked complete; downstream domains are notified via events
+
+**What workflow does not cover:** eligibility rules, approval/denial decisions, notice generation, case data management. Those are downstream domain concerns that subscribe to workflow events.
+
+---
+
+## Regulatory requirements
+
+### Processing deadlines
+
+Federal law sets maximum processing timelines that begin at application receipt, not when a caseworker claims the task.
+
+**SNAP (7 CFR § 273.2):** 30-day processing deadline from application receipt. Expedited households must be processed within 7 days. Client-caused delays (waiting for the client to respond) are excluded from the agency's deadline calculation — the clock pauses, not stops.
+
+**Medicaid (42 CFR § 435.912):** 45-day processing deadline (90 days for disability-based Medicaid) from application receipt.
+
+### Quality control requirements
+
+**SNAP (7 CFR § 275):** Federal quality control audits review a sample of cases each year. Determinations must be documented and, in many states, supervisor-reviewed before finalization. The workflow domain supports structured supervisor sign-off as a first-class lifecycle state.
+
+**Medicaid (42 CFR Part 431, Subpart F):** Similar QC framework; states must maintain documentation of eligibility determinations.
+
+---
+
+## Task lifecycle
 
 ### States
 
-Every workflow system tracks which stage a work item is in — typically something like pending, active, blocked, or complete — because state drives routing, SLA accountability, and access control. Systems vary in granularity: JSM and ServiceNow use a small set of broad states with sub-statuses for nuance; WS-HumanTask defines a fixed set of abstract states; IBM Curam ties state to the underlying case process. The blueprint uses a flat, explicit state enum sized for benefits casework — with first-class states for waiting conditions that federal regulations treat differently for SLA purposes. Each state has distinct SLA clock behavior, routing implications, and access control requirements; they are modeled as first-class states rather than sub-statuses or flags.
+| State | SLA clock | Description |
+|---|---|---|
+| `pending` | running | Task created; in queue awaiting claim |
+| `in_progress` | running | Claimed by a caseworker; actively being worked |
+| `awaiting_client` | paused | Waiting for the client to respond or provide information; federal regulations exclude this time from the agency's deadline |
+| `awaiting_verification` | paused | Waiting for a third-party verification service to return results |
+| `escalated` | running | Elevated for supervisor attention; agency deadline continues running |
+| `pending_review` | running | Submitted for supervisor sign-off; supervisor must approve or return for revision |
+| `completed` | stopped | Work finished; regulatory deadline no longer applies |
+| `cancelled` | stopped | Task abandoned; can be reopened by a supervisor, which resets routing via `pending` |
 
-**States:** `pending`, `in_progress`, `awaiting_client`, `awaiting_verification`, `escalated`, `pending_review`, `completed`, `cancelled`
+All states have an explicit `slaClock` value — see [Decision 13](#decision-13-slaclock-required-on-every-state). The `awaiting_*` states use `paused` rather than `stopped` — see [Decision 14](#decision-14-awaiting-states-pause-the-sla-clock).
 
-The state set covers all task types in the domain. Task-type-specific states (e.g., fair hearing states like `hearing_scheduled`) are added alongside the baseline states and are only reachable via transitions guarded on `$object.taskType` — making them invisible to incompatible task types at runtime without requiring a separate state machine or separate API resource. See [Guards and access control](#guards-and-access-control) for how this works.
+Task-type-specific states (e.g., `hearing_scheduled` for fair hearing tasks) are added alongside these baseline states and are only reachable via transitions guarded on task type — see [Decision 10](#decision-10-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine).
 
-**Design decisions:**
+### Key transitions
 
-- **Task state is an explicit field, not derived from timestamps or computed values.** Deriving state from timestamps is fragile — if `completedAt` is set but then cleared, what is the state? All major systems model task state explicitly. Explicit state is unambiguous and directly queryable.
-- **`awaiting_client` and `awaiting_verification` are separate first-class states, not sub-reasons of a single `on_hold`.** Federal regulations treat client-caused and agency-caused delays differently for SLA accountability, resolution paths, and regulatory implications. ServiceNow collapses them into `on_hold` sub-reasons; first-class states enable distinct timer behavior and clearer federal reporting. Other vendors handle the same concepts:
+- **`claim`**: `pending` → `in_progress` — caseworker takes ownership from the queue; see [Decision 4](#decision-4-named-rpc-transitions-not-patch)
+- **`await-client`**: `in_progress` → `awaiting_client` — caseworker is waiting on the client; pauses SLA clock
+- **`await-verification`**: `in_progress` → `awaiting_verification` — caseworker waiting on a third-party data source; pauses SLA clock
+- **`resume`**: `awaiting_*` → `in_progress` — caseworker resumes after external input received; clock resumes
+- **`system-resume`**: `awaiting_verification` → `in_progress` — automated callback from a verification service; see [Decision 9](#decision-9-automated-verification-uses-a-dedicated-system-resume-trigger)
+- **`escalate`**: `pending` | `in_progress` → `escalated` — caseworker or timer escalates for supervisor attention; re-evaluates priority via rules engine
+- **`de-escalate`**: `escalated` → `pending` — supervisor resolves; returns to queue for re-claim (handles both assigned and unassigned origin states cleanly)
+- **`submit-for-review`**: `in_progress` → `pending_review` — caseworker requests supervisor sign-off
+- **`approve`**: `pending_review` → `completed` — supervisor approves; task closes
+- **`return-to-worker`**: `pending_review` → `in_progress` — supervisor returns for revision; keeps task with the same caseworker rather than re-queuing
+- **`complete`**: `in_progress` → `completed` — caseworker marks work done (no review required)
+- **`cancel`**: `pending` | `in_progress` | `escalated` → `cancelled` — supervisor-only; see [Decision 8](#decision-8-cancel-is-supervisor-only-no-notify-effect)
+- **`reopen`**: `cancelled` → `pending` — supervisor reinstates; clears assignment for fresh routing
 
-  | Concept | Blueprint state | JSM | ServiceNow | Curam | Salesforce Gov Cloud | WS-HumanTask |
-  |---|---|---|---|---|---|---|
-  | Waiting for client action | `awaiting_client` | Waiting for Customer | On Hold / Awaiting Caller | Manual activity pending in inbox | Waiting on Someone Else | Suspended |
-  | Waiting for third-party verification | `awaiting_verification` | Pending | On Hold / Awaiting Evidence | Suspended process | Deferred | Suspended |
+Timer-triggered transitions fire automatically when durations elapse. See [Decision 7](#decision-7-calendartype-is-explicit-per-timer-transition) for how calendar vs. business-hour deadlines are handled.
 
-  Pega handles waiting via an **Assignment Ready** field that delays SLA clock start rather than pausing a running clock — an alternative approach with different federal reporting implications (delayed start vs. excluded interval). Appian has no built-in waiting states; pause behavior must be modeled via intermediate process nodes or custom status fields.
+### Lifecycle hooks
 
-- **Status values use snake_case.** Consistent with the blueprint's JSON API conventions and widely used in government API contexts (GitHub, Stack Exchange, Twitter). OpenAPI places no constraint on enum value casing; code generators map to language-appropriate forms (e.g., `InProgress` in TypeScript).
-- **`cancelled` has a `reopen` transition that returns the task to `pending` with fresh routing.** Cancellation is sometimes an error, and supervisors need a way to reinstate a task without recreating it from scratch. Matches ServiceNow and Curam behavior.
-- **`pending_review` is a dedicated state for structured supervisor sign-off before completion.** Quality control regulations in SNAP and Medicaid require supervisor approval before a determination is finalized. This is distinct from escalation — escalation is upward for help; review is a structured approval gate. A caseworker submits via `submit-for-review`; the supervisor either `approve`s (→ `completed`) or `return-to-worker`s (→ `in_progress`).
-- **The SLA clock keeps running in `escalated` — urgency does not pause the agency's regulatory obligation.** Compare to `awaiting_client`, which pauses the clock because the delay is attributable to an external party.
+**`onCreate`** — fires when a task is created. Used to invoke routing rules, set initial priority, and emit a creation event.
 
-**Customization points:**
-- States can add their own status values via overlay (e.g., `awaiting_supervisor`).
-- `slaClock` behavior per state can be overridden (e.g., a state may prefer to stop rather than pause the clock for `awaiting_client`, treating client delay as the client's time to spend).
-- States needing tiered escalation (L1 → L2 → L3, as in JSM and ServiceNow) can add intermediate escalation states via overlay (e.g., `escalated_l2`, `escalated_supervisor`, `escalated_director`) with their own transitions and guards.
-
-### Transitions and effects
-
-> *Industry equivalents — transitions: "flow actions" (Pega), "state transitions" (ServiceNow), "sequence flows" (BPMN/Camunda). Effects: "post-functions" (JSM), "business rules" (ServiceNow), "activities" (Pega), "Smart Services" (Appian).*
-
-Workflow systems vary in how they model state changes and the side effects that accompany them. Some expose a generic PATCH or update endpoint and infer intent from the diff; others use named transition operations with structured request bodies and explicit side effects. Named operations produce unambiguous audit events, can carry action-specific data (e.g., a cancellation reason), and can be independently guarded — at the cost of more API surface area. The blueprint uses named triggers that become RPC endpoints, with declarative effects specified in the state machine contract that the engine executes.
-
-**Effect types in the blueprint:**
-- `set` — update fields on the resource (e.g., set `assignedToId` when claiming a task)
-- `evaluate-rules` — invoke the rules engine to re-evaluate assignment or priority
-- `event` — emit a named domain event with an optional data payload
-- `create` — write a new record to another collection (e.g., a follow-up task)
-- `when` — conditional wrapper on any effect; uses JSON Logic to decide whether the effect fires
-
-Transitions can be actor-triggered (a human or system makes an API call) or timer-triggered (fire automatically when a duration elapses — see [Timer-triggered transitions](#timer-triggered-transitions)).
-
-**Design decisions:**
-
-- **Transitions use named RPC endpoints, not PATCH requests.** `claim` → `POST /tasks/:id/claim`. Each trigger maps cleanly to an audit event, can carry a request body (e.g., a cancellation reason), and can be independently guarded. PATCH endpoints require parsing the diff to determine what changed and whether it was allowed. Comparable systems:
-
-  | Concept | Blueprint | JSM | ServiceNow | Camunda | WS-HumanTask | Pega | Appian |
-  |---|---|---|---|---|---|---|---|
-  | Transition trigger | Named trigger → RPC endpoint | Status transition button | State flow trigger | Sequence flow / signal | Claim, start, complete, skip operations | Named flow action → RPC endpoint | Generic BPMN gateway with conditional flow |
-  | Precondition | Guards (field/operator/value) | Validator condition | Condition script | Gateway condition | Constraints (potential owners, etc.) | Decision rule or router activity (scripted) | Conditional gateway expression (scripted) |
-  | Side effect on transition | `set`, `create`, `evaluate-rules`, `event` effects | Post-function | Business Rule | Execution Listener | Task handler | Declare Expressions + activity steps | Smart Services (automation activities) |
-  | Conditional effect | `when` (JSON Logic) | — | Condition on Business Rule | Expression on Listener | — | Condition on activity step | Conditional gateway branch |
-
-- **Effects are declared in the state machine YAML, not implemented per-endpoint.** The state machine contract declares what should happen; the engine executes it. Implementations don't need to read source code to understand what a transition does — the contract is the specification.
-- **`when` conditions use JSON Logic, not a separate condition language.** JSON Logic is already used for rules and metric filters. Using it for `when` conditions too means one evaluator, one set of tooling, and no learning curve for state implementers.
-- **Transitions support `from: [array]` for shared triggers from multiple source states.** `cancel` fires from `pending`, `in_progress`, and `escalated`. Without array support, three blocks with the same guards and effects would be needed. `from: [pending, in_progress, escalated]` keeps it as one readable entry.
-- **`return-to-worker` routes to `in_progress`, keeping the task with the assigned caseworker.** Returning to `pending` would force an unnecessary re-claim and break the revision cycle. When a supervisor returns work for revision, the same caseworker should revise it — not re-queue and re-claim it.
-- **`de-escalate` routes to `pending`, not back to `in_progress`.** Tasks may be escalated from `in_progress` (assigned worker) or from `pending` (no assigned worker). Re-queuing via `→ pending` handles both: assigned-worker tasks can be immediately re-claimed; unassigned tasks re-queue cleanly without an `in_progress`-with-no-owner inconsistency. Consistent with `reopen → pending` and `release → pending`.
-- **`reopen` clears assignment and re-evaluates routing via `pending`.** Cancellation implies closure — reopen should start fresh, not return the task to its original owner. The original caseworker may no longer be the right person for the case.
-- **`cancel` is restricted to supervisors.** Closing a benefits application has federal reporting and client appeal implications — caseworkers cannot cancel unilaterally. States that want a worker-initiated request with supervisor approval can model this via a custom `request-cancel` state.
-- **There is no `notify` effect type — notification is a consumer concern, handled by subscribers to domain events.** JSM, ServiceNow, and Curam all have built-in notification on escalation, which creates tight coupling to delivery mechanisms. States that need push notifications should build notification services that subscribe to domain events.
-
-**Customization points:**
-- States can add effects to existing transitions via overlay (e.g., send a notice to the client when `await-client` fires).
-- States can add new transitions (e.g., a `pend` transition for applications requiring additional review before determination).
-
-### Timer-triggered transitions
-
-Most workflow systems support time-based automation — escalating tasks that sit too long, canceling requests after extended inactivity, or warning before a deadline is missed. Timer triggers typically fire relative to task creation, a deadline timestamp, or a timestamp marking when a waiting condition began. Whether the duration uses calendar days or business hours matters significantly for regulatory deadline calculations, since SNAP and Medicaid deadlines are calendar days while staffing SLAs are often business hours. The blueprint supports timer transitions on the state machine with explicit `after`, `relativeTo`, and `calendarType` fields.
-
-**Design decisions:**
-
-- **`calendarType` is explicit per transition — calendar days for regulatory deadlines, business hours for staffing SLAs.** Conflating the two produces incorrect enforcement and federal reporting errors. Regulatory deadlines (SNAP 30-day determination) are calendar days; staffing SLAs are typically business hours. Setting the wrong type silently miscalculates deadlines. Comparable systems:
-
-  | Concept | JSM | ServiceNow | Curam |
-  |---|---|---|---|
-  | Time-based transition | SLA timer → auto-transition on breach | Escalation rule with time condition | Deadline escalation on process |
-  | Business vs. calendar time | Configurable per SLA | Configurable per schedule | Configurable per deadline |
-  | Relative to deadline | SLA breach point | SLA breach point | Process deadline |
-
-- **Timer transitions support `relativeTo: slaDeadline` with a negative duration, firing before the breach point.** Reacting only after a deadline is missed is too late. A `-48h` offset gives supervisors time to intervene. This is how JSM and ServiceNow are typically configured to prevent breaches rather than just record them.
-- **On SLA warning, the timer transition fires a state change to `escalated`, not just a notification.** JSM issues an SLA warning notification without changing task status. ServiceNow auto-escalates on breach. We follow the ServiceNow model: the state change + domain event creates a clear audit trail, triggers assignment and priority re-evaluation, and makes the escalation visible in queue views — all without requiring a separate notification integration. States that prefer notification-only can remove this timer via overlay.
-- **`auto-escalate-sla-breach` fires at `0h` relative to `slaDeadline`, emitting a distinct `sla_breached` event at the deadline moment.** ServiceNow fires a distinct breach escalation separate from the warning. The blueprint follows the same model: the breach transition ensures a clear, queryable state change and a domain event carrying breach data for federal compliance reporting — distinct from the `-48h` warning transition.
-- **All `after` durations in the baseline state machine are illustrative placeholders, expected to be overridden per state.** The correct timer thresholds vary by program type, jurisdiction, and policy — SNAP expedited (7-day deadline) needs a much shorter `auto-escalate` threshold than SNAP standard (30-day deadline), and neither baseline value should be used in production without review. Baseline values in the state machine:
-
-  | Trigger | From | To | After | Relative to | Calendar type |
-  |---|---|---|---|---|---|
-  | `auto-escalate` | `pending` | `escalated` | 72h | `createdAt` | business |
-  | `auto-escalate-sla-warning` | `in_progress` | `escalated` | -48h | `slaDeadline` | calendar |
-  | `auto-escalate-sla-breach` | `pending`, `in_progress`, `escalated` | `escalated` | 0h | `slaDeadline` | calendar |
-  | `auto-cancel-awaiting-client` | `awaiting_client` | `cancelled` | 30d | `blockedAt` | calendar |
-  | `auto-resume-awaiting-verification` | `awaiting_verification` | `in_progress` | 7d | `blockedAt` | calendar |
-
-**We support:** `on: timer`, `after` (duration string), `relativeTo` (task field or `slaDeadline`), `calendarType: calendar | business`
-
-**Customization points:**
-- All `after` durations are overlay points — states set their own thresholds per program type and regulatory requirement.
-- States should configure separate timer thresholds for expedited vs. standard cases (different SLA deadlines).
-- `calendarType` can be overridden per transition.
-- Timer transitions support an optional `guards` field for conditional suppression — e.g., skip `auto-escalate` for tasks already flagged by a supervisor.
-
-### Lifecycle hooks (`onCreate`, `onUpdate`)
-
-> *Industry equivalents: "business rules (before/after insert/update)" (ServiceNow), "When rules" / "Declare Expressions" (Pega), "record-triggered flows" (Salesforce), "start/boundary events" (BPMN).*
-
-Workflow systems need to run automation not just on explicit state transitions, but when objects are created or when specific fields change outside a transition. Creation hooks initialize derived state — routing a new task to a queue, setting its priority, emitting a creation event. Field-change hooks re-run routing logic when key attributes are updated after the fact (e.g., a supervisor marks a task as expedited after it was created as standard). The blueprint models these as `onCreate` and `onUpdate` lifecycle hooks in the state machine contract, keeping creation and update behavior co-located with transition behavior in the same declarative artifact.
-
-**Design decisions:**
-
-- **`onUpdate` includes an explicit `fields` filter — it fires only when listed fields change, not on every PATCH.** Without scoping, `onUpdate` would fire on every PATCH including updates made by transitions themselves, creating re-evaluation loops. The `fields` filter explicitly declares which field changes have downstream effects — e.g., `isExpedited` and `programType`, but not `assignedToId` (set by transitions). If a field isn't in the list, it's intentional. ServiceNow's Business Rules have the same scoping problem and solve it similarly with condition scripts. Comparable systems:
-
-  | Concept | Blueprint | JSM | ServiceNow | Camunda | BPMN |
-  |---|---|---|---|---|---|
-  | On creation | `onCreate` | — | Business Rule on insert | Start event listener | Start event |
-  | On field change | `onUpdate` (scoped by `fields`) | — | Business Rule on update | Execution listener on variable change | Data Object change event |
-
-- **Transition-internal field changes (e.g., `set assignedToId`) do not trigger `onUpdate`.** `onUpdate` fires only on external PATCH requests. In benefits processing, this matters: a supervisor correcting a task's `programType` should re-trigger routing; a caseworker claiming a task should not.
-
-**Customization points:**
-- States can add `onUpdate` effects via overlay (e.g., send a supervisor alert when `priority` changes to `expedited`).
-- States can extend the `fields` list to react to additional field changes.
-
----
-
-## Guards and access control
-
-> *Industry equivalents: "condition scripts" (ServiceNow), "validators" (JSM), "routing constraints" / "decision rules" (Pega), "gateway conditions" (Camunda/BPMN), "potential owner constraints" (WS-HumanTask).*
-
-Workflow systems enforce preconditions on state transitions to prevent unauthorized or invalid operations — ensuring a task can't be claimed twice, that only supervisors can cancel, or that a caseworker can only act on their own assigned work. Most systems implement this via scripted conditions (ServiceNow, JSM) or expression languages (Camunda). The blueprint uses declarative field/operator/value guards defined at the top of the state machine and referenced by name from transitions, with `any`/`all` composition operators for OR/AND logic at the transition level. A transition only fires if all its guards pass.
-
-**Design decisions:**
-
-- **Compound conditions are expressed as `any`/`all` operators at the transition level, referencing named simple guards — not embedded logic inside guard definitions.** This keeps guard definitions readable (`field/operator/value`) and makes composition explicit and inspectable — consistent with how XState and similar declarative state machine systems handle compound preconditions. Comparable systems:
-
-  | Concept | JSM | ServiceNow | Camunda | WS-HumanTask |
-  |---|---|---|---|---|
-  | Precondition | Validator (Groovy/JS) | Condition script (JS) | Expression language (JUEL/SpEL) | Deployment/routing constraints |
-  | Role check | Project role condition | Role condition | Candidate group check | Potential owners list |
-  | Compound condition | Multiple validators | Multiple conditions | Composite expression | — |
-
-- **`callerIsSupervisor` is a named guard stub — RBAC will plug into this contract point when implemented.** `callerIsSupervisor` references `$caller.role`, which is the convention for what the platform-level RBAC service will expose. Until then, enforcement is at the service layer.
-- **Automated verification callbacks use a dedicated `system-resume` trigger, not a relaxed version of the human `resume` guard.** IEVS and FDSH return results asynchronously. A separate trigger keeps domain events distinguishable and allows the request body to carry verification result data (source, result summary). SNAP and Medicaid quality control requirements also require this distinction in the audit trail — automated callbacks from IEVS, FDSH, and state data hubs are system actors, not human caseworkers.
-- **Guards are defined at the top of the state machine and referenced by name across transitions — not duplicated inline.** Copying conditions to each transition creates inconsistency over time. Named guards stay consistent and make intent legible at a glance. Baseline guards:
-
-  | Guard | Expression | Used on |
-  |---|---|---|
-  | `taskIsUnassigned` | `assignedToId is_null` | `claim` — prevents double-claiming in queue-based processing |
-  | `callerIsAssignedWorker` | `assignedToId == $caller.id` | `complete`, `release`, `await-client`, etc. |
-  | `callerIsSupervisor` | `$caller.role == supervisor` | `cancel`, `de-escalate`, `approve`, `return-to-worker` — enforces federal QC requirements on eligibility determinations |
-  | `callerIsSystem` | `$caller.type == system` | `system-resume` |
-
-  Compound conditions use composition at the transition level: `escalate` uses `any: [callerIsAssignedWorker, callerIsSupervisor]` — keeping named guards simple and composable.
-
-- **`await-client` and `await-verification` require `callerIsAssignedWorker` — supervisors cannot block tasks unilaterally.** Blocking a task on external input reflects the caseworker's knowledge of the case. If a supervisor needs to block a task, they can reassign it to themselves. States that want supervisors to be able to await can add `callerIsSupervisor` to these guards via overlay.
-- **There is no `entryGuards` concept per state — every transition must carry its own guards explicitly.** This is standard for declarative state machines but requires discipline when adding new transitions — a missing guard is a silent gap in access control. A future schema enhancement could enforce this at the contract level.
-- **Guards on `$object.taskType` enable multiple lifecycles within a single state machine.** Task-type-specific transitions carry a named guard that checks `$object.taskType` (e.g., `taskTypeIsFairHearing: taskType equals fair_hearing`). This scopes those transitions to the applicable task type without requiring a separate state machine file, a separate API resource, or separate endpoints. The result is one API surface and shared infrastructure (queues, SLA tracking, domain events, assignment rules) serving multiple task lifecycles — consistent with how Pega (`caseTypeID`), Salesforce (`RecordTypeId`), and JSM (issue type) scope available operations within a single object type's API. Shared transitions like `cancel`, `assign`, and `set-priority` carry no task type guard and apply to all types. The trade-off: the OpenAPI status enum includes states from all task types, so `taskType` is the authoritative constraint on which states are reachable for a given task — not the schema.
-
-**We support:** simple `field/operator/value` guards; composition operators (`any`, `all`) at the transition level for OR/AND conditions across named guards.
-
-**Customization points:**
-- States can add guards to existing transitions via overlay (e.g., restrict `claim` to workers assigned to the correct program team).
-- States can define additional named guards for their custom transitions.
-- Once platform-level RBAC is implemented, `callerIsSupervisor` can be tightened to reference the real role model without changing transition definitions.
-
----
-
-## Rules engine
-
-Routing logic — which queue a task goes to, what priority it gets — varies enormously across states and program types. The rules engine separates this logic from the state machine so each can change independently.
-
-**Design decisions:**
-
-- **`workflow-rules.yaml` is entirely replaceable per state, separate from the state machine.** Routing logic varies significantly across states — entangling it with the state machine would make customization harder. A state drops in their own rules file without touching the state machine. JSM and ServiceNow similarly decouple automation rules from workflow status transitions:
-
-  | Concept | JSM | ServiceNow | Camunda | WfMC | Pega | Appian |
-  |---|---|---|---|---|---|---|
-  | Routing rules | Automation rules | Assignment rules | Task listener / routing | Participant resolution | Push (system assigns to operator/queue) + Pull (Get Next Work algorithm) | Automated Case Routing module (round-robin, workload balance, shared queue) |
-  | Priority rules | Priority field automation | SLA-based priority | — | — | Urgency (1–100); SLA milestone-driven escalation | Process HQ KPI-based; no dedicated priority rule |
-  | Rule order | First matching automation | Rule processing order | — | — | Router activity scripts; decision tree precedence | Rule number precedence (lower = higher priority) |
-
-- **Pega supports both push routing (system assigns) and pull routing (Get Next Work algorithm).** Pull routing presents the next best assignment to a worker based on urgency, availability, and skills — the worker requests work rather than having it assigned. The blueprint uses push routing only; pull routing is a future consideration for caseworker queue management. Appian's Automated Case Routing module explicitly names its strategies (round-robin, workload balance, shared queue), which is the same model as the `routingStrategy` field planned for the Queue entity — confirming that named strategies are the industry-standard approach.
-- **Rules use `first-match-wins` evaluation — simple, predictable, and easy to debug.** Rules are evaluated in order and the first match wins. Multi-factor weighted scoring — combining urgency, program type, task age, and other attributes into a numeric priority — is not expressible with `first-match-wins` and is a known gap.
-- **Rules are invoked via `evaluate-rules` effects in the state machine — not embedded in rule definitions.** The state machine declares when rules run; the rules engine decides what happens. Neither system needs to understand the other's internals.
-- **`escalate` uses `evaluate-rules: priority`, not `set priority: high`.** Hardcoding a priority value would break states with different escalation behavior per program. `evaluate-rules: priority` delegates the decision to the rules engine, which can apply different priority logic for expedited vs. standard cases. This is especially important in benefits processing, where SNAP expedited and standard cases have different deadline profiles.
-
-**Customization points:**
-- States replace `workflow-rules.yaml` entirely with their own assignment and priority rules.
-- States can add `evaluate-rules` effects to additional transitions via overlay.
+**`onUpdate`** — fires when specific fields change via an external update (not a transition). The `fields` filter explicitly declares which field changes have downstream effects — e.g., `isExpedited` and `programType`, but not `assignedToId` (set by transitions). Transition-internal field changes do not trigger `onUpdate`.
 
 ---
 
 ## SLA and deadline management
 
-### SLA clock behavior by state
+Each task carries one `slaInfo` record per applicable SLA type. Multiple SLA types can apply simultaneously — a SNAP application initially filed as standard may later be determined to qualify for expedited processing, at which point both deadlines apply. See [Decision 16](#decision-16-multiple-sla-types-can-apply-per-task).
 
-Workflow systems that track SLA deadlines need to handle delays attributable to external parties — when the agency is waiting on the client or a third-party verifier, that time should not count against the agency's processing deadline. All major systems support some form of clock pause, typically via hold states or sub-statuses that exclude certain intervals from SLA calculation. The blueprint declares clock behavior directly on each state via a `slaClock` field (`running`, `paused`, or `stopped`), consumed by the SLA engine when evaluating pause/resume conditions on every transition.
+SLA type definitions live in `*-sla-types.yaml`, separately from the state machine, and are independently replaceable per state. The baseline types derived from federal regulatory deadlines:
 
-**Design decisions:**
+| SLA type | Duration | Warning threshold | Pauses when |
+|---|---|---|---|
+| `snap_expedited` | 7 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
+| `snap_standard` | 30 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
+| `medicaid_standard` | 45 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
+| `medicaid_disability` | 90 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
 
-- **`slaClock` is required on every state with no default.** If a state has no `slaClock` value, it's ambiguous whether the clock is running or stopped. Requiring explicit declaration forces intentional choices and prevents silent regressions when new states are added. The baseline assignment:
-
-  | State | Clock behavior | Rationale |
-  |---|---|---|
-  | `pending` | running | Deadline starts at creation; time in queue counts against the agency |
-  | `in_progress` | running | Work is actively in progress |
-  | `escalated` | running | Still the agency's responsibility; urgency doesn't pause the deadline |
-  | `awaiting_client` | paused | External dependency; federal regulations exclude client-caused delays from the agency's deadline |
-  | `awaiting_verification` | paused | External dependency; clock resumes when verification service returns |
-  | `pending_review` | running | Supervisor review counts against the agency's deadline |
-  | `completed` | stopped | Work is done; deadline is no longer relevant |
-  | `cancelled` | stopped | Work is abandoned; `reopen` transition restarts the clock from `pending` |
-
-- **Waiting states use `slaClock: paused`, not `stopped`.** `paused` means the clock resumes from where it left off, preserving the original deadline. `stopped` would reset the clock, granting a fresh deadline on each block/resume cycle — federal SNAP regulations treat client-caused delays as excluded time, not as time that resets the agency's clock. Comparable systems:
-
-  | Concept | Blueprint | JSM | ServiceNow | Curam | Pega | Appian |
-  |---|---|---|---|---|---|---|
-  | Pause SLA | `slaClock: paused` on states with external dependencies | "Pending" status excludes from SLA timers | On Hold sub-reasons pause SLA | SLA tracked at process level, not task state | Assignment Ready field delays clock start (clock doesn't begin until assignment is ready) | No built-in pause; requires custom process logic |
-  | Stop SLA | `slaClock: stopped` on terminal states | Resolved / Closed | Resolved / Closed / Canceled | Process completed / aborted | Case resolution / Resolved stage | Process completion / case closure |
-  | Business hours | `calendarType` per timer transition | Configurable per SLA | Configurable per schedule | Configurable per deadline | System-wide calendar configuration | Per-day-of-week configurable process calendar |
-
-- **Pega uses a three-tier SLA model (Goal → Deadline → Passed Deadline) rather than a single deadline with a warning threshold.** Goal is a soft performance target; Deadline is the hard deadline; Passed Deadline is a repeating escalation interval after the deadline is missed. The blueprint uses a single deadline with a percentage-based warning threshold — simpler, but it lacks a separate performance-target tier. States that want Pega-style tiered escalation can model it with multiple timer transitions (warning → deadline → breach).
-- **`pending_review` uses `slaClock: running` — supervisor review counts against the agency's deadline.** JSM and ServiceNow do not pause external SLA timers during approval states. States where regulation explicitly excludes review time from the deadline can override `slaClock` via overlay.
-
-**Customization points:**
-- States can override `slaClock` per state via overlay. A state that treats client non-response differently (e.g., stops rather than pauses) can do so without touching the baseline.
-- The actual clock-pause/resume/stop logic is evaluated by the SLA engine on every transition using the `pauseWhen`/`resumeWhen` conditions in `*-sla-types.yaml` (see [SLA type definitions](#sla-type-definitions)). The `slaClock` value on each state declares the intent; the SLA engine reads the task's current state when evaluating those conditions.
-
-### SLA type definitions
-
-Federal regulations impose strict processing deadlines on benefits applications. The SLA types system tracks these deadlines per task, auto-assigns them based on task attributes, pauses the clock when delays are attributable to external parties, and warns before breach. SLA type definitions live in `*-sla-types.yaml`, separate from the state machine.
-
-**Design decisions:**
-
-- **SLA type definitions live in `*-sla-types.yaml`, a file that is independently replaceable per state.** A state with a different program mix needs to replace deadlines without touching lifecycle logic. JSM and ServiceNow store SLA definitions as separate database records, decoupled from workflow configuration. Embedding deadlines as constants in the state machine would couple two concerns that change independently.
-- **Each task carries one `slaInfo` entry per applicable SLA type — multiple SLAs can apply simultaneously.** A SNAP application initially filed as standard may later be determined to qualify for expedited processing — both deadlines then apply. JSM and ServiceNow both support multiple SLA records per work item for exactly this reason. IBM Curam's single-deadline-per-process model is less flexible for multi-program cases. Comparable systems:
-
-  | Concept | JSM | ServiceNow | IBM Curam | Salesforce Gov Cloud |
-  |---|---|---|---|---|
-  | SLA definition | SLA agreement (separate record) | SLA Definition (separate record) | Process deadline on case | Milestone on entitlement |
-  | Multiple SLAs per record | Yes — multiple agreements can apply | Yes — multiple SLA records can attach | Typically one deadline per process | Multiple milestones per case |
-  | Auto-attach conditions | Automation rule conditions | SLA Definition conditions (scripted/GUI) | Configured at process design time | Entitlement criteria |
-  | Pause/resume | "Pending" sub-status excludes from timer | On-hold condition scripts | Not granular; handled at process level | Milestone pause conditions |
-  | Warning before breach | Warning percentage on SLA agreement | Warning threshold on SLA Definition | Not built-in | Milestone warning time |
-
-- **`autoAssignWhen` uses JSON Logic — the same evaluator used for guards, rules, and metric filters.** ServiceNow uses scripted conditions; JSM uses automation rules. `isExpedited == true` on the task causes `snap_expedited` to attach automatically at creation, with no second language to learn. The baseline SLA types — derived from federal regulatory deadlines — and their auto-assign conditions:
-
-  | SLA type | Duration | Warning threshold | Pauses when |
-  |---|---|---|---|
-  | `snap_expedited` | 7 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
-  | `snap_standard` | 30 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
-  | `medicaid_standard` | 45 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
-  | `medicaid_disability` | 90 days | 75% elapsed | `awaiting_client` or `awaiting_verification` |
-
-- **`pauseWhen` / `resumeWhen` use JSON Logic conditions per SLA type — not a hardcoded list of states.** Different SLA types can have different pause behavior on the same state. A state might pause `snap_standard` but not `snap_expedited` during `awaiting_client` (the 7-day clock continues running). States can override pause behavior without modifying the state machine. ServiceNow's on-hold conditions work the same way.
-- **The SLA clock is paused, not stopped, during `awaiting_client` — preserving the original deadline rather than granting a fresh one.** Federal SNAP regulations treat client-caused delays as excluded time. `pauseWhen` pauses rather than stops the clock, resuming from the same point. Stopping would grant a fresh deadline on each block/resume cycle, distorting federal reporting. JSM and ServiceNow default to the same behavior.
-- **Warning thresholds are a percentage of the total SLA duration, not a fixed offset.** 75% of 7 days ≈ 5.25 days elapsed; 75% of 90 days = 67.5 days elapsed. A fixed 2-day offset would feel identical regardless of deadline length. ServiceNow uses the same percentage model on SLA Definitions.
-- **`slaTypeCode` is an untyped string in the base contract — the valid enum is injected from `*-sla-types.yaml` at build time.** Hardcoding valid SLA type codes in the base OpenAPI spec would conflict with state overlays that add or replace types. The resolve pipeline injects the correct enum at build time.
-
-**Customization points:**
-- States can replace or extend SLA types via overlay.
-- `pauseWhen` conditions can be tightened or loosened per regulatory interpretation — some states treat `awaiting_client` as the client's time to spend (stopping rather than pausing the clock) and can express that without touching the state machine.
-- `autoAssignWhen` logic can be adjusted to match state-specific program routing criteria (e.g., attach `snap_expedited` when household income is below the expedited threshold, not just when `isExpedited` is set).
+All baseline durations are derived from federal regulations. See [Decision 15](#decision-15-sla-type-definitions-are-independently-replaceable).
 
 ---
 
 ## Domain events
 
-> *Industry equivalents: "audit log" / "issue history" (JSM), "audit log" / "event management" (ServiceNow), "case history" (Pega), "record events" (Appian). The blueprint's domain events go further — they are also the integration surface for cross-domain communication, not just an internal audit record.*
+Domain events serve two purposes: they are the audit trail required by federal and state regulations, and they are the integration surface for cross-domain communication. Other domains (communication, case management, eligibility) subscribe to workflow events rather than polling task state.
 
-Domain events serve two purposes: they are the audit trail required by federal and state program regulations, and they are the integration surface for cross-domain communication (other domains subscribe to events rather than polling task state).
-
-**Design decisions:**
-
-- **Events are stored in a shared collection across all domains, identified by `domain`, `resource`, and `action`.** Siloed event stores per domain would require joining them for cross-domain queries. A shared collection enables queries like "show all events for this person across case management and workflow" without joining separate stores. JSM, ServiceNow, and Camunda each maintain separate audit logs per system — cross-system queries require custom reporting.
-- **The audit trail must be immutable.** Events are never POST'd, PATCH'd, or DELETE'd via the API. Allowing mutations would undermine the regulatory function of the record. Federal quality control reviews and fair hearings depend on an unaltered history of who acted, when, and why. Comparable systems:
-
-  | Concept | JSM | ServiceNow | Camunda | WfMC |
-  |---|---|---|---|---|
-  | Transition audit | Issue history | Audit log | User Operation Log | Task Event History |
-  | Real-time stream | Webhooks | Event Management | Process event stream | — |
-  | Immutable log | Read-only history | Read-only audit | History service | — |
-
-- **The state machine YAML is the authoritative source for what events exist and what they carry.** `event` effects declare the action name and data payload. Implementations derive event schema from the contract — not from source code. In contrast, JSM and ServiceNow build audit records as a side effect of internal processing — the schema is implicit and not independently inspectable.
-
-**Customization points:**
-- States can add additional `event` effects to transitions via overlay (e.g., include the client's case number in the `completed` event payload for easier cross-referencing).
-- Cross-domain event consumers subscribe to specific `action` values — adding new actions is non-breaking.
+The state machine YAML is the authoritative source for what events exist and what they carry — `event` effects declare the action name and data payload. The audit trail is immutable — events are never modified or deleted via the API. See [Decision 18](#decision-18-events-in-a-shared-collection-across-domains) and [Decision 19](#decision-19-the-audit-trail-is-immutable).
 
 ---
 
 ## Metrics
 
-States and federal partners need operational visibility into queue health, processing time, and SLA compliance. All major systems bury metric definitions in proprietary GUI dashboards — non-portable and invisible to implementers. Metrics in the blueprint are contract artifacts defined in `workflow-metrics.yaml`, computed on demand from live task and event data.
+Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, alongside the state machine — not in a proprietary GUI. This makes measurement definitions explicit, versionable, and portable across state implementations. See [Decision 20](#decision-20-metrics-as-yaml-contract-artifacts).
 
-**Design decisions:**
+---
 
-- **Metrics are defined as YAML contract artifacts alongside the state machine, not in a proprietary GUI.** All major systems (JSM, ServiceNow, Salesforce) define metrics through a proprietary GUI — non-portable and not version-controlled. Defining them as contract artifacts makes measurement definitions explicit, versionable, and portable across state implementations. This is a deliberate departure from industry norms.
-- **Each metric is defined as a `collection` + `aggregate` + JSON Logic `filter` — not as hardcoded computation logic.** Adding a new metric is a data-definition problem, not a code problem. IBM Curam ties each metric to a fixed report type — adding a new metric often requires custom development. The decomposed model lets states define metrics declaratively. Baseline metrics:
+## Key design decisions
 
-  | Metric | Aggregate | Measures |
-  |---|---|---|
-  | `task_time_to_claim` | duration | Median time from task creation to first claim event |
-  | `tasks_in_queue` | count | Tasks currently in `pending` status |
-  | `release_rate` | ratio | Release events as a fraction of total task transitions |
-  | `sla_breach_rate` | ratio | Tasks with at least one breached SLA entry |
-  | `sla_warning_rate` | ratio | Auto-escalate-sla-warning events as a fraction of total transitions |
+| # | Decision | Summary |
+|---|---|---|
+| 1 | [Task state is explicit, not derived](#decision-1-task-state-is-explicit-not-derived) | State is a first-class field — not computed from timestamps or conditions. |
+| 2 | [`awaiting_client` and `awaiting_verification` as separate states](#decision-2-awaiting_client-and-awaiting_verification-as-separate-first-class-states) | Federal regulations treat client-caused and agency-caused delays differently — collapsing them loses that distinction. |
+| 3 | [`pending_review` as dedicated supervisor sign-off state](#decision-3-pending_review-as-a-dedicated-supervisor-sign-off-state) | QC regulations require structured supervisor approval before determination — distinct from escalation. |
+| 4 | [Named RPC transitions, not PATCH](#decision-4-named-rpc-transitions-not-patch) | Named triggers map cleanly to audit events, can carry request bodies, and can be independently guarded. |
+| 5 | [Effects declared in state machine YAML](#decision-5-effects-declared-in-state-machine-yaml) | The contract is the specification — implementations don't need to read source code to understand what a transition does. |
+| 6 | [`when` conditions use JSON Logic](#decision-6-when-conditions-use-json-logic) | One evaluator and one toolchain across guards, rules, metric filters, and conditional effects. |
+| 7 | [`calendarType` explicit per timer transition](#decision-7-calendartype-is-explicit-per-timer-transition) | Regulatory deadlines are calendar days; staffing SLAs are business hours — conflating them produces incorrect enforcement. |
+| 8 | [`cancel` is supervisor-only; no `notify` effect](#decision-8-cancel-is-supervisor-only-no-notify-effect) | Cancellation has federal reporting implications; notification is a consumer concern handled by event subscribers. |
+| 9 | [Automated verification uses a dedicated `system-resume` trigger](#decision-9-automated-verification-uses-a-dedicated-system-resume-trigger) | Keeps automated callbacks distinguishable from human actions in the audit trail — required for SNAP/Medicaid QC. |
+| 10 | [Guards on `taskType` enable multiple lifecycles per state machine](#decision-10-guards-on-tasktype-enable-multiple-lifecycles-per-state-machine) | One API surface and shared infrastructure serving multiple task types without separate state machines or endpoints. |
+| 11 | [`workflow-rules.yaml` is independently replaceable](#decision-11-workflow-rulesyaml-is-independently-replaceable) | Routing logic varies significantly across states — decoupling it from the state machine lets each change independently. |
+| 12 | [`first-match-wins` rule evaluation](#decision-12-first-match-wins-rule-evaluation) | Simple and predictable; multi-factor weighted scoring is a known gap. |
+| 13 | [`slaClock` required on every state](#decision-13-slaclock-required-on-every-state) | No default prevents silent regressions when new states are added. |
+| 14 | [`awaiting_*` states pause the SLA clock](#decision-14-awaiting-states-pause-the-sla-clock) | Federal SNAP regulations treat client-caused delays as excluded time — pausing preserves the original deadline rather than granting a fresh one. |
+| 15 | [SLA type definitions are independently replaceable](#decision-15-sla-type-definitions-are-independently-replaceable) | Deadline values vary by program mix — states replace the file without touching lifecycle logic. |
+| 16 | [Multiple SLA types can apply per task](#decision-16-multiple-sla-types-can-apply-per-task) | A SNAP task may become expedited after initial creation — both deadlines must apply simultaneously. |
+| 17 | [`pauseWhen`/`resumeWhen` per SLA type, not a hardcoded state list](#decision-17-pausewhenresumewhen-per-sla-type) | Different SLA types can pause on different conditions — a state might pause `snap_standard` but not `snap_expedited` during `awaiting_client`. |
+| 18 | [Events in a shared collection across domains](#decision-18-events-in-a-shared-collection-across-domains) | Cross-domain queries without joining separate stores — consistent with the cross-cutting audit domain approach. |
+| 19 | [The audit trail is immutable](#decision-19-the-audit-trail-is-immutable) | Federal QC reviews and fair hearings depend on an unaltered history — mutations undermine the regulatory function. |
+| 20 | [Metrics as YAML contract artifacts](#decision-20-metrics-as-yaml-contract-artifacts) | Metric definitions are explicit, versionable, and portable — unlike proprietary GUI dashboards. |
+| 21 | [Duration metrics via event pairs, not pre-computed fields](#decision-21-duration-metrics-via-event-pairs) | Declarative model lets metric authors define new measurements without schema changes. |
+| 22 | [Pre-aggregation is an adapter-layer concern](#decision-22-pre-aggregation-is-an-adapter-layer-concern) | On-demand computation is simpler and always current for the baseline; states add pre-aggregation in their adapters. |
 
-- **Metric filters use JSON Logic — the same evaluator used for guards and rules.** JSM uses JQL; ServiceNow uses condition scripts; Salesforce uses SOQL. A second filter language would mean two evaluators, two toolchains, and two learning curves. The trade-off is expressiveness: JSON Logic is less powerful than SQL. For the patterns needed here (filter by field value, check array membership), it is sufficient. Comparable systems:
+---
 
-  | Concept | JSM | ServiceNow | IBM Curam | Salesforce Gov Cloud | Pega | Appian |
+### Decision 1: Task state is explicit, not derived
+
+**Status:** Decided
+
+**What's being decided:** Whether task state is stored as an explicit field or computed from timestamps and other conditions.
+
+**Considerations:**
+- Deriving state from timestamps is fragile — if `completedAt` is set but then cleared, the state is ambiguous; if a timer fires but the update fails, the state is silently wrong
+- All major platforms model task state explicitly: JSM (`status`), ServiceNow (`state`), Pega (`pyStatusWork`), Appian (`status`), WS-HumanTask (explicit state enum)
+- Explicit state is unambiguous, directly queryable, and produces clean audit events on each transition
+
+**Decision:** Task state is a first-class, explicitly stored field. State changes only via named transitions.
+
+**Customization:** States can add status values via overlay.
+
+---
+
+### Decision 2: `awaiting_client` and `awaiting_verification` as separate first-class states
+
+**Status:** Decided
+
+**What's being decided:** Whether to model waiting conditions as a single `on_hold` state with sub-reasons, or as separate first-class states.
+
+**Considerations:**
+- Federal regulations treat client-caused delays and agency-caused delays differently for SLA accountability and regulatory reporting. Collapsing them into sub-reasons of one state requires parsing sub-reason data to determine SLA behavior — fragile and easy to get wrong.
+- How comparable systems handle this:
+
+  | Concept | Blueprint | JSM | ServiceNow | Curam | Salesforce Gov Cloud | WS-HumanTask |
   |---|---|---|---|---|---|---|
-  | Metric definitions | Custom gadgets + SLA reports | Performance Analytics indicators | MIS caseload reports | Reports + formula fields | Application Quality + manager dashboards; role-configurable | Process HQ KPIs (count, duration, custom expression) |
-  | Stored vs. computed | Pre-aggregated dashboards | Pre-aggregated by PA data collector | Pre-computed batch reports | Pre-aggregated by reports engine | Pre-aggregated dashboard views | Pre-computed from process execution data |
-  | Filter conditions | JQL (Jira Query Language) | Conditions (scripted or condition builder) | Fixed filter criteria on report type | SOQL filter criteria | Case type, operator, date range (GUI) | Activity, sequence, custom field conditions (GUI) |
-  | Event-pair duration | Pre-computed `resolutionDate - createdDate` field | Pre-computed duration field on task record | Pre-computed case duration field | Pre-computed formula field | Pre-computed start/end timestamps on case | Duration from process timeline |
-  | Performance targets | SLA goals on SLA agreements | PA thresholds with color-coding | Fixed targets in MIS | Report filter thresholds | Goal/Deadline tiers on SLA definition | SLA fulfillment/violation thresholds |
-  | Dimensional breakdown | Filter by project/team | Breakdown by group or category | Fixed groupings in report | Report group-by | Manager views by team/case type | Executive dashboard by process/activity |
+  | Waiting for client | `awaiting_client` | Waiting for Customer | On Hold / Awaiting Caller | Manual activity pending | Waiting on Someone Else | Suspended |
+  | Waiting for third-party | `awaiting_verification` | Pending | On Hold / Awaiting Evidence | Suspended process | Deferred | Suspended |
 
-- **Duration metrics are defined via `from`/`to` event pairs correlated by a `pairBy` field — not as pre-computed task fields.** Pre-computing duration as a task field requires deciding in advance which event pairs define "duration," locking in that decision at schema design time. The declarative model lets metric authors define new duration measurements without schema changes — any pair of events correlated by a shared field qualifies.
-- **Performance `targets` are declared in the metric definition itself — not configured separately in a UI.** JSM puts goals on SLA agreements; ServiceNow puts thresholds on PA indicators — both in separate configuration surfaces. Declaring `targets` in the metric definition makes performance expectations visible to implementers at contract review time.
-- **Dimensional breakdown is a query parameter (`groupBy`), not a property of the metric definition.** ServiceNow's PA breakdowns are baked into the indicator definition — modifying the definition to add a new view creates unnecessary coupling. `groupBy` as a query parameter allows any caller to slice any metric by any field without modifying the definition, consistent with how Grafana and Prometheus handle dimensions.
-- **Pre-aggregation is an adapter-layer performance optimization, not a contract concern.** ServiceNow and JSM pre-aggregate metrics on a schedule for performance. For the blueprint's use case (development mock, contract definition), on-demand computation from live data is simpler, always current, and avoids a separate aggregation pipeline. States building production implementations will add pre-aggregation in their adapters — the metric definitions remain the same; only the computation strategy changes.
+- Pega delays SLA clock start via an **Assignment Ready** field rather than pausing a running clock — a different approach with different federal reporting implications (delayed start vs. excluded interval).
+- ServiceNow collapses both into `on_hold` sub-reasons; first-class states enable distinct timer behavior and clearer federal reporting without sub-reason parsing.
 
-**Customization points:**
-- States can replace or extend `workflow-metrics.yaml` via overlay.
-- `targets` can be overridden to reflect state-specific performance goals.
-- New metrics can be added for state-specific programs or reporting requirements.
+**Decision:** `awaiting_client` and `awaiting_verification` are separate first-class states with distinct SLA clock behavior and distinct domain events.
+
+**Customization:** States can override `slaClock` per state via overlay (e.g., treating client non-response as stopped rather than paused).
+
+---
+
+### Decision 3: `pending_review` as a dedicated supervisor sign-off state
+
+**Status:** Decided
+
+**What's being decided:** Whether supervisor approval before determination is a first-class lifecycle state or an ad-hoc step outside the state machine.
+
+**Considerations:**
+- SNAP and Medicaid QC regulations require supervisor approval before a determination is finalized in many states. Without a first-class state, this approval is invisible to the state machine — no clean SLA accountability, no audit event, no queue visibility.
+- This is distinct from escalation: escalation is upward for help or urgency; `pending_review` is a structured approval gate before completion.
+- JSM and ServiceNow both support approval states within workflows; Pega models these as approval shapes in the case lifecycle.
+
+**Decision:** `pending_review` is a dedicated state. The caseworker submits via `submit-for-review`; the supervisor either `approve`s (→ `completed`) or `return-to-worker`s (→ `in_progress`). The SLA clock keeps running — supervisor review counts against the agency's deadline.
+
+**Customization:** States where regulation explicitly excludes review time from the deadline can override `slaClock: paused` on `pending_review` via overlay.
+
+---
+
+### Decision 4: Named RPC transitions, not PATCH
+
+**Status:** Decided
+
+**What's being decided:** Whether state changes are triggered by named action endpoints or by PATCH requests on the task resource.
+
+**Considerations:**
+- PATCH requires parsing the diff to determine what changed and whether it was authorized — the intent of the change is implicit. Named triggers make intent explicit.
+- Named triggers map cleanly to audit events, can carry an action-specific request body (e.g., a cancellation reason), and can be independently guarded.
+- How comparable systems handle transitions:
+
+  | | Blueprint | JSM | ServiceNow | Camunda | WS-HumanTask | Pega | Appian |
+  |---|---|---|---|---|---|---|---|
+  | Trigger | Named trigger → RPC endpoint | Status transition button | State flow trigger | Sequence flow / signal | Claim, start, complete, skip | Named flow action → RPC | Generic BPMN gateway |
+  | Precondition | Guards | Validator condition | Condition script | Gateway condition | Potential owner constraints | Decision rule / router | Conditional expression |
+  | Side effect | `set`, `create`, `evaluate-rules`, `event` | Post-function | Business Rule | Execution Listener | Task handler | Declare Expressions + activity | Smart Services |
+  | Conditional effect | `when` (JSON Logic) | — | Condition on Business Rule | Expression on Listener | — | Condition on activity | Conditional gateway |
+
+**Decision:** Each transition trigger becomes a named RPC endpoint (`POST /tasks/:id/claim`). PATCH is reserved for updating task fields (not state changes).
+
+**Customization:** States can add new named transitions via overlay.
+
+---
+
+### Decision 5: Effects declared in state machine YAML
+
+**Status:** Decided
+
+**What's being decided:** Whether transition side effects are declared in the state machine contract or implemented per-endpoint in code.
+
+**Considerations:**
+- Declaring effects in the contract makes the behavior inspectable and independently verifiable — a reviewer can understand what a transition does without reading source code.
+- JSM and ServiceNow build audit records as a side effect of internal processing — the schema is implicit and not independently inspectable.
+- Effect types: `set` (update fields), `evaluate-rules` (invoke rules engine), `event` (emit domain event), `create` (write a new record), `when` (conditional wrapper using JSON Logic).
+
+**Decision:** Effects are declared in the state machine YAML and executed by the engine. The contract is the specification.
+
+**Customization:** States can add effects to existing transitions via overlay.
+
+---
+
+### Decision 6: `when` conditions use JSON Logic
+
+**Status:** Decided
+
+**What's being decided:** The expression language for conditional effects on transitions.
+
+**Considerations:**
+- JSON Logic is already used for guard conditions, routing rules, SLA auto-assign conditions, and metric filters. Using it for `when` conditions too means one evaluator, one toolchain, and no additional learning curve for state implementers.
+- The alternative — a separate condition language — would introduce a second evaluator and second set of tooling for state customizers.
+
+**Decision:** `when` conditions use JSON Logic — the same evaluator used across the rest of the contract system.
+
+---
+
+### Decision 7: `calendarType` is explicit per timer transition
+
+**Status:** Decided
+
+**What's being decided:** Whether timer transitions use calendar days or business hours, and how that is expressed.
+
+**Considerations:**
+- Regulatory deadlines (SNAP 30-day, Medicaid 45-day) are calendar days. Staffing SLAs are typically business hours. Conflating the two produces incorrect enforcement and federal reporting errors.
+- How comparable systems handle this:
+
+  | Concept | JSM | ServiceNow | Curam |
+  |---|---|---|---|
+  | Calendar vs. business time | Configurable per SLA | Configurable per schedule | Configurable per deadline |
+  | Time-based transition | SLA timer → auto-transition on breach | Escalation rule with time condition | Deadline escalation on process |
+
+- Setting the wrong type silently miscalculates deadlines — making it explicit and required prevents silent errors.
+
+**Decision:** `calendarType` is an explicit, required field per timer transition: `calendar` for regulatory deadlines, `business` for staffing SLAs. All `after` durations in the baseline are illustrative placeholders — states must override them per program type and regulatory requirement.
+
+**Baseline timer transitions:**
+
+| Trigger | From | To | After | Relative to | Calendar type |
+|---|---|---|---|---|---|
+| `auto-escalate` | `pending` | `escalated` | 72h | `createdAt` | business |
+| `auto-escalate-sla-warning` | `in_progress` | `escalated` | -48h | `slaDeadline` | calendar |
+| `auto-escalate-sla-breach` | `pending`, `in_progress`, `escalated` | `escalated` | 0h | `slaDeadline` | calendar |
+| `auto-cancel-awaiting-client` | `awaiting_client` | `cancelled` | 30d | `blockedAt` | calendar |
+| `auto-resume-awaiting-verification` | `awaiting_verification` | `in_progress` | 7d | `blockedAt` | calendar |
+
+**Customization:** All durations are overlay points. `calendarType` can be overridden per transition. Timer transitions support an optional `guards` field for conditional suppression.
+
+---
+
+### Decision 8: `cancel` is supervisor-only; no `notify` effect
+
+**Status:** Decided
+
+**What's being decided:** Two related access control and integration decisions for `cancel`.
+
+**Considerations:**
+- Cancelling a benefits task has federal reporting and client appeal implications — caseworkers cannot cancel unilaterally. JSM, ServiceNow, and Curam all restrict cancellation to privileged roles.
+- A `notify` effect type would couple the workflow domain to specific notification delivery mechanisms. JSM, ServiceNow, and Curam all have built-in notification on escalation, which creates tight coupling to delivery channels. States that need push notifications should build notification services that subscribe to domain events — the decoupled model.
+
+**Decision:** `cancel` is restricted to supervisors. There is no `notify` effect type — notification is a consumer concern handled by subscribers to domain events.
+
+**Customization:** States that want a worker-initiated cancellation request with supervisor approval can model this via a custom `request-cancel` state.
+
+---
+
+### Decision 9: Automated verification uses a dedicated `system-resume` trigger
+
+**Status:** Decided
+
+**What's being decided:** Whether automated callbacks from verification services (IEVS, FDSH) use the same `resume` trigger as human caseworkers or a dedicated trigger.
+
+**Considerations:**
+- SNAP and Medicaid QC requirements distinguish automated callbacks from human caseworker actions in the audit trail. A separate trigger keeps domain events distinguishable and allows the request body to carry verification result data (source, result summary).
+- A relaxed guard on the shared `resume` trigger would allow system actors to use it, but the resulting domain event would be indistinguishable from a human resuming the task.
+
+**Decision:** Automated verification callbacks use a dedicated `system-resume` trigger, guarded by `callerIsSystem`. The resulting event is distinct from the human `task.resumed` event.
+
+---
+
+### Decision 10: Guards on `taskType` enable multiple lifecycles per state machine
+
+**Status:** Decided
+
+**What's being decided:** Whether task-type-specific states and transitions require separate state machine files and API resources, or can be expressed within a single state machine.
+
+**Considerations:**
+- Requiring a separate state machine and API resource per task type would fragment the API surface and duplicate shared infrastructure (queues, SLA tracking, domain events, assignment rules).
+- Pega (`caseTypeID`), Salesforce (`RecordTypeId`), and JSM (issue type) all scope available operations within a single object type's API — the blueprint follows the same pattern.
+- Task-type-specific transitions carry a named guard checking `$object.taskType`. Shared transitions (`cancel`, `assign`, `set-priority`) carry no task type guard and apply to all types.
+- Trade-off: the OpenAPI status enum includes states from all task types, so `taskType` is the authoritative constraint on which states are reachable — not the schema.
+
+**Decision:** Task-type-specific states and transitions are added to the baseline state machine and guarded on `$object.taskType`. One API surface; shared infrastructure; multiple lifecycles.
+
+**Customization:** States add task-type-specific transitions and guards via overlay, with `taskType` guards scoping them appropriately.
+
+---
+
+### Decision 11: `workflow-rules.yaml` is independently replaceable
+
+**Status:** Decided
+
+**What's being decided:** Whether routing and priority rules are embedded in the state machine or defined in a separate, independently replaceable file.
+
+**Considerations:**
+- Routing logic varies significantly across states — program mix, geography, workload balancing, and organizational structure all affect assignment rules. Entangling routing with lifecycle logic would make both harder to change.
+- How comparable systems decouple routing:
+
+  | | JSM | ServiceNow | Camunda | Pega | Appian |
+  |---|---|---|---|---|---|
+  | Routing rules | Automation rules | Assignment rules | Task listener | Push (system assigns) + Pull (Get Next Work) | Automated Case Routing module |
+  | Priority rules | Field automation | SLA-based priority | — | Urgency (1–100) | KPI-based |
+  | Rule order | First matching automation | Rule processing order | — | Decision tree precedence | Rule number precedence |
+
+- Pega supports both push (system assigns) and pull (worker requests next task) routing. The blueprint uses push routing only; pull routing is a known gap — see [Known gaps](#routing-and-assignment).
+
+**Decision:** `workflow-rules.yaml` is entirely replaceable per state. Rules are invoked via `evaluate-rules` effects in the state machine — neither system needs to understand the other's internals.
+
+**Customization:** States replace `workflow-rules.yaml` entirely. States can add `evaluate-rules` effects to additional transitions via overlay.
+
+---
+
+### Decision 12: `first-match-wins` rule evaluation
+
+**Status:** Decided
+
+**What's being decided:** The evaluation model for routing and priority rules.
+
+**Considerations:**
+- `first-match-wins` is simple, predictable, and easy to debug. Rules are evaluated in order; the first match wins.
+- Multi-factor weighted scoring — combining urgency, program type, task age, and other attributes into a numeric priority — is not expressible with `first-match-wins`. This is a known gap; see [Known gaps](#routing-and-assignment).
+- `escalate` uses `evaluate-rules: priority` rather than `set priority: high` — hardcoding a priority value would break states with different escalation behavior per program type.
+
+**Decision:** `first-match-wins`. Weighted scoring is a planned enhancement — see issue #200.
+
+---
+
+### Decision 13: `slaClock` required on every state
+
+**Status:** Decided
+
+**What's being decided:** Whether `slaClock` has a default value or must be explicitly declared on every state.
+
+**Considerations:**
+- If `slaClock` had a default, new states added via overlay could silently inherit the wrong clock behavior — running when they should pause, or stopping when they should run.
+- Requiring explicit declaration forces intentional choices and prevents silent regressions. The schema enforces this.
+
+**Decision:** `slaClock` is required on every state with no default. The valid values are `running`, `paused`, and `stopped`.
+
+---
+
+### Decision 14: `awaiting_*` states pause the SLA clock
+
+**Status:** Decided
+
+**What's being decided:** Whether waiting states use `slaClock: paused` or `slaClock: stopped`.
+
+**Considerations:**
+- Federal SNAP regulations treat client-caused delays as excluded time — not as time that resets the agency's clock. `paused` means the clock resumes from where it left off, preserving the original deadline. `stopped` would grant a fresh deadline on each block/resume cycle, distorting federal reporting.
+- How comparable systems handle SLA pausing:
+
+  | Concept | Blueprint | JSM | ServiceNow | Curam | Pega | Appian |
+  |---|---|---|---|---|---|---|
+  | Pause SLA | `slaClock: paused` on waiting states | "Pending" status excludes from SLA | On Hold sub-reasons pause SLA | Process-level SLA tracking | Assignment Ready delays clock start | No built-in pause; custom logic |
+  | Stop SLA | `slaClock: stopped` on terminal states | Resolved / Closed | Resolved / Closed | Process completed | Case resolution | Process completion |
+
+**Decision:** `awaiting_client` and `awaiting_verification` use `slaClock: paused`. The clock resumes from the same point when the task returns to `in_progress`.
+
+**Customization:** States that treat client non-response as the client's time to spend (stopping rather than pausing) can override `slaClock` via overlay.
+
+---
+
+### Decision 15: SLA type definitions are independently replaceable
+
+**Status:** Decided
+
+**What's being decided:** Whether SLA deadline values are embedded in the state machine or defined in a separate, independently replaceable file.
+
+**Considerations:**
+- States with different program mixes need different deadline values. Embedding deadlines in the state machine would couple two concerns that change independently.
+- JSM and ServiceNow store SLA definitions as separate database records, decoupled from workflow configuration. The blueprint follows the same separation with `*-sla-types.yaml`.
+
+**Decision:** SLA type definitions live in `*-sla-types.yaml`, separately from the state machine, and are independently replaceable per state.
+
+**Customization:** States replace or extend SLA types via overlay. `autoAssignWhen` logic can be adjusted to match state-specific program routing criteria.
+
+---
+
+### Decision 16: Multiple SLA types can apply per task
+
+**Status:** Decided
+
+**What's being decided:** Whether a task can have multiple active SLA deadlines simultaneously.
+
+**Considerations:**
+- A SNAP application initially filed as standard may later be determined to qualify for expedited processing. Both the 30-day standard and 7-day expedited deadlines then apply.
+- IBM Curam's single-deadline-per-process model is less flexible for multi-program cases.
+- JSM and ServiceNow both support multiple SLA records per work item.
+
+  | Concept | JSM | ServiceNow | IBM Curam | Salesforce Gov Cloud |
+  |---|---|---|---|---|
+  | Multiple SLAs per record | Yes | Yes | Typically one per process | Multiple milestones per case |
+  | Auto-attach conditions | Automation rule conditions | SLA Definition conditions | Configured at design time | Entitlement criteria |
+
+**Decision:** Each task carries one `slaInfo` entry per applicable SLA type. Multiple SLA types can apply simultaneously.
+
+---
+
+### Decision 17: `pauseWhen`/`resumeWhen` per SLA type
+
+**Status:** Decided
+
+**What's being decided:** Whether SLA clock pause/resume behavior is determined by a hardcoded state list or by per-SLA-type JSON Logic conditions.
+
+**Considerations:**
+- Different SLA types may need different pause behavior on the same state. A state might pause `snap_standard` but not `snap_expedited` during `awaiting_client` (the 7-day clock keeps running). Hardcoding pause behavior to a list of states cannot express this.
+- ServiceNow's on-hold conditions work the same way — conditions are expressed per SLA definition, not as a global state list.
+- Warning thresholds are expressed as a percentage of the total SLA duration (75%), not a fixed offset — 75% of 7 days and 75% of 90 days scale appropriately. ServiceNow uses the same percentage model.
+
+**Decision:** `pauseWhen` and `resumeWhen` are JSON Logic conditions defined per SLA type, evaluated on every transition.
+
+**Customization:** `pauseWhen` conditions can be tightened or loosened per regulatory interpretation via overlay.
+
+---
+
+### Decision 18: Events in a shared collection across domains
+
+**Status:** Decided
+
+**What's being decided:** Whether domain events are stored per-domain or in a shared collection.
+
+**Considerations:**
+- Siloed event stores per domain would require joining them for cross-domain queries — "all events for this person across case management and workflow" would require joining separate stores.
+- A shared collection enables cross-domain queries from one place, consistent with the cross-cutting audit domain approach (see intake [Decision 8](intake-design-reference.md#decision-8-application-data-mutability-and-audit-trail)).
+- JSM, ServiceNow, and Camunda each maintain separate audit logs per system — cross-system queries require custom reporting.
+
+**Decision:** Events are stored in a shared collection across all domains, identified by `domain`, `resource`, and `action`.
+
+**Customization:** States can add additional `event` effects to transitions via overlay.
+
+---
+
+### Decision 19: The audit trail is immutable
+
+**Status:** Decided
+
+**What's being decided:** Whether events can be modified or deleted after they are written.
+
+**Considerations:**
+- Federal QC reviews and fair hearings depend on an unaltered history of who acted, when, and why. Allowing mutations would undermine the regulatory function of the record.
+- All major platforms maintain read-only audit trails: JSM (issue history), ServiceNow (audit log), Camunda (history service).
+
+  | Concept | JSM | ServiceNow | Camunda | WfMC |
+  |---|---|---|---|---|
+  | Transition audit | Issue history | Audit log | User Operation Log | Task Event History |
+  | Immutable log | Read-only history | Read-only audit | History service | — |
+
+**Decision:** Events are never POST'd, PATCH'd, or DELETE'd via the API.
+
+---
+
+### Decision 20: Metrics as YAML contract artifacts
+
+**Status:** Decided
+
+**What's being decided:** Whether metric definitions are expressed as contract artifacts or configured in a proprietary GUI.
+
+**Considerations:**
+- All major systems define metrics through proprietary GUIs — non-portable and not version-controlled.
+
+  | | JSM | ServiceNow | IBM Curam | Salesforce Gov Cloud | Pega | Appian |
+  |---|---|---|---|---|---|---|
+  | Metric definitions | Custom gadgets + SLA reports | Performance Analytics indicators | MIS caseload reports | Reports + formula fields | Application Quality dashboards | Process HQ KPIs |
+  | Stored vs. computed | Pre-aggregated | Pre-aggregated by PA collector | Pre-computed batch | Pre-aggregated | Pre-aggregated views | Pre-computed |
+  | Filter conditions | JQL | Condition builder / script | Fixed filter on report type | SOQL | GUI-based | GUI-based |
+
+- Defining metrics as YAML artifacts makes measurement definitions explicit, versionable, and portable across state implementations. A deliberate departure from industry norms.
+- Each metric is defined as a `collection` + `aggregate` + JSON Logic `filter`. Adding a new metric is a data-definition problem, not a code problem.
+
+**Decision:** Metrics are YAML contract artifacts in `workflow-metrics.yaml`, alongside the state machine.
+
+**Customization:** States replace or extend `workflow-metrics.yaml` via overlay. `targets` can be overridden to reflect state-specific performance goals.
+
+---
+
+### Decision 21: Duration metrics via event pairs
+
+**Status:** Decided
+
+**What's being decided:** Whether duration metrics (e.g., time-to-claim) are pre-computed task fields or defined declaratively as event pair correlations.
+
+**Considerations:**
+- Pre-computing duration as a task field requires deciding in advance which event pairs define "duration," locking in that decision at schema design time. Adding a new duration measurement requires a schema change.
+- The declarative model — `from` event, `to` event, correlated by a `pairBy` field — lets metric authors define new measurements without schema changes. Any pair of events correlated by a shared field qualifies.
+
+**Decision:** Duration metrics are defined via `from`/`to` event pairs correlated by a `pairBy` field.
+
+---
+
+### Decision 22: Pre-aggregation is an adapter-layer concern
+
+**Status:** Decided
+
+**What's being decided:** Whether metrics are pre-aggregated on a schedule or computed on demand.
+
+**Considerations:**
+- ServiceNow and JSM pre-aggregate metrics on a schedule for performance. For the blueprint's use case (development mock, contract definition), on-demand computation is simpler and always current.
+- States building production implementations will add pre-aggregation in their adapters — the metric definitions remain the same; only the computation strategy changes.
+
+**Decision:** On-demand computation from live data for the baseline. Pre-aggregation is an adapter-layer performance optimization, not a contract concern.
 
 ---
 
 ## Known gaps and future considerations
 
-Standard capabilities found in major workflow systems (JSM, ServiceNow, IBM Curam, Salesforce Government Cloud, Pega, Appian), and the blueprint's current coverage. See [References](#references) for system descriptions.
+Standard capabilities found in major workflow systems (JSM, ServiceNow, IBM Cúram, Salesforce Government Cloud, Pega, Appian), and the blueprint's current coverage. See [References](#references) for system descriptions.
 
-Status values: **Planned** = on the roadmap with a tracking issue; **Partial** = some coverage exists; **Not in scope** = intentional design boundary (handled by another domain); **Adapter layer** = intentionally delegated to the state adapter; not a blueprint contract concern; **Gap** = not yet assessed.
+Status values: **Planned** = on the roadmap with a tracking issue; **Partial** = some coverage exists; **Not in scope** = intentional design boundary (handled by another domain); **Adapter layer** = intentionally delegated to the state adapter; **Gap** = not yet assessed.
 
 ### Workflow engine
 
@@ -394,17 +605,17 @@ Status values: **Planned** = on the roadmap with a tracking issue; **Partial** =
 | Overflow routing | When a queue exceeds capacity, tasks overflow to a backup queue (JSM, ServiceNow, Pega) | **Adapter layer** — high-volume routing logic is an adapter concern. |
 | Bulk reassignment | Supervisor reassigns multiple tasks at once (JSM, ServiceNow, Curam) | **Planned** — see issue #183. |
 | Weighted priority scoring | Multi-factor priority scoring combining urgency, program type, age, and other attributes into a numeric score (Pega Urgency 1–100, ServiceNow urgency × impact) | **Planned** — see issue #200. |
-| Delegation / identity acting-as | One user acting on behalf of another with a dual-identity audit trail distinguishing who acted from who they acted as (JSM, ServiceNow, Pega) | **Not in scope** — a cross-cutting platform concern resolved before the state machine sees the request. See issue #181. |
+| Delegation / identity acting-as | One user acting on behalf of another with a dual-identity audit trail (JSM, ServiceNow, Pega) | **Not in scope** — a cross-cutting platform concern resolved before the state machine sees the request. See issue #181. |
 
 ### SLA and deadline management
 
 | Capability | Industry standard | Blueprint status |
 |---|---|---|
 | SLA goal tier | Soft performance target separate from the hard deadline — Goal / Deadline / Passed Deadline (Pega three-tier) | **Planned** — see issue #189. |
-| Holiday calendar management | Agency-specific holiday calendars that exclude non-working days from SLA calculations (JSM, ServiceNow, Pega, Appian, Salesforce) | **Planned** — federal holiday exclusion is required for correct regulatory deadline calculation. See issue #190. |
-| SLA retroactive recalculation | When task attributes change after creation (e.g., `isExpedited` is set), SLA deadlines are recalculated accordingly (ServiceNow, Pega, Curam) | **Planned** — see issue #191. |
+| Holiday calendar management | Agency-specific holiday calendars excluding non-working days from SLA calculations (JSM, ServiceNow, Pega, Appian, Salesforce) | **Planned** — federal holiday exclusion is required for correct regulatory deadline calculation. See issue #190. |
+| SLA retroactive recalculation | When task attributes change after creation (e.g., `isExpedited` is set), SLA deadlines are recalculated (ServiceNow, Pega, Curam) | **Planned** — see issue #191. |
 | Deadline extensions | Formal process for extending a deadline with documented justification (ServiceNow, Curam, Pega) | **Planned** — see issue #192. |
-| Grace period handling | A defined window after the deadline before adverse action is taken — common in SNAP and Medicaid processing | **Planned** — see issue #197. |
+| Grace period handling | A defined window after the deadline before adverse action — common in SNAP and Medicaid processing | **Planned** — see issue #197. |
 
 ### Task structure and types
 
@@ -429,7 +640,7 @@ Status values: **Planned** = on the roadmap with a tracking issue; **Partial** =
 
 | Capability | Industry standard | Blueprint status |
 |---|---|---|
-| Event-triggered task creation | Tasks auto-created when domain events fire (e.g., `application.submitted` → review task) | **Planned** — event infrastructure is in place; the wiring that maps incoming events to task creation is not yet implemented. See issue #163. |
+| Event-triggered task creation | Tasks auto-created when domain events fire (e.g., application submitted → review task) | **Planned** — event infrastructure is in place; the wiring that maps incoming events to task creation is not yet implemented. See issue #163. |
 | Real-time event streaming / webhooks | Push notifications to external subscribers when events fire (JSM webhooks, ServiceNow Event Management, Pega, Appian) | **Not in scope** — a cross-cutting platform concern; real-time delivery should not be duplicated per domain. |
 | Event replay | Ability to replay past events for debugging or migrating to a new system (ServiceNow, Pega, Appian) | **Not in scope** — a cross-cutting platform operations concern. |
 | Notification on state change | Configurable push notifications on escalation, block, completion, etc. | **Not in scope** — handled by the [communications domain](../cross-cutting/communication.md), which subscribes to domain events. |
@@ -439,14 +650,14 @@ Status values: **Planned** = on the roadmap with a tracking issue; **Partial** =
 | Capability | Industry standard | Blueprint status |
 |---|---|---|
 | Operational reporting | Built-in reports on caseload, productivity, backlog, and team performance (JSM, ServiceNow, Pega, Appian, Curam) | **Not in scope** — a reporting-domain concern. Workflow metrics provide the raw data; report generation is out of scope. |
-| Staffing forecasting | Predictive models for upcoming workload and staffing needs based on historical trends and upcoming deadlines (Pega, ServiceNow, Curam) | **Not in scope** — a reporting-domain concern. |
+| Staffing forecasting | Predictive models for upcoming workload and staffing needs based on historical trends (Pega, ServiceNow, Curam) | **Not in scope** — a reporting-domain concern. |
 
 ### Compliance and government-specific
 
 | Capability | Industry standard | Blueprint status |
 |---|---|---|
 | Federal reporting exports | Structured exports for SNAP (FNS-388), Medicaid (T-MSIS), and other federal reporting requirements (Curam, Pega, ServiceNow) | **Not in scope** — a reporting-domain concern. |
-| Fair hearing / appeals tracking | Dedicated workflow for applicant appeals with hearing date scheduling, statutory deadlines (90-day rule), and outcome tracking (Curam, Pega, ServiceNow) | **Planned** — depends on issue #193 (task type as lifecycle discriminator). |
+| Fair hearing / appeals tracking | Dedicated workflow for applicant appeals with hearing date scheduling, statutory deadlines, and outcome tracking (Curam, Pega, ServiceNow) | **Planned** — depends on issue #193 (task type as lifecycle discriminator). |
 | Change of circumstance handling | When household composition, income, or program status changes mid-case, associated tasks are automatically created or updated (Curam, Pega) | **Not in scope** — handled via cross-domain event wiring (see issue #163). |
 | Overpayment / recoupment tracking | Tracking and recovering benefits paid in error, including repayment schedules and federal reporting (Curam, Pega) | **Not in scope** — a case management or financial domain concern. |
 
@@ -463,7 +674,7 @@ Status values: **Planned** = on the roadmap with a tracking issue; **Partial** =
 | [IBM Curam](https://www.ibm.com/products/curam-social-program-management) | Social program management platform purpose-built for benefits administration (SNAP, Medicaid, TANF). Used by several U.S. states and international governments. |
 | [Salesforce Government Cloud](https://www.salesforce.com/solutions/government/) | CRM and case management platform for public sector. FedRAMP authorized; used by several states for benefits case management and constituent services. |
 | [Pegasystems (Pega)](https://www.pega.com/) | BPM and case management platform. Named a Leader in the Gartner Magic Quadrant for BPM-Platform-Based Case Management Frameworks; significant government and healthcare presence. Key docs: [Case Life Cycle Design](https://academy.pega.com/topic/case-life-cycle-design/v2), [SLAs](https://academy.pega.com/topic/service-level-agreements/v6), [Assignment Routing](https://academy.pega.com/topic/assignment-routing/v1), [Get Next Work](https://academy.pega.com/topic/get-next-work-feature/v1). |
-| [Appian](https://appian.com/) | Low-code BPM and case management platform. Named a Leader in Gartner's LCAP and BPM Magic Quadrants; FedRAMP authorized with documented government credentials. Key docs: [Case Management Studio](https://docs.appian.com/suite/help/26.2/case-management-studio-overview.html), [Automated Case Routing](https://docs.appian.com/suite/help/24.4/cms-automated-case-routing-overview.html), [KPIs](https://docs.appian.com/suite/help/25.4/process-custom-kpis.html), [Record Events](https://docs.appian.com/suite/help/25.4/record-events.html). |
+| [Appian](https://appian.com/) | Low-code BPM and case management platform. Named a Leader in Gartner's LCAP and BPM Magic Quadrants; FedRAMP authorized. Key docs: [Case Management Studio](https://docs.appian.com/suite/help/26.2/case-management-studio-overview.html), [Automated Case Routing](https://docs.appian.com/suite/help/24.4/cms-automated-case-routing-overview.html), [KPIs](https://docs.appian.com/suite/help/25.4/process-custom-kpis.html), [Record Events](https://docs.appian.com/suite/help/25.4/record-events.html). |
 | [Camunda](https://camunda.com/) | Open-source BPMN-native workflow and process orchestration engine. Useful reference for BPMN-aligned state machine and human task patterns. |
 | [WfMC / WS-HumanTask](https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=bpel4people) | OASIS standard for human task management in service-oriented architectures. Predecessor to modern task API patterns; referenced for WS-HumanTask state model. |
 
@@ -481,11 +692,3 @@ Status values: **Planned** = on the roadmap with a tracking issue; **Partial** =
 |---|---|
 | [7 CFR Part 273](https://www.ecfr.gov/current/title-7/subtitle-B/chapter-II/subchapter-C/part-273) | SNAP program regulations — processing timelines, quality control requirements, and the basis for blueprint SLA deadlines (7-day expedited, 30-day standard). |
 | [42 CFR Part 435](https://www.ecfr.gov/current/title-42/chapter-IV/subchapter-C/part-435) | Medicaid eligibility regulations — 45-day processing requirement for most Medicaid; 90-day for disability-related determinations. |
-
-### Industry research
-
-| Source | Description |
-|---|---|
-| [Gartner Magic Quadrant for BPM-Platform-Based Case Management Frameworks](https://www.gartner.com/en/documents/3488121) | Vendor landscape for case management platforms. Leaders include Pega, Appian, IBM, and Microsoft. |
-| [Gartner Top Trends in Government: Case Management as a Service (2022)](https://www.gartner.com/en/doc/785084-top-trend-in-government-case-management-as-a-service) | Government-specific case management trends; introduces the CMaaS composable architecture model. |
-| [Gartner Magic Quadrant for Business Orchestration and Automation Technologies](https://www.flowable.com/gartner-market-guide) | Successor to the BPM MQ; covers workflow orchestration vendors including Appian, Pega, ServiceNow, and Flowable. |


### PR DESCRIPTION
## Summary
- Rewrites `docs/architecture/domains/workflow-industry-reference.md` as a design reference, following the same format as the intake design reference
- Restructures from a capability-by-capability vendor comparison into: overview, process steps, regulatory requirements, entity model, task lifecycle, SLA management, domain events, and 20 numbered design decisions
- Extracts 20 design decisions from inline bullets in the original document into proper decision sections with considerations, options, and decisions
- Removes cross-cutting decisions (JSON Logic expression language, shared event collection) — moved to #216 platform design reference
- Preserves Known Gaps and References sections unchanged

## Notes for reviewer
The original document was organized as a vendor comparison capability-by-capability, with design decisions embedded as bullets inside each capability section. The rewrite moves all vendor comparison content into decision sections where it belongs, leaving the process/entity/lifecycle sections free of rationale and vendor detail.

Validation steps are in the linked issue once one exists — this is a docs-only change; no contracts or mock server are affected.
