### PR TITLE
Fix expand strategy creating dangling $refs for cross-spec schemas

### DIFF
--- a/packages/contracts/src/overlay/relationship-resolver.js
+++ b/packages/contracts/src/overlay/relationship-resolver.js
@@ -69,6 +69,73 @@ function discoverRelationships(spec) {
 }
 
 // =============================================================================
+// Schema Dependency Helpers
+// =============================================================================
+
+/**
+ * Walk a schema object and collect all internal $ref targets of the form
+ * "#/components/schemas/X", returning the schema names (e.g., "User", "Address").
+ *
+ * @param {*} node - Any value (recursively walked)
+ * @returns {Set<string>} Schema names referenced
+ */
+function findSchemaRefs(node) {
+  const refs = new Set();
+  function walk(n) {
+    if (!n || typeof n !== 'object') return;
+    if (Array.isArray(n)) { for (const item of n) walk(item); return; }
+    for (const [key, value] of Object.entries(n)) {
+      if (key === '$ref' && typeof value === 'string' && value.startsWith('#/components/schemas/')) {
+        refs.add(value.slice('#/components/schemas/'.length));
+      } else {
+        walk(value);
+      }
+    }
+  }
+  walk(node);
+  return refs;
+}
+
+/**
+ * Copy a schema (and all its transitive $ref dependencies) from the schema index
+ * into a target spec's components/schemas. Skips schemas already present in the target.
+ * Uses the schema index to locate transitive deps that may live in different source specs.
+ *
+ * @param {string} schemaName - Schema to copy
+ * @param {object} sourceSpec - Spec where schemaName is defined
+ * @param {object} targetSpec - Spec to copy into
+ * @param {Map<string, { spec: object, specFile: string }>} schemaIndex - Cross-spec schema index
+ * @param {Set<string>} [visited] - Cycle guard (schema names already processed)
+ */
+function copySchemaWithDependencies(schemaName, sourceSpec, targetSpec, schemaIndex, visited = new Set()) {
+  if (visited.has(schemaName)) return;
+  visited.add(schemaName);
+
+  if (!targetSpec.components) targetSpec.components = {};
+  if (!targetSpec.components.schemas) targetSpec.components.schemas = {};
+
+  // Already in target spec — no need to copy, but still recurse for its deps
+  if (!targetSpec.components.schemas[schemaName]) {
+    const schema = sourceSpec.components?.schemas?.[schemaName];
+    if (!schema) return;
+    targetSpec.components.schemas[schemaName] = JSON.parse(JSON.stringify(schema));
+  }
+
+  // Walk the now-copied schema for transitive $ref dependencies
+  const deps = findSchemaRefs(targetSpec.components.schemas[schemaName]);
+  for (const depName of deps) {
+    if (visited.has(depName)) continue;
+    if (targetSpec.components.schemas[depName]) {
+      visited.add(depName);
+      continue;
+    }
+    const depSource = schemaIndex.get(depName);
+    if (!depSource) continue;
+    copySchemaWithDependencies(depName, depSource.spec, targetSpec, schemaIndex, visited);
+  }
+}
+
+// =============================================================================
 // Schema Index
 // =============================================================================
 
@@ -181,13 +248,17 @@ function applyLinksOnly(schema, fields) {
  * Renames the FK field (fooId → foo) and replaces it with the related object schema.
  * Resolution is build-time: the expanded object is always present, no query param needed.
  *
+ * For full-object expand (no fields list), copies the target schema and all its transitive
+ * $ref dependencies into the target spec's components/schemas so the local $ref resolves.
+ *
  * @param {string} schemaName - Name of the schema being transformed (for warnings)
  * @param {object} schema - The schema object (mutated in place)
  * @param {Array<{ propertyName: string, relationship: object }>} fields - Annotated FK fields
  * @param {Map} schemaIndex - Schema index for cross-spec resolution
  * @param {string[]} warnings - Warning accumulator
+ * @param {object} spec - The full target spec (needed to copy schemas for cross-spec refs)
  */
-function applyExpand(schemaName, schema, fields, schemaIndex, warnings) {
+function applyExpand(schemaName, schema, fields, schemaIndex, warnings, spec) {
   for (const { propertyName, relationship } of fields) {
     // Build the expanded schema
     let expandedSchema;
@@ -202,9 +273,10 @@ function applyExpand(schemaName, schema, fields, schemaIndex, warnings) {
         properties: subsetProperties
       };
     } else {
-      // Full $ref to target schema
+      // Full $ref to target schema — copy schema and all transitive deps into this spec
       const targetInfo = schemaIndex.get(relationship.resource);
       if (targetInfo) {
+        copySchemaWithDependencies(relationship.resource, targetInfo.spec, spec, schemaIndex);
         expandedSchema = { $ref: `#/components/schemas/${relationship.resource}` };
       } else {
         warnings.push(
@@ -465,7 +537,7 @@ function resolveRelationships(spec, globalStyle = 'links-only', schemaIndex = ne
     }
 
     if (expandFields.length > 0) {
-      applyExpand(schemaName, schema, expandFields, schemaIndex, warnings);
+      applyExpand(schemaName, schema, expandFields, schemaIndex, warnings, spec);
 
       for (const field of expandFields) {
         expandRenames.push({

--- a/packages/contracts/tests/unit/relationship-resolver.test.js
+++ b/packages/contracts/tests/unit/relationship-resolver.test.js
@@ -343,6 +343,99 @@ test('relationship-resolver tests', async (t) => {
     assert.strictEqual(props.assignedTo.$ref, '#/components/schemas/User');
   });
 
+  await t.test('resolveRelationships expand - copies cross-spec schema into target spec so $ref resolves', () => {
+    // Task is in workflow-spec, User is in users-spec — two separate specs
+    const usersSpec = {
+      components: {
+        schemas: {
+          User: { type: 'object', properties: { id: { type: 'string' }, name: { type: 'string' } } }
+        }
+      }
+    };
+    const workflowSpec = {
+      components: {
+        schemas: {
+          Task: {
+            type: 'object',
+            properties: {
+              assignedToId: {
+                type: 'string',
+                format: 'uuid',
+                'x-relationship': { resource: 'User', style: 'expand' }
+              }
+            }
+          }
+          // User is NOT in workflowSpec — it lives in usersSpec
+        }
+      }
+    };
+
+    const schemaIndex = buildSchemaIndex(new Map([
+      ['workflow-spec.yaml', workflowSpec],
+      ['users-spec.yaml', usersSpec]
+    ]));
+    const { result } = resolveRelationships(workflowSpec, 'links-only', schemaIndex);
+
+    // $ref is present on the expanded field
+    assert.strictEqual(result.components.schemas.Task.properties.assignedTo.$ref, '#/components/schemas/User');
+    // User schema was copied into the target spec — no dangling $ref
+    assert.ok(result.components.schemas.User, 'User schema should be copied into target spec');
+    assert.deepStrictEqual(result.components.schemas.User, usersSpec.components.schemas.User);
+  });
+
+  await t.test('resolveRelationships expand - transitively copies schemas referenced by the copied schema', () => {
+    // Task → User (users-spec), User.$ref → Address (address-spec)
+    const addressSpec = {
+      components: {
+        schemas: {
+          Address: { type: 'object', properties: { street: { type: 'string' }, city: { type: 'string' } } }
+        }
+      }
+    };
+    const usersSpec = {
+      components: {
+        schemas: {
+          User: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              address: { $ref: '#/components/schemas/Address' }
+            }
+          }
+          // Address is in addressSpec, not here
+        }
+      }
+    };
+    const workflowSpec = {
+      components: {
+        schemas: {
+          Task: {
+            type: 'object',
+            properties: {
+              assignedToId: {
+                type: 'string',
+                format: 'uuid',
+                'x-relationship': { resource: 'User', style: 'expand' }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const schemaIndex = buildSchemaIndex(new Map([
+      ['workflow-spec.yaml', workflowSpec],
+      ['users-spec.yaml', usersSpec],
+      ['address-spec.yaml', addressSpec]
+    ]));
+    const { result } = resolveRelationships(workflowSpec, 'links-only', schemaIndex);
+
+    // Both User and its transitive dep Address are copied into the target spec
+    assert.ok(result.components.schemas.User, 'User should be copied into target spec');
+    assert.ok(result.components.schemas.Address, 'Address (transitive dep) should be copied into target spec');
+    assert.deepStrictEqual(result.components.schemas.Address, addressSpec.components.schemas.Address);
+  });
+
   await t.test('resolveRelationships expand - updates required array when FK field was required', () => {
     const spec = {
       components: {

--- a/packages/mock-server/src/setup.js
+++ b/packages/mock-server/src/setup.js
@@ -118,7 +118,17 @@ export async function performSetup({ specsDir, seedDir, verbose = true, skipVali
       const msg = seedErrors
         .map(e => `  ${e.api}${e.key ? ` [${e.key}]` : ''}: ${e.message}`)
         .join('\n');
-      throw new Error(`Seed data validation failed:\n${msg}`);
+      const looksLikeExpandMismatch = seedErrors.some(e =>
+        e.message.includes("must have required property") ||
+        e.message.includes("must NOT have additional properties")
+      );
+      const hint = looksLikeExpandMismatch
+        ? '\n\nHint: If you are using an overlay with x-relationship.style: expand, ' +
+          'your seed data must use the post-expansion field names (e.g., "person" not "personId"). ' +
+          'Regenerate seed data from your resolved specs:\n' +
+          `  npm run mock:seed -- --spec=${specsDir} --out=<seed-dir>`
+        : '';
+      throw new Error(`Seed data validation failed:\n${msg}${hint}`);
     }
     if (verbose) {
       console.log('✓ Seed data valid');


### PR DESCRIPTION
Closes #222

## Summary

- `applyExpand` was injecting `$ref: '#/components/schemas/X'` into a target spec without ensuring `X` was defined locally, causing `Missing $ref pointer` errors at mock server startup
- Added `copySchemaWithDependencies`: copies the referenced schema into the target spec, then recursively follows all `$ref` chains in the copied schema, fetching transitive dependencies from the schema index (which may span multiple source specs), until the full dependency graph is resolved
- Covers both the immediate case (User defined in users-spec, referenced from workflow-spec) and transitive chains (User.$ref → Address in a third spec)

## Notes for reviewer

The subset/fields case (`relationship.fields` specified) was already correct — it inlines properties directly without `$ref`. Only the full-object expand path needed the fix.

Validation steps are in the issue.