### PR TITLE
Add cross-domain event wiring

### DIFF
--- a/docs/architecture/domains/workflow-design-reference.md
+++ b/docs/architecture/domains/workflow-design-reference.md
@@ -581,9 +581,71 @@ Metrics are defined as YAML contract artifacts in `workflow-metrics.yaml`, along
 
 **Static validation:** `validate-rules.js` runs at `npm run validate` and checks entity paths against discoverable API resources and `from` fields against the calling resource's schema. Runtime: bindings are required by default — any resolution failure (entity not found, `from` path resolves to no value) skips the rule set and is logged as an error. Bindings marked `optional: true` skip only the failing binding (warning logged) and allow the rule set to continue without it. This is stricter than industry defaults (JSM, Salesforce Flow, Appian, and Cúram all continue with null on resolution failure), but catches misconfigured rules explicitly rather than silently routing with missing data.
 
+**Event-triggered rule sets:** The same context enrichment model applies to event-triggered rule sets. The event envelope is `this` — `this.subject`, `this.type`, `this.source`, `this.data.*`. Context bindings resolve related entities from the envelope fields using `from: subject` (the standard CloudEvents subject field, typically the affected resource ID). There is no separate "event context" namespace; rules access the envelope as the primary record and resolve everything else through explicit bindings.
+
 **Known gap:** Runtime error handling — what surfaces to callers when rule evaluation is skipped, how to distinguish degraded evaluation from no-op evaluation — is a separate design concern. See [issue #220](https://github.com/codeforamerica/safety-net-blueprint/issues/220).
 
 **Customization:** States add or replace context bindings in their overlay of `workflow-rules.yaml` to expose additional subject entity fields to rule conditions.
+
+---
+
+### Decision 22: Event envelope as the base evaluation context for event-triggered rule sets
+
+**Status:** Decided
+
+**What's being decided:** When a domain event fires and an event-triggered rule set evaluates, what is the primary "resource" — the `this` alias and the source for context binding `from` paths?
+
+**Options:**
+- **(A) ✓ Event envelope as `this`** — `this.subject`, `this.type`, `this.source`, `this.data.*`, etc. Context bindings resolve related entities from envelope fields (e.g., `from: subject` looks up the subject entity). Rule authors start at the envelope and walk down to the entities they need.
+- **(B) Pre-fetched subject as `this`** — the event engine looks up the subject entity first and makes it `this`, so conditions read `this.programs` rather than `application.programs`. Removes one binding declaration; hides the resolution from the contract artifact.
+- **(C) Event data payload as `this`** — the `data` field of the CloudEvents envelope is the root context. Loses access to envelope metadata (type, source, time) in conditions.
+
+**Decision:** Event envelope as `this` (A). Starting at the envelope provides the most capability: rule authors can reference any envelope field (subject, type, time, source, data) without losing access to it. Options B and C each discard envelope information that conditions or future extensions might need. The envelope-first model also uses the same `this` alias and context binding mechanics as on-demand rule sets — no new concepts for rule authors to learn.
+
+**Industry comparison:** JSM Automation uses the triggering issue as the base context (analogous to B — subject first). ServiceNow Event Management rules pass the event record as the base context (analogous to A — envelope first). Salesforce Flow event-triggered flows use the platform event record as the entry record (A). Pega event strategies use the event message payload directly (C). The blueprint follows the ServiceNow/Salesforce pattern — envelope first — because it provides a richer starting context and aligns with the CloudEvents envelope as the canonical event representation used everywhere else in the architecture.
+
+**Customization:** States writing custom event-triggered rule sets use `this.subject` to reference the triggering resource ID and declare context bindings to resolve the full entity. The envelope-first model gives states access to `this.type` and `this.source` for multi-source subscriptions without additional binding declarations.
+
+---
+
+### Decision 23: Reactive cross-domain coordination via event subscriptions
+
+**Status:** Decided
+
+**What's being decided:** When a workflow event (e.g., `task.claimed`) should trigger a status change in another domain (e.g., intake application moves to `under_review`), where does the coordination logic live and who calls whom?
+
+**Options:**
+- **(A) Imperative push — workflow triggers intake:** The workflow domain's rule set or state machine effect directly calls the intake state machine transition when a task is claimed. Workflow is the active party; intake is passive.
+- **(B) ✓ Reactive subscription — intake subscribes to workflow events:** The intake domain declares a rule set with `on: workflow.task.claimed`. When the event fires, intake evaluates its own rules and decides whether to transition the application. Workflow has no knowledge of downstream reactions.
+
+**Decision:** Reactive subscription (B). This keeps cross-domain coupling out of the publishing domain's contracts. States that want to suppress or modify the `task.claimed → application.open` behavior override `intake-rules.yaml`, not workflow contracts — a cleaner overlay target. The workflow domain emits events; what reacts is each domain's own concern.
+
+**Industry comparison:** ServiceNow Business Rules on separate tables (each table handles its own reaction to events from other tables). Salesforce Platform Events — subscribers handle their own reactions via separate flows. Pega case types subscribe to each other's events via Event Strategies rather than direct case-to-case calls. Appian Process Models can subscribe to process events from other processes. IBM Cúram Workflow uses event-driven handoffs between case types via the case lifecycle manager. The reactive pattern is the majority approach across major platforms; imperative cross-domain calls exist (Pega `StartCasing` activity) but are generally considered tighter coupling and harder to customize per state.
+
+**`triggerTransition` as a platform action:** The intake subscription uses `triggerTransition` to invoke the `open` transition on the application. This action calls the existing state machine transition engine with a `system` identity — no new transition capability, just a routing layer that reaches the already-built machinery. The contract declares which transition to call; the engine validates guards and applies effects as it would for any HTTP-triggered transition.
+
+**Customization:** States override `intake-rules.yaml` to change the conditions under which a task claim moves an application to review, or to suppress it entirely. The workflow domain requires no change.
+
+---
+
+### Decision 24: Generic platform action types with named schemas in rules-schema.yaml
+
+**Status:** Decided
+
+**What's being decided:** How action types that are useful across multiple domains (create a resource, trigger a transition) are defined and validated so any domain's rules can use them without duplicating schema definitions.
+
+**Options:**
+- **(A) Domain-specific action names** — each domain defines its own action keywords (`createTask`, `openApplication`). Simple to implement; every domain reimplements the same concepts with different names; no cross-domain reuse.
+- **(B) ✓ Generic platform actions with named schemas** — `createResource` and `triggerTransition` are defined once in `rules-schema.yaml` as named `$defs`. Any domain's rules YAML uses these keywords and gets schema validation automatically. Domain-specific actions (e.g., `assignToQueue`, `setPriority`) are also defined in the same schema as the single source of truth for all action types.
+- **(C) Action type registry in a separate catalog file** — a standalone `action-catalog.yaml` documents and validates action types separately from the rules schema. Cleaner separation; adds a second file for rule authors to consult.
+
+**Decision:** Generic platform actions with named schemas in `rules-schema.yaml` (B). The rules schema is already consulted for every rules YAML file; adding action type `$defs` there makes the schema both a validator and the complete documentation for what actions are available. States writing custom rules see exactly what fields each action expects from the schema alone.
+
+**Industry comparison:** ServiceNow has a built-in action library for Business Rule scripts — generic actions (Set field, Create record, Run script) reusable across any table. JSM Automation has ~30 generic action types (Edit issue, Create sub-task, Transition issue) available to all projects. Salesforce Flow Standard Actions are global across all object types. Pega Data Transforms and Activities are reusable across case types. All major platforms maintain a shared action vocabulary; domain-specific behavior is a specialization of generic primitives, not a parallel vocabulary.
+
+**`on:` as discriminator (no separate `kind` field):** The presence of the `on:` field distinguishes event-triggered rule sets from on-demand sets. No separate `kind:` field is needed — `on:` being present IS the trigger declaration, following the principle that a single field should carry one meaning. JSON Schema `if/then` can enforce constraints specific to each mode.
+
+**Customization:** States add custom action types by using `additionalProperties: true` on the `action` field — the schema validates known types strictly but does not reject unknown ones. States implement custom action handlers in their adapter layer and register them alongside the platform registry.
 
 ---
 

--- a/docs/contract-tables/intake/overview.md
+++ b/docs/contract-tables/intake/overview.md
@@ -82,3 +82,17 @@ Data sent when calling a trigger endpoint. Required fields must always be includ
 | `withdraw` | `reason` *(string)* | — |
 | `close` | — | — |
 | `flag-expedited` | — | — |
+
+---
+
+## Rules
+
+Rules are evaluated automatically at key lifecycle moments (on create, on update, and after certain transitions). They determine how tasks are routed and prioritized.
+
+### Status transition
+
+Evaluation strategy: **first-match-wins**
+
+| # | Condition | Action | Fallback |
+|---|-----------|--------|----------|
+| 1 | application.id != null and task.taskType = "application_review" and application.status = "submitted" | triggerTransition: {"entity":"intake/applications","idFrom":"application.id","transition":"open"} | — |

--- a/docs/contract-tables/intake/rules-status-transition.csv
+++ b/docs/contract-tables/intake/rules-status-transition.csv
@@ -1,0 +1,3 @@
+Order,Condition,Action,Fallback,Description
+1,"{""and"":[{""!="":[{""var"":""application.id""},null]},{""=="":[{""var"":""task.taskType""},""application_review""]},{""=="":[{""var"":""application.status""},""submitted""]}]}","{""triggerTransition"":{""entity"":""intake/applications"",""idFrom"":""application.id"",""transition"":""open""}}",,"When a caseworker claims an application_review task, transition the linked application from submitted to under_review. Guards on the intake open transition enforce that only system-role callers can execute this.
+"

--- a/docs/contract-tables/workflow/rules-assignment.csv
+++ b/docs/contract-tables/workflow/rules-assignment.csv
@@ -1,3 +1,3 @@
 Order,Condition,Action,Fallback,Description
-1,"{""in"":[""snap"",{""var"":""application.programs""}]}","{""assignToQueue"":""snap-intake""}","{""assignToQueue"":""general-intake""}",Route tasks linked to a SNAP application to the SNAP intake queue.
+1,"{""and"":[{""=="":[{""var"":""application.programs.length""},1]},{""in"":[""snap"",{""var"":""application.programs""}]}]}","{""assignToQueue"":""snap-intake""}","{""assignToQueue"":""general-intake""}",Route tasks linked to a SNAP-only application to the SNAP intake queue. Multi-program applications fall through to general intake.
 2,true,"{""assignToQueue"":""general-intake""}",,Route all other tasks to the general intake queue.

--- a/docs/contract-tables/workflow/rules-task-creation.csv
+++ b/docs/contract-tables/workflow/rules-task-creation.csv
@@ -1,0 +1,2 @@
+Order,Condition,Action,Fallback,Description
+1,true,"{""createResource"":{""entity"":""workflow/tasks"",""fields"":{""taskType"":""application_review"",""name"":""Application review"",""status"":""pending"",""subjectType"":""application"",""subjectId"":{""var"":""this.subject""}}}}",,Create an intake review task when an application is submitted.

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -1,0 +1,40 @@
+$schema: ./schemas/rules-schema.yaml
+version: "1.0"
+domain: intake
+resource: intake/applications
+ruleSets:
+  - id: task-claimed-open-application
+    ruleType: status-transition
+    on: workflow.task.claimed
+    evaluation: first-match-wins
+    context:
+      - as: task
+        entity: workflow/tasks
+        from: subject
+      - as: application
+        entity: intake/applications
+        from: task.subjectId
+        optional: true
+    rules:
+      - id: open-application-on-intake-task-claim
+        order: 1
+        condition:
+          and:
+            - "!=":
+                - var: application.id
+                - null
+            - "==":
+                - var: task.taskType
+                - application_review
+            - "==":
+                - var: application.status
+                - submitted
+        action:
+          triggerTransition:
+            entity: intake/applications
+            idFrom: application.id
+            transition: open
+        description: >
+          When a caseworker claims an application_review task, transition the linked
+          application from submitted to under_review. Guards on the intake open
+          transition enforce that only system-role callers can execute this.

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -5,7 +5,7 @@ resource: intake/applications
 ruleSets:
   - id: task-claimed-open-application
     ruleType: status-transition
-    on: workflow.task.claimed
+    "on": workflow.task.claimed
     evaluation: first-match-wins
     context:
       - as: task
@@ -34,7 +34,5 @@ ruleSets:
             entity: intake/applications
             idFrom: application.id
             transition: open
-        description: >
-          When a caseworker claims an application_review task, transition the linked
-          application from submitted to under_review. Guards on the intake open
-          transition enforce that only system-role callers can execute this.
+        description: |
+          When a caseworker claims an application_review task, transition the linked application from submitted to under_review. Guards on the intake open transition enforce that only system-role callers can execute this.

--- a/packages/contracts/schemas/rules-schema.yaml
+++ b/packages/contracts/schemas/rules-schema.yaml
@@ -38,12 +38,69 @@ properties:
     minItems: 1
 
 $defs:
+  # ---------------------------------------------------------------------------
+  # Action types — platform-level primitives available to all domains.
+  # Domain-specific actions (assignToQueue, setPriority) are also defined here
+  # so the schema is the single source of truth for what each action expects.
+  # ---------------------------------------------------------------------------
+
+  ActionCreateResource:
+    type: object
+    description: >
+      Creates a new resource in the specified domain/collection. Generic platform
+      action — any domain's rules can use this to create any resource type.
+      Field values may be literals or JSON Logic expressions evaluated against
+      the current rule context (e.g., { var: "this.subject" } to reference the
+      event subject).
+    required: [entity, fields]
+    properties:
+      entity:
+        type: string
+        pattern: "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$"
+        description: Target entity in domain/resource format (e.g., workflow/tasks).
+      fields:
+        type: object
+        description: >
+          Field name/value pairs for the new resource. Values may be literals
+          or JSON Logic expressions resolved against the current rule context.
+        minProperties: 1
+        additionalProperties: true
+    additionalProperties: false
+
+  ActionTriggerTransition:
+    type: object
+    description: >
+      Triggers a state machine transition on a related entity. Generic platform
+      action — any domain's rules can invoke a transition on any entity type.
+      The entity ID is resolved from the current rule context using idFrom.
+    required: [entity, idFrom, transition]
+    properties:
+      entity:
+        type: string
+        pattern: "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$"
+        description: Target entity in domain/resource format (e.g., intake/applications).
+      idFrom:
+        type: string
+        description: >
+          Dot-path in the rule context whose value is the ID of the entity to
+          transition. Examples: "application.id", "this.subjectId".
+      transition:
+        type: string
+        description: The transition trigger to invoke (e.g., "open", "submit").
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # Context, rule sets, and rules
+  # ---------------------------------------------------------------------------
+
   ContextBinding:
     type: object
     description: >
       Declares a related entity to resolve before rule evaluation. The entity is fetched
       by ID from the declared source and made available in rule conditions under the given alias.
       The calling resource is always available as "this" — no binding needed.
+      For event-triggered rule sets, "this" is the event envelope; from-paths resolve
+      against envelope fields (subject, type, source, data, time).
     required: [as, entity, from]
     properties:
       as:
@@ -59,9 +116,11 @@ $defs:
       from:
         type: string
         description: >
-          Dot-path on the calling resource (or a previously resolved entity) whose value
-          is the ID to look up. Examples: "subjectId", "application.caseId".
-          Validated against the resource schema by validate-rules.js.
+          Dot-path on "this" (or a previously resolved entity) whose value is the ID
+          to look up. For event-triggered rule sets, resolves against the event envelope
+          (e.g., "subject" resolves to the event's subject field).
+          For on-demand rule sets, resolves against the calling resource schema.
+          Validated against the resource schema by validate-rules.js for on-demand sets.
       optional:
         type: boolean
         description: >
@@ -73,7 +132,11 @@ $defs:
 
   RuleSet:
     type: object
-    description: A group of rules with a shared type and evaluation strategy.
+    description: >
+      A group of rules with a shared type and evaluation strategy. When `on` is present,
+      the rule set is event-triggered — evaluated when a matching domain event fires.
+      When `on` is absent, the rule set is on-demand — evaluated when the calling resource
+      is created or transitions state.
     required:
       - id
       - ruleType
@@ -85,7 +148,15 @@ $defs:
         description: Unique identifier for overlay targeting.
       ruleType:
         type: string
-        description: Rule category (e.g., assignment, priority, escalation, alert).
+        description: Rule category (e.g., assignment, priority, escalation, task-creation).
+      on:
+        type: string
+        description: >
+          CloudEvents type to subscribe to. Presence of this field makes the rule set
+          event-triggered. The event envelope is available as "this" in conditions and
+          context binding from-paths (fields: subject, type, source, data, time, id).
+          Accepts the full type (org.codeforamerica.safety-net-blueprint.intake.application.submitted)
+          or a short suffix form (intake.application.submitted).
       evaluation:
         type: string
         enum:
@@ -96,7 +167,7 @@ $defs:
         description: >
           Related entities to resolve before evaluating this rule set.
           Each binding resolves one entity by ID and makes it available under its alias.
-          The calling resource is always available as "this" without declaration.
+          The calling resource (or event envelope) is always available as "this" without declaration.
         items:
           $ref: "#/$defs/ContextBinding"
       rules:
@@ -125,17 +196,42 @@ $defs:
       condition:
         description: >
           JSON Logic expression evaluated against context variables.
-          Reference the calling resource as "this.fieldName".
+          Reference the calling resource (or event envelope) as "this.fieldName".
           Reference resolved entities as "alias.fieldName" (e.g., "application.programs").
           Use `true` for catch-all/default rules.
       action:
         type: object
-        description: Type-specific action map (e.g., assignToQueue, setPriority).
+        description: >
+          One or more actions to execute when this rule matches. Each key is an action
+          type; the value is the action payload. Known platform action types are validated
+          by schema; unknown keys are allowed for state-defined custom actions.
         minProperties: 1
+        properties:
+          assignToQueue:
+            type: string
+            description: Name of the queue to assign the resource to.
+          setPriority:
+            type: string
+            enum: [expedited, high, normal, low]
+            description: Priority value to set on the resource.
+          createResource:
+            $ref: "#/$defs/ActionCreateResource"
+          triggerTransition:
+            $ref: "#/$defs/ActionTriggerTransition"
         additionalProperties: true
       fallbackAction:
         type: object
         description: Action to take if the primary action fails (e.g., queue not found).
+        properties:
+          assignToQueue:
+            type: string
+          setPriority:
+            type: string
+            enum: [expedited, high, normal, low]
+          createResource:
+            $ref: "#/$defs/ActionCreateResource"
+          triggerTransition:
+            $ref: "#/$defs/ActionTriggerTransition"
         additionalProperties: true
       description:
         type: string

--- a/packages/contracts/workflow-openapi.yaml
+++ b/packages/contracts/workflow-openapi.yaml
@@ -640,6 +640,13 @@ components:
           type: string
           x-enum-source: states[].id
           description: Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml.
+        taskType:
+          type: string
+          description: >
+            The type of work this task represents (e.g., application_review, interview,
+            document_review). Used by state machine guards to enable type-specific
+            lifecycle branches and by routing rules for type-aware assignment.
+            Open string — states extend via overlay without schema changes.
         subjectType:
           type: string
           enum:

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -5,7 +5,7 @@ resource: workflow/tasks
 ruleSets:
   - id: application-submitted-intake-task
     ruleType: task-creation
-    on: intake.application.submitted
+    "on": intake.application.submitted
     evaluation: first-match-wins
     context:
       - as: application
@@ -24,9 +24,8 @@ ruleSets:
               status: pending
               subjectType: application
               subjectId:
-                var: "this.subject"
+                var: this.subject
         description: Create an intake review task when an application is submitted.
-
   - id: workflow-assignment
     ruleType: assignment
     evaluation: first-match-wins

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -3,6 +3,30 @@ version: "1.0"
 domain: workflow
 resource: workflow/tasks
 ruleSets:
+  - id: application-submitted-intake-task
+    ruleType: task-creation
+    on: intake.application.submitted
+    evaluation: first-match-wins
+    context:
+      - as: application
+        entity: intake/applications
+        from: subject
+    rules:
+      - id: create-intake-review-task
+        order: 1
+        condition: true
+        action:
+          createResource:
+            entity: workflow/tasks
+            fields:
+              taskType: application_review
+              name: Application review
+              status: pending
+              subjectType: application
+              subjectId:
+                var: "this.subject"
+        description: Create an intake review task when an application is submitted.
+
   - id: workflow-assignment
     ruleType: assignment
     evaluation: first-match-wins

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -36,17 +36,21 @@ ruleSets:
         from: subjectId
         optional: true
     rules:
-      - id: snap-to-snap-queue
+      - id: snap-only-to-snap-queue
         order: 1
         condition:
-          in:
-            - snap
-            - var: application.programs
+          and:
+            - "==":
+                - var: application.programs.length
+                - 1
+            - in:
+                - snap
+                - var: application.programs
         action:
           assignToQueue: snap-intake
         fallbackAction:
           assignToQueue: general-intake
-        description: Route tasks linked to a SNAP application to the SNAP intake queue.
+        description: Route tasks linked to a SNAP-only application to the SNAP intake queue. Multi-program applications fall through to general intake.
       - id: default-to-general-queue
         order: 2
         condition: true

--- a/packages/mock-server/scripts/server.js
+++ b/packages/mock-server/scripts/server.js
@@ -13,6 +13,7 @@ import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { performSetup } from '../src/setup.js';
 import { registerAllRoutes, registerStateMachineRoutes } from '../src/route-generator.js';
+import { registerEventSubscriptions } from '../src/event-subscription.js';
 import { closeAll } from '../src/database-manager.js';
 import { validateJSON } from '../src/validator.js';
 import { createSseHandler } from '../src/handlers/sse-handler.js';
@@ -141,6 +142,9 @@ async function startMockServer(specDirs = null, seedDir = null) {
     // Register SSE stream endpoint before item routes to avoid :id capture
     app.get('/platform/events/stream', createSseHandler());
     console.log('  GET    /platform/events/stream - Domain event stream (SSE)');
+
+    // Register event subscriptions (event-triggered rule sets)
+    registerEventSubscriptions(allRules, allStateMachines, allSlaTypes);
 
     // Register API routes dynamically
     const baseUrl = `http://${HOST}:${PORT}`;

--- a/packages/mock-server/seed/intake.yaml
+++ b/packages/mock-server/seed/intake.yaml
@@ -3,7 +3,6 @@ ApplicationExample1:
   status: submitted
   programs:
     - snap
-    - medicaid
   channel: online
   isExpedited: false
   submittedAt: "2026-04-01T09:15:00Z"

--- a/packages/mock-server/src/action-handlers.js
+++ b/packages/mock-server/src/action-handlers.js
@@ -1,55 +1,27 @@
 /**
- * Action handlers — registry of functions that execute rule actions.
- * Each handler mutates the resource based on the action value.
+ * Action handlers — merged registry of all platform and domain-specific actions.
+ *
+ * Platform actions (createResource, triggerTransition) are generic and available
+ * to all domain rule sets. Domain-specific actions (assignToQueue, setPriority)
+ * are co-located here since all domains share the same rule evaluation pipeline.
+ *
+ * To add domain-specific actions: create a <domain>-action-handlers.js file,
+ * export a Map, and merge it into actionRegistry below.
  */
 
-/**
- * Assign a task to a queue by looking up the queue by name.
- * @param {string} queueName - Name of the queue to assign to
- * @param {Object} resource - Resource to mutate
- * @param {Object} deps - Dependencies (findByField function)
- * @param {Object|null} fallbackAction - Fallback action if queue not found
- */
-function assignToQueue(queueName, resource, deps, fallbackAction) {
-  const queue = deps.findByField('queues', 'name', queueName);
-  if (queue) {
-    resource.queueId = queue.id;
-  } else if (fallbackAction?.assignToQueue) {
-    // Try fallback queue
-    const fallbackQueue = deps.findByField('queues', 'name', fallbackAction.assignToQueue);
-    if (fallbackQueue) {
-      resource.queueId = fallbackQueue.id;
-    } else {
-      console.warn(`Queue "${queueName}" and fallback "${fallbackAction.assignToQueue}" not found`);
-    }
-  } else {
-    console.warn(`Queue "${queueName}" not found, no fallback configured`);
-  }
-}
+import { platformActionRegistry } from './platform-action-handlers.js';
+import { workflowActionRegistry } from './workflow-action-handlers.js';
 
-/**
- * Set the priority of a resource.
- * @param {string} priority - Priority value to set
- * @param {Object} resource - Resource to mutate
- */
-function setPriority(priority, resource) {
-  resource.priority = priority;
-}
-
-/**
- * Registry of action type → handler function.
- * Each handler signature: (actionValue, resource, deps, fallbackAction)
- */
 const actionRegistry = new Map([
-  ['assignToQueue', assignToQueue],
-  ['setPriority', setPriority]
+  ...platformActionRegistry,
+  ...workflowActionRegistry
 ]);
 
 /**
  * Execute all actions in an action object against a resource.
  * @param {Object} action - Action object (e.g., { assignToQueue: "snap-intake", setPriority: "high" })
  * @param {Object} resource - Resource to mutate
- * @param {Object} deps - Dependencies for handlers that need lookups
+ * @param {Object} deps - Dependencies for handlers that need lookups or creation
  * @param {Object|null} fallbackAction - Fallback action if primary fails
  */
 export function executeActions(action, resource, deps, fallbackAction = null) {

--- a/packages/mock-server/src/event-subscription.js
+++ b/packages/mock-server/src/event-subscription.js
@@ -1,0 +1,150 @@
+/**
+ * Event subscription engine — evaluates event-triggered rule sets.
+ *
+ * Subscribes to the event bus and, when a domain event fires, finds all rule sets
+ * whose `on:` field matches the event type. For each matching rule set, resolves
+ * context bindings using the event envelope as "this", evaluates rule conditions,
+ * and executes actions (createResource, triggerTransition, etc.).
+ *
+ * The event envelope is the evaluation "resource" — this.subject, this.type,
+ * this.source, this.data, etc. Context bindings resolve related entities from
+ * the envelope fields (e.g., from: subject looks up the subject entity by ID).
+ */
+
+import { eventBus } from './event-bus.js';
+import { create, update, findAll } from './database-manager.js';
+import { buildRuleContext, evaluateRuleSet, resolvePath } from './rules-engine.js';
+import { resolveContextEntities } from './handlers/rule-evaluation.js';
+import { executeActions } from './action-handlers.js';
+import { executeTransition } from './state-machine-runner.js';
+import { applyEffects } from './state-machine-engine.js';
+import { processRuleEvaluations } from './handlers/rule-evaluation.js';
+import { emitEvent } from './emit-event.js';
+
+const FULL_TYPE_PREFIX = 'org.codeforamerica.safety-net-blueprint.';
+
+/**
+ * Test whether a CloudEvents type matches the `on:` field value.
+ * Accepts the full type or a short suffix (last three dot-segments).
+ * Examples:
+ *   on: "org.codeforamerica.safety-net-blueprint.intake.application.submitted" → matches exactly
+ *   on: "intake.application.submitted" → matches by suffix
+ */
+function eventTypeMatches(eventType, onValue) {
+  if (!onValue || !eventType) return false;
+  if (eventType === onValue) return true;
+  // Short form: accept if the event type ends with the declared suffix
+  return eventType === FULL_TYPE_PREFIX + onValue;
+}
+
+/**
+ * Find the state machine for a domain/collection entity reference.
+ * @param {string} entity - "domain/collection" format (e.g., "workflow/tasks")
+ * @param {Array} allStateMachines - from discoverStateMachines()
+ * @returns {Object|null} The state machine contract, or null
+ */
+function findStateMachineForEntity(entity, allStateMachines) {
+  const [domainName, collectionName] = entity.split('/');
+  const match = allStateMachines.find(sm =>
+    sm.domain === domainName &&
+    sm.object.toLowerCase() + 's' === collectionName
+  );
+  return match?.stateMachine || null;
+}
+
+/**
+ * Build rich deps for platform actions (createResource, triggerTransition).
+ * These actions need access to the full server context: DB, state machines, rules.
+ */
+function buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes) {
+  return {
+    // For assignToQueue / setPriority (existing on-demand deps)
+    findByField(collection, field, value) {
+      const { items } = findAll(collection, { [field]: value }, { limit: 1 });
+      return items.length > 0 ? items[0] : null;
+    },
+
+    // For createResource
+    context: ruleContext,
+    dbCreate: create,
+    dbUpdate: update,
+    findStateMachine: (entity) => findStateMachineForEntity(entity, allStateMachines),
+    applyEffects,
+    processRuleEvaluations,
+    allRules,
+    allSlaTypes,
+    emitCreatedEvent(domainName, collectionName, resource) {
+      try {
+        emitEvent({
+          domain: domainName,
+          object: collectionName.replace(/s$/, ''),
+          action: 'created',
+          resourceId: resource.id,
+          source: `/${domainName}`,
+          data: { ...resource },
+          callerId: 'system'
+        });
+      } catch (e) {
+        console.error(`Failed to emit created event for ${domainName}/${collectionName}:`, e.message);
+      }
+    },
+
+    // For triggerTransition
+    resolvePath,
+    executeTransition: (opts) => executeTransition({ ...opts, allRules, allSlaTypes })
+  };
+}
+
+/**
+ * Register event subscriptions for all loaded rule sets that declare an `on:` field.
+ * Call once at server startup after rules and state machines are loaded.
+ *
+ * @param {Array} allRules         - from discoverRules()
+ * @param {Array} allStateMachines - from discoverStateMachines()
+ * @param {Array} [allSlaTypes]    - from discoverSlaTypes()
+ */
+export function registerEventSubscriptions(allRules, allStateMachines, allSlaTypes = []) {
+  // Collect all event-triggered rule sets across all rule files
+  const subscriptions = [];
+  for (const ruleFile of allRules) {
+    for (const ruleSet of ruleFile.ruleSets || []) {
+      if (ruleSet.on) {
+        subscriptions.push({ ruleSet, domain: ruleFile.domain, resource: ruleFile.resource });
+      }
+    }
+  }
+
+  if (subscriptions.length === 0) return;
+
+  console.log(`\n✓ Registered ${subscriptions.length} event subscription(s):`);
+  for (const { ruleSet, domain } of subscriptions) {
+    console.log(`  - ${domain}/${ruleSet.id} → on: ${ruleSet.on}`);
+  }
+
+  eventBus.on('domain-event', (event) => {
+    for (const { ruleSet } of subscriptions) {
+      if (!eventTypeMatches(event.type, ruleSet.on)) continue;
+
+      try {
+        // Resolve context bindings with the event envelope as "this"
+        const resolvedEntities = resolveContextEntities(ruleSet.context, event);
+        if (resolvedEntities === null) continue; // required binding failed
+
+        // Build rule context: this = event envelope, plus resolved entities
+        const ruleContext = buildRuleContext(event, resolvedEntities);
+
+        // Evaluate rules
+        const result = evaluateRuleSet(ruleSet, ruleContext);
+        if (!result.matched) continue;
+
+        // Build rich deps for platform actions
+        const deps = buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes);
+
+        // Execute actions
+        executeActions(result.action, event, deps, result.fallbackAction);
+      } catch (e) {
+        console.error(`Event subscription "${ruleSet.id}" failed for event "${event.type}":`, e.message);
+      }
+    }
+  });
+}

--- a/packages/mock-server/src/handlers/rule-evaluation.js
+++ b/packages/mock-server/src/handlers/rule-evaluation.js
@@ -35,7 +35,7 @@ function buildDependencies() {
  * @param {Object} resource - The primary resource being evaluated
  * @returns {Object|null} Map of alias → fetched entity, or null if a required entity is missing
  */
-function resolveContextEntities(contextBindings, resource) {
+export function resolveContextEntities(contextBindings, resource) {
   const resolved = {};
 
   for (const binding of contextBindings || []) {

--- a/packages/mock-server/src/handlers/transition-handler.js
+++ b/packages/mock-server/src/handlers/transition-handler.js
@@ -2,11 +2,7 @@
  * Handler for POST /resources/{id}/{trigger} (state machine transitions)
  */
 
-import { findById, findAll, update, create } from '../database-manager.js';
-import { findTransition, evaluateGuards, applyEffects } from '../state-machine-engine.js';
-import { updateSlaInfo } from '../sla-engine.js';
-import { processRuleEvaluations } from './rule-evaluation.js';
-import { emitEvent } from '../emit-event.js';
+import { executeTransition } from '../state-machine-runner.js';
 
 /**
  * Create a transition handler for an RPC endpoint.
@@ -15,6 +11,7 @@ import { emitEvent } from '../emit-event.js';
  * @param {string} trigger - Transition trigger name (e.g., "claim")
  * @param {string} paramName - URL parameter name for the resource ID
  * @param {Array} rules - Array from discoverRules()
+ * @param {Array} [slaTypes] - SLA types from discoverSlaTypes()
  * @returns {Function} Express handler
  */
 export function createTransitionHandler(resourceName, stateMachine, trigger, paramName, rules, slaTypes = []) {
@@ -22,7 +19,6 @@ export function createTransitionHandler(resourceName, stateMachine, trigger, par
     try {
       const resourceId = req.params[paramName];
 
-      // Require caller identity
       const callerId = req.headers['x-caller-id'];
       if (!callerId) {
         return res.status(400).json({
@@ -31,125 +27,29 @@ export function createTransitionHandler(resourceName, stateMachine, trigger, par
         });
       }
 
-      // Load the resource
-      const resource = findById(resourceName, resourceId);
-      if (!resource) {
-        return res.status(404).json({
-          code: 'NOT_FOUND',
-          message: `Resource not found: ${resourceId}`
-        });
-      }
-
-      // Find a valid transition
-      const { transition, error } = findTransition(stateMachine, trigger, resource);
-      if (!transition) {
-        return res.status(409).json({
-          code: 'CONFLICT',
-          message: error
-        });
-      }
-
-      // Parse caller roles from header (comma-separated)
       const callerRoles = req.headers['x-caller-roles']
         ? req.headers['x-caller-roles'].split(',').map(r => r.trim()).filter(Boolean)
         : [];
 
-      // Enforce actors — if transition defines actors, caller must have at least one matching role
-      if (transition.actors && transition.actors.length > 0) {
-        if (!callerRoles.some(r => transition.actors.includes(r))) {
-          return res.status(403).json({
-            code: 'FORBIDDEN',
-            message: `Transition "${trigger}" requires one of the following roles: ${transition.actors.join(', ')}`
-          });
-        }
-      }
-
-      // Support X-Mock-Now header for clock simulation in testing
       const now = req.headers['x-mock-now'] || new Date().toISOString();
-      const context = {
-        caller: {
-          id: callerId,
-          roles: callerRoles
-        },
-        object: { ...resource },  // Pre-transition snapshot
-        request: req.body || {},
-        now
-      };
-
-      const guardsMap = Object.fromEntries((stateMachine.guards || []).map(g => [g.id, g]));
-      const guardResult = evaluateGuards(
-        transition.guards,
-        guardsMap,
-        resource,
-        context
-      );
-
-      if (!guardResult.pass) {
-        return res.status(409).json({
-          code: 'CONFLICT',
-          message: `Guard "${guardResult.failedGuard}" failed: ${guardResult.reason}`
-        });
-      }
-
-      // Clone resource, apply effects, update status
-      const updated = { ...resource };
-      if (resource.slaInfo) updated.slaInfo = resource.slaInfo.map(e => ({ ...e }));
-      const { pendingCreates, pendingRuleEvaluations, pendingEvents } = applyEffects(transition.effects, updated, context);
-      // Only update status if the transition declares a non-empty target state.
-      // In-place transitions (assign, set-priority) omit `to` and leave status unchanged.
-      if (transition.to != null && transition.to !== '') {
-        updated.status = transition.to;
-      }
-
-      // Update SLA clock state based on new status
-      if (slaTypes.length > 0 && updated.slaInfo?.length > 0) {
-        updateSlaInfo(updated, slaTypes, now, stateMachine.states || {});
-      }
-
-      // Process pending rule evaluations
-      processRuleEvaluations(pendingRuleEvaluations, updated, rules, stateMachine.domain);
-
-      // Compute diff (only changed fields)
-      const diff = {};
-      for (const [key, value] of Object.entries(updated)) {
-        if (resource[key] !== value) {
-          diff[key] = value;
-        }
-      }
-
-      // Persist changes
-      const result = update(resourceName, resourceId, diff);
-
-      // Execute pending creates
-      for (const { entity, data } of pendingCreates) {
-        try {
-          create(entity, data);
-        } catch (createError) {
-          console.error(`Failed to create ${entity}:`, createError.message);
-        }
-      }
-
-      // Emit pending domain events via shared utility
-      const domain = stateMachine.domain;
-      const object = stateMachine.object.toLowerCase();
-      const source = `/${domain}`;
       const traceparent = req.headers['traceparent'] || null;
-      for (const event of pendingEvents) {
-        try {
-          emitEvent({
-            domain,
-            object,
-            action: event.action,
-            resourceId: resource.id,
-            source,
-            data: event.data || null,
-            callerId,
-            traceparent,
-            now,
-          });
-        } catch (eventError) {
-          console.error(`Failed to emit event "${event.action}":`, eventError.message);
-        }
+
+      const { success, result, status, error } = executeTransition({
+        resourceName,
+        resourceId,
+        trigger,
+        callerId,
+        callerRoles,
+        now,
+        stateMachine,
+        rules,
+        slaTypes,
+        requestBody: req.body || {},
+        traceparent
+      });
+
+      if (!success) {
+        return res.status(status).json({ code: statusCode(status), message: error });
       }
 
       res.json(result);
@@ -162,4 +62,10 @@ export function createTransitionHandler(resourceName, stateMachine, trigger, par
       });
     }
   };
+}
+
+function statusCode(status) {
+  if (status === 404) return 'NOT_FOUND';
+  if (status === 403) return 'FORBIDDEN';
+  return 'CONFLICT';
 }

--- a/packages/mock-server/src/platform-action-handlers.js
+++ b/packages/mock-server/src/platform-action-handlers.js
@@ -1,0 +1,158 @@
+/**
+ * Platform-level action handlers — generic, available to all domains.
+ * These actions create resources and trigger state machine transitions;
+ * they are not specific to any one domain's rules.
+ */
+
+import jsonLogic from 'json-logic-js';
+
+/**
+ * Create a new resource in the specified domain/collection.
+ * Field values may be literals or JSON Logic expressions resolved against the
+ * current rule context (e.g., { var: "this.subject" } to use the event subject).
+ *
+ * After creation, runs the entity's state machine onCreate pipeline (initial state
+ * + rule evaluations) using the same machinery as the HTTP create handler.
+ *
+ * @param {Object} actionValue - { entity: "domain/collection", fields: { ... } }
+ * @param {Object} resource    - The current "this" context (event envelope or calling resource)
+ * @param {Object} deps        - {
+ *   context,           // full rule evaluation context for JSON Logic resolution
+ *   dbCreate,          // function(collection, fields) → created
+ *   dbUpdate,          // function(collection, id, diff)
+ *   findStateMachine,  // function(entity) → stateMachine | null
+ *   applyEffects,      // function(effects, resource, context) → { pendingRuleEvaluations, ... }
+ *   processRuleEvaluations,  // function(pending, resource, rules, domain)
+ *   allRules,
+ *   allSlaTypes,
+ *   emitCreatedEvent   // function(domain, collectionName, resource, callerId)
+ * }
+ */
+function createResource(actionValue, resource, deps) {
+  const { entity, fields } = actionValue || {};
+  if (!entity || !fields) {
+    console.error('createResource: missing required fields "entity" or "fields"');
+    return;
+  }
+
+  const parts = entity.split('/');
+  const domainName = parts[0];
+  const collectionName = parts[1];
+
+  // Resolve field values — literals pass through; objects are JSON Logic expressions
+  const resolvedFields = {};
+  const ctx = deps.context || {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      resolvedFields[key] = jsonLogic.apply(value, ctx);
+    } else {
+      resolvedFields[key] = value;
+    }
+  }
+
+  const created = deps.dbCreate(collectionName, resolvedFields);
+
+  // Apply state machine onCreate pipeline if one exists for this entity
+  const stateMachine = deps.findStateMachine?.(entity);
+  if (stateMachine) {
+    // Apply initial state
+    if (stateMachine.initialState) {
+      created.status = stateMachine.initialState;
+      deps.dbUpdate(collectionName, created.id, { status: stateMachine.initialState });
+    }
+
+    // Run onCreate effects (evaluate-rules, etc.) using existing applyEffects machinery
+    if (stateMachine.onCreate?.effects?.length > 0) {
+      const onCreateContext = {
+        caller: { id: 'system', roles: ['system'] },
+        object: { ...created },
+        request: {},
+        now: new Date().toISOString()
+      };
+      const original = JSON.parse(JSON.stringify(created));
+      const { pendingRuleEvaluations } = deps.applyEffects(
+        stateMachine.onCreate.effects,
+        created,
+        onCreateContext
+      );
+
+      if (pendingRuleEvaluations.length > 0) {
+        deps.processRuleEvaluations(pendingRuleEvaluations, created, deps.allRules, domainName);
+      }
+
+      // Persist rule-driven mutations
+      const diff = {};
+      for (const [key, value] of Object.entries(created)) {
+        if (original[key] !== value && key !== 'id' && key !== 'createdAt' && key !== 'updatedAt') {
+          diff[key] = value;
+        }
+      }
+      if (Object.keys(diff).length > 0) {
+        deps.dbUpdate(collectionName, created.id, diff);
+        Object.assign(created, diff);
+      }
+    }
+  }
+
+  // Emit created event so downstream systems can observe the new resource
+  deps.emitCreatedEvent?.(domainName, collectionName, created);
+
+  return created;
+}
+
+/**
+ * Trigger a state machine transition on a related entity.
+ * The entity ID is resolved from the current rule context using the idFrom dot-path.
+ *
+ * @param {Object} actionValue - { entity: "domain/collection", idFrom: "dot.path", transition: "trigger" }
+ * @param {Object} resource    - The current "this" context
+ * @param {Object} deps        - {
+ *   context,           // full rule evaluation context for idFrom resolution
+ *   resolvePath,       // function(obj, path) → value
+ *   findStateMachine,  // function(entity) → stateMachine | null
+ *   executeTransition, // function(options) → { success, result, error }
+ *   allRules,
+ *   allSlaTypes
+ * }
+ */
+function triggerTransition(actionValue, resource, deps) {
+  const { entity, idFrom, transition } = actionValue || {};
+  if (!entity || !idFrom || !transition) {
+    console.error('triggerTransition: missing required fields "entity", "idFrom", or "transition"');
+    return;
+  }
+
+  const entityId = deps.resolvePath?.(deps.context || {}, idFrom);
+  if (!entityId) {
+    console.error(`triggerTransition: "${idFrom}" resolved to no value in rule context`);
+    return;
+  }
+
+  const stateMachine = deps.findStateMachine?.(entity);
+  if (!stateMachine) {
+    console.error(`triggerTransition: no state machine found for entity "${entity}"`);
+    return;
+  }
+
+  const collectionName = entity.split('/')[1];
+
+  const { success, error } = deps.executeTransition({
+    resourceName: collectionName,
+    resourceId: entityId,
+    trigger: transition,
+    callerId: 'system',
+    callerRoles: ['system'],
+    stateMachine,
+    rules: deps.allRules || [],
+    slaTypes: deps.allSlaTypes || []
+  });
+
+  if (!success) {
+    console.error(`triggerTransition: "${transition}" on ${entity}/${entityId} failed — ${error}`);
+  }
+}
+
+export const platformActionRegistry = new Map([
+  ['createResource', createResource],
+  ['triggerTransition', triggerTransition]
+]);

--- a/packages/mock-server/src/state-machine-runner.js
+++ b/packages/mock-server/src/state-machine-runner.js
@@ -1,0 +1,133 @@
+/**
+ * Shared state machine transition logic.
+ * Called by the HTTP transition handler and by the platform triggerTransition action.
+ * Extracted so both paths use identical evaluation, mutation, and event emission.
+ */
+
+import { findById, update, create } from './database-manager.js';
+import { findTransition, evaluateGuards, applyEffects } from './state-machine-engine.js';
+import { updateSlaInfo } from './sla-engine.js';
+import { processRuleEvaluations } from './handlers/rule-evaluation.js';
+import { emitEvent } from './emit-event.js';
+
+/**
+ * Execute a state machine transition programmatically.
+ *
+ * @param {Object} options
+ * @param {string} options.resourceName     - DB collection name (e.g., "applications")
+ * @param {string} options.resourceId       - UUID of the resource to transition
+ * @param {string} options.trigger          - Transition trigger (e.g., "open")
+ * @param {string} options.callerId         - Caller identity (use "system" for automated transitions)
+ * @param {string[]} options.callerRoles    - Caller roles (e.g., ["system"])
+ * @param {string} [options.now]            - ISO timestamp; defaults to current time
+ * @param {Object} options.stateMachine     - State machine contract
+ * @param {Array}  options.rules            - Rules from discoverRules()
+ * @param {Array}  [options.slaTypes]       - SLA types from discoverSlaTypes()
+ * @param {Object} [options.requestBody]     - Request body passed to effects as $request.*; empty for system transitions
+ * @param {string} [options.traceparent]    - W3C traceparent for distributed tracing
+ * @returns {{ success: boolean, result?: Object, status?: number, error?: string }}
+ */
+export function executeTransition({
+  resourceName,
+  resourceId,
+  trigger,
+  callerId,
+  callerRoles,
+  now,
+  stateMachine,
+  rules,
+  slaTypes = [],
+  requestBody = {},
+  traceparent = null
+}) {
+  const timestamp = now || new Date().toISOString();
+
+  const resource = findById(resourceName, resourceId);
+  if (!resource) {
+    return { success: false, status: 404, error: `Resource not found: ${resourceId}` };
+  }
+
+  const { transition, error } = findTransition(stateMachine, trigger, resource);
+  if (!transition) {
+    return { success: false, status: 409, error };
+  }
+
+  if (transition.actors?.length > 0) {
+    if (!callerRoles.some(r => transition.actors.includes(r))) {
+      return {
+        success: false,
+        status: 403,
+        error: `Transition "${trigger}" requires one of: ${transition.actors.join(', ')}`
+      };
+    }
+  }
+
+  const context = {
+    caller: { id: callerId, roles: callerRoles },
+    object: { ...resource },
+    request: requestBody,
+    now: timestamp
+  };
+
+  const guardsMap = Object.fromEntries((stateMachine.guards || []).map(g => [g.id, g]));
+  const guardResult = evaluateGuards(transition.guards, guardsMap, resource, context);
+  if (!guardResult.pass) {
+    return {
+      success: false,
+      status: 409,
+      error: `Guard "${guardResult.failedGuard}" failed: ${guardResult.reason}`
+    };
+  }
+
+  const updated = { ...resource };
+  if (resource.slaInfo) updated.slaInfo = resource.slaInfo.map(e => ({ ...e }));
+
+  const { pendingCreates, pendingRuleEvaluations, pendingEvents } = applyEffects(
+    transition.effects,
+    updated,
+    context
+  );
+
+  if (transition.to != null && transition.to !== '') {
+    updated.status = transition.to;
+  }
+
+  if (slaTypes.length > 0 && updated.slaInfo?.length > 0) {
+    updateSlaInfo(updated, slaTypes, timestamp, stateMachine.states || {});
+  }
+
+  processRuleEvaluations(pendingRuleEvaluations, updated, rules, stateMachine.domain);
+
+  const diff = {};
+  for (const [key, value] of Object.entries(updated)) {
+    if (resource[key] !== value) diff[key] = value;
+  }
+  const result = update(resourceName, resourceId, diff);
+
+  for (const { entity, data } of pendingCreates) {
+    try { create(entity, data); }
+    catch (e) { console.error(`Failed to create ${entity}:`, e.message); }
+  }
+
+  const domain = stateMachine.domain;
+  const object = stateMachine.object.toLowerCase();
+  for (const event of pendingEvents) {
+    try {
+      emitEvent({
+        domain,
+        object,
+        action: event.action,
+        resourceId: resource.id,
+        source: `/${domain}`,
+        data: event.data || null,
+        callerId,
+        traceparent,
+        now: timestamp
+      });
+    } catch (e) {
+      console.error(`Failed to emit event "${event.action}":`, e.message);
+    }
+  }
+
+  return { success: true, result };
+}

--- a/packages/mock-server/src/workflow-action-handlers.js
+++ b/packages/mock-server/src/workflow-action-handlers.js
@@ -1,0 +1,41 @@
+/**
+ * Workflow-domain action handlers.
+ * Domain-specific actions for routing and prioritizing workflow tasks.
+ */
+
+/**
+ * Assign a task to a queue by looking up the queue by name.
+ * @param {string} queueName - Name of the queue to assign to
+ * @param {Object} resource - Resource to mutate
+ * @param {Object} deps - Dependencies (findByField function)
+ * @param {Object|null} fallbackAction - Fallback action if queue not found
+ */
+function assignToQueue(queueName, resource, deps, fallbackAction) {
+  const queue = deps.findByField('queues', 'name', queueName);
+  if (queue) {
+    resource.queueId = queue.id;
+  } else if (fallbackAction?.assignToQueue) {
+    const fallbackQueue = deps.findByField('queues', 'name', fallbackAction.assignToQueue);
+    if (fallbackQueue) {
+      resource.queueId = fallbackQueue.id;
+    } else {
+      console.warn(`Queue "${queueName}" and fallback "${fallbackAction.assignToQueue}" not found`);
+    }
+  } else {
+    console.warn(`Queue "${queueName}" not found, no fallback configured`);
+  }
+}
+
+/**
+ * Set the priority of a resource.
+ * @param {string} priority - Priority value to set
+ * @param {Object} resource - Resource to mutate
+ */
+function setPriority(priority, resource) {
+  resource.priority = priority;
+}
+
+export const workflowActionRegistry = new Map([
+  ['assignToQueue', assignToQueue],
+  ['setPriority', setPriority]
+]);

--- a/packages/mock-server/tests/fixtures/intake.yaml
+++ b/packages/mock-server/tests/fixtures/intake.yaml
@@ -8,7 +8,6 @@ ApplicationExample1:
   status: submitted
   programs:
     - snap
-    - medicaid
   channel: online
   isExpedited: false
   submittedAt: "2026-04-01T09:15:00Z"

--- a/packages/mock-server/tests/unit/event-subscription.test.js
+++ b/packages/mock-server/tests/unit/event-subscription.test.js
@@ -1,0 +1,420 @@
+/**
+ * Unit tests for event-subscription — event-triggered rule set evaluation.
+ * Tests event type matching, context resolution from event envelope,
+ * createResource action, and triggerTransition action.
+ */
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { insertResource, clearAll, findAll, findById } from '../../src/database-manager.js';
+import { registerEventSubscriptions } from '../../src/event-subscription.js';
+import { eventBus } from '../../src/event-bus.js';
+
+// Each test registers subscriptions; remove all listeners between tests to prevent accumulation
+beforeEach(() => eventBus.removeAllListeners('domain-event'));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const SNAP_QUEUE_ID = 'q-snap-uuid';
+const GENERAL_QUEUE_ID = 'q-general-uuid';
+
+function seed() {
+  clearAll('applications');
+  clearAll('tasks');
+  clearAll('queues');
+  clearAll('events');
+  insertResource('queues', { id: SNAP_QUEUE_ID, name: 'snap-intake' });
+  insertResource('queues', { id: GENERAL_QUEUE_ID, name: 'general-intake' });
+}
+
+function makeEvent(type, subject, data = null) {
+  return {
+    specversion: '1.0',
+    id: 'test-event-' + Math.random(),
+    type,
+    source: '/intake',
+    subject,
+    time: new Date().toISOString(),
+    data
+  };
+}
+
+// Minimal state machine for tasks
+const taskStateMachine = {
+  domain: 'workflow',
+  object: 'task',
+  initialState: 'pending',
+  states: { pending: {}, in_progress: {}, completed: {} },
+  transitions: [],
+  guards: [],
+  onCreate: {
+    effects: [
+      { type: 'evaluate-rules', ruleType: 'assignment' },
+      { type: 'evaluate-rules', ruleType: 'priority' }
+    ]
+  }
+};
+
+// Minimal state machine for applications
+const applicationStateMachine = {
+  domain: 'intake',
+  object: 'application',
+  initialState: 'draft',
+  states: { draft: {}, submitted: {}, under_review: {} },
+  transitions: [
+    {
+      trigger: 'open',
+      from: 'submitted',
+      to: 'under_review',
+      actors: ['system'],
+      guards: ['callerIsSystem'],
+      effects: [
+        { type: 'event', action: 'opened', data: { openedAt: '$now' } }
+      ]
+    }
+  ],
+  guards: [
+    {
+      id: 'callerIsSystem',
+      field: '$caller.roles',
+      operator: 'contains_any',
+      value: ['system']
+    }
+  ]
+};
+
+const allStateMachines = [
+  { domain: 'workflow', object: 'task', stateMachine: taskStateMachine },
+  { domain: 'intake', object: 'application', stateMachine: applicationStateMachine }
+];
+
+// =============================================================================
+// Event type matching
+// =============================================================================
+
+test('registerEventSubscriptions — matches full CloudEvents type', (t, done) => {
+  seed();
+  clearAll('tasks');
+
+  const APP_ID = 'app-full-type';
+  insertResource('applications', { id: APP_ID, programs: ['snap'], status: 'submitted' });
+
+  const rules = [{
+    domain: 'workflow',
+    resource: 'workflow/tasks',
+    ruleSets: [{
+      id: 'test-subscription',
+      ruleType: 'task-creation',
+      on: 'org.codeforamerica.safety-net-blueprint.intake.application.submitted',
+      evaluation: 'first-match-wins',
+      rules: [{ id: 'r1', order: 1, condition: true, action: { createResource: { entity: 'workflow/tasks', fields: { name: 'Test task', status: 'pending', subjectId: { var: 'this.subject' } } } } }]
+    }]
+  }];
+
+  registerEventSubscriptions(rules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.intake.application.submitted',
+    APP_ID
+  ));
+
+  setImmediate(() => {
+    const { items } = findAll('tasks', { subjectId: APP_ID });
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].status, 'pending');
+    done();
+  });
+});
+
+test('registerEventSubscriptions — matches short-form type', (t, done) => {
+  seed();
+
+  const APP_ID = 'app-short-type';
+  insertResource('applications', { id: APP_ID, programs: ['snap'], status: 'submitted' });
+
+  const rules = [{
+    domain: 'workflow',
+    resource: 'workflow/tasks',
+    ruleSets: [{
+      id: 'test-short-form',
+      ruleType: 'task-creation',
+      on: 'intake.application.submitted',
+      evaluation: 'first-match-wins',
+      rules: [{ id: 'r1', order: 1, condition: true, action: { createResource: { entity: 'workflow/tasks', fields: { name: 'Short form task', status: 'pending', subjectId: { var: 'this.subject' } } } } }]
+    }]
+  }];
+
+  registerEventSubscriptions(rules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.intake.application.submitted',
+    APP_ID
+  ));
+
+  setImmediate(() => {
+    const { items } = findAll('tasks', { subjectId: APP_ID });
+    assert.strictEqual(items.length, 1);
+    done();
+  });
+});
+
+test('registerEventSubscriptions — non-matching event type does not fire', (t, done) => {
+  seed();
+
+  const APP_ID = 'app-no-match';
+
+  const rules = [{
+    domain: 'workflow',
+    resource: 'workflow/tasks',
+    ruleSets: [{
+      id: 'test-no-match',
+      ruleType: 'task-creation',
+      on: 'intake.application.submitted',
+      evaluation: 'first-match-wins',
+      rules: [{ id: 'r1', order: 1, condition: true, action: { createResource: { entity: 'workflow/tasks', fields: { name: 'Should not exist', status: 'pending', subjectId: APP_ID } } } }]
+    }]
+  }];
+
+  registerEventSubscriptions(rules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.intake.application.created',
+    APP_ID
+  ));
+
+  setImmediate(() => {
+    const { items } = findAll('tasks', { subjectId: APP_ID });
+    assert.strictEqual(items.length, 0);
+    done();
+  });
+});
+
+// =============================================================================
+// createResource — context resolution and JSON Logic field values
+// =============================================================================
+
+test('createResource — resolves context binding from event envelope subject', (t, done) => {
+  seed();
+
+  const APP_ID = 'app-ctx-resolve';
+  insertResource('applications', { id: APP_ID, programs: ['snap'], status: 'submitted' });
+
+  const rules = [{
+    domain: 'workflow',
+    resource: 'workflow/tasks',
+    ruleSets: [{
+      id: 'test-ctx',
+      ruleType: 'task-creation',
+      on: 'intake.application.submitted',
+      evaluation: 'first-match-wins',
+      context: [{ as: 'application', entity: 'intake/applications', from: 'subject' }],
+      rules: [{
+        id: 'r1',
+        order: 1,
+        condition: { in: ['snap', { var: 'application.programs' }] },
+        action: {
+          createResource: {
+            entity: 'workflow/tasks',
+            fields: {
+              name: 'SNAP task',
+              status: 'pending',
+              subjectId: { var: 'this.subject' },
+              taskType: 'application_review'
+            }
+          }
+        }
+      }]
+    }],
+    // Assignment rules for routing
+    ...[{
+      domain: 'workflow',
+      resource: 'workflow/tasks',
+      ruleSets: [{
+        id: 'workflow-assignment',
+        ruleType: 'assignment',
+        evaluation: 'first-match-wins',
+        context: [{ as: 'application', entity: 'intake/applications', from: 'subjectId', optional: true }],
+        rules: [
+          { id: 'snap', order: 1, condition: { in: ['snap', { var: 'application.programs' }] }, action: { assignToQueue: 'snap-intake' }, fallbackAction: { assignToQueue: 'general-intake' } },
+          { id: 'default', order: 2, condition: true, action: { assignToQueue: 'general-intake' } }
+        ]
+      }]
+    }]
+  }];
+
+  // Build flat rules array
+  const allRules = [
+    {
+      domain: 'workflow',
+      resource: 'workflow/tasks',
+      ruleSets: [
+        {
+          id: 'test-ctx',
+          ruleType: 'task-creation',
+          on: 'intake.application.submitted',
+          evaluation: 'first-match-wins',
+          context: [{ as: 'application', entity: 'intake/applications', from: 'subject' }],
+          rules: [{
+            id: 'r1',
+            order: 1,
+            condition: { in: ['snap', { var: 'application.programs' }] },
+            action: {
+              createResource: {
+                entity: 'workflow/tasks',
+                fields: {
+                  name: 'SNAP task',
+                  status: 'pending',
+                  subjectId: { var: 'this.subject' },
+                  taskType: 'application_review'
+                }
+              }
+            }
+          }]
+        },
+        {
+          id: 'workflow-assignment',
+          ruleType: 'assignment',
+          evaluation: 'first-match-wins',
+          context: [{ as: 'application', entity: 'intake/applications', from: 'subjectId', optional: true }],
+          rules: [
+            { id: 'snap', order: 1, condition: { in: ['snap', { var: 'application.programs' }] }, action: { assignToQueue: 'snap-intake' }, fallbackAction: { assignToQueue: 'general-intake' } },
+            { id: 'default', order: 2, condition: true, action: { assignToQueue: 'general-intake' } }
+          ]
+        }
+      ]
+    }
+  ];
+
+  registerEventSubscriptions(allRules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.intake.application.submitted',
+    APP_ID
+  ));
+
+  setImmediate(() => {
+    const { items } = findAll('tasks', { subjectId: APP_ID });
+    assert.strictEqual(items.length, 1, 'task created');
+    assert.strictEqual(items[0].taskType, 'application_review');
+    assert.strictEqual(items[0].status, 'pending');
+    assert.strictEqual(items[0].queueId, SNAP_QUEUE_ID, 'routed to snap-intake via assignment rules');
+    done();
+  });
+});
+
+// =============================================================================
+// triggerTransition — via context binding chain
+// =============================================================================
+
+test('triggerTransition — transitions a related entity to new state', (t, done) => {
+  seed();
+
+  const APP_ID = 'app-trigger-test';
+  const TASK_ID = 'task-trigger-test';
+  insertResource('applications', { id: APP_ID, status: 'submitted' });
+  insertResource('tasks', { id: TASK_ID, subjectId: APP_ID, subjectType: 'application', taskType: 'application_review', status: 'in_progress' });
+
+  const allRules = [{
+    domain: 'intake',
+    resource: 'intake/applications',
+    ruleSets: [{
+      id: 'task-claimed-open-application',
+      ruleType: 'status-transition',
+      on: 'workflow.task.claimed',
+      evaluation: 'first-match-wins',
+      context: [
+        { as: 'task', entity: 'workflow/tasks', from: 'subject' },
+        { as: 'application', entity: 'intake/applications', from: 'task.subjectId', optional: true }
+      ],
+      rules: [{
+        id: 'open-on-claim',
+        order: 1,
+        condition: {
+          and: [
+            { '!=': [{ var: 'application.id' }, null] },
+            { '==': [{ var: 'task.taskType' }, 'application_review'] },
+            { '==': [{ var: 'application.status' }, 'submitted'] }
+          ]
+        },
+        action: {
+          triggerTransition: {
+            entity: 'intake/applications',
+            idFrom: 'application.id',
+            transition: 'open'
+          }
+        }
+      }]
+    }]
+  }];
+
+  registerEventSubscriptions(allRules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.workflow.task.claimed',
+    TASK_ID
+  ));
+
+  setImmediate(() => {
+    const app = findById('applications', APP_ID);
+    assert.strictEqual(app.status, 'under_review', 'application transitioned to under_review');
+    done();
+  });
+});
+
+test('triggerTransition — skips when application not in submitted state', (t, done) => {
+  seed();
+
+  const APP_ID = 'app-already-under-review';
+  const TASK_ID = 'task-already-under-review';
+  insertResource('applications', { id: APP_ID, status: 'under_review' });
+  insertResource('tasks', { id: TASK_ID, subjectId: APP_ID, subjectType: 'application', taskType: 'application_review', status: 'in_progress' });
+
+  const allRules = [{
+    domain: 'intake',
+    resource: 'intake/applications',
+    ruleSets: [{
+      id: 'task-claimed-open-application',
+      ruleType: 'status-transition',
+      on: 'workflow.task.claimed',
+      evaluation: 'first-match-wins',
+      context: [
+        { as: 'task', entity: 'workflow/tasks', from: 'subject' },
+        { as: 'application', entity: 'intake/applications', from: 'task.subjectId', optional: true }
+      ],
+      rules: [{
+        id: 'open-on-claim',
+        order: 1,
+        condition: {
+          and: [
+            { '!=': [{ var: 'application.id' }, null] },
+            { '==': [{ var: 'task.taskType' }, 'application_review'] },
+            { '==': [{ var: 'application.status' }, 'submitted'] }
+          ]
+        },
+        action: {
+          triggerTransition: {
+            entity: 'intake/applications',
+            idFrom: 'application.id',
+            transition: 'open'
+          }
+        }
+      }]
+    }]
+  }];
+
+  registerEventSubscriptions(allRules, allStateMachines);
+
+  eventBus.emit('domain-event', makeEvent(
+    'org.codeforamerica.safety-net-blueprint.workflow.task.claimed',
+    TASK_ID
+  ));
+
+  setImmediate(() => {
+    const app = findById('applications', APP_ID);
+    // Status should be unchanged — condition required submitted, got under_review
+    assert.strictEqual(app.status, 'under_review');
+    done();
+  });
+});


### PR DESCRIPTION
Closes #163

## Summary

- Adds `on:` field to rule sets, making them event-triggered — presence of the field subscribes the rule set to a CloudEvents type (short-form `intake.application.submitted` or full type both accepted)
- Adds `createResource` and `triggerTransition` as generic platform actions, available to any domain; defined as named `$defs` in `rules-schema.yaml`
- Extracts `executeTransition` from the HTTP handler into `state-machine-runner.js` so programmatic callers (event-triggered transitions) share the same machinery as HTTP requests
- Adds `event-subscription.js` — the engine that listens on the event bus, resolves context bindings from the event envelope, evaluates matching rule sets, and dispatches actions
- Adds `workflow-rules.yaml` rule set: on `intake.application.submitted`, create an `application_review` task routed to snap-intake (SNAP-only) or general-intake (multi-program)
- Adds `intake-rules.yaml`: on `workflow.task.claimed`, if the linked application is in `submitted` state, transition it to `under_review` — intake owns its own transition, workflow has no downstream knowledge
- Adds `taskType` as an open string field on tasks, used by routing rules and available as a lifecycle discriminator
- Adds design decisions 22–24 to the workflow design reference (event envelope as `this`, reactive subscription pattern, generic platform actions)

## Notes for reviewer

The cross-domain coordination is reactive, not orchestrated: intake subscribes to `workflow.task.claimed` and triggers its own `open` transition. Workflow emits the event; it has no knowledge of what intake does in response. This matches the ServiceNow Business Rules / Salesforce Platform Events pattern documented in Decision 23.

The `triggerTransition` action runs with system identity, which satisfies the `callerIsSystem` guard on the intake `open` transition — the same guard that prevents caseworkers from calling that transition directly via HTTP.

Validation steps are in the issue.