### PR TITLE
Cross-resource search does not find values in nested object fields

### DIFF
--- a/packages/mock-server/src/query-parser.js
+++ b/packages/mock-server/src/query-parser.js
@@ -294,60 +294,32 @@ function tokenToSqlCondition(token, searchableFields) {
   const { type, field, value } = token;
 
   switch (type) {
-    // Full-text search types (search across multiple fields)
+    // Full-text search types — search all string values at any depth using json_tree()
     case TokenType.FULL_TEXT: {
-      if (searchableFields.length === 0) {
-        return { clause: null, tokenParams: [] };
-      }
-      // Exact match across searchable fields
-      const clauses = searchableFields.map(f =>
-        `LOWER(COALESCE(json_extract(data, '$.${f}'), '')) = LOWER(?)`
-      );
       return {
-        clause: `(${clauses.join(' OR ')})`,
-        tokenParams: searchableFields.map(() => value)
+        clause: `EXISTS (SELECT 1 FROM json_tree(data) WHERE type = 'text' AND LOWER(value) = LOWER(?))`,
+        tokenParams: [value]
       };
     }
 
     case TokenType.FULL_TEXT_CONTAINS: {
-      if (searchableFields.length === 0) {
-        return { clause: null, tokenParams: [] };
-      }
-      const clauses = searchableFields.map(f =>
-        `LOWER(COALESCE(json_extract(data, '$.${f}'), '')) LIKE LOWER(?)`
-      );
-      const pattern = `%${value}%`;
       return {
-        clause: `(${clauses.join(' OR ')})`,
-        tokenParams: searchableFields.map(() => pattern)
+        clause: `EXISTS (SELECT 1 FROM json_tree(data) WHERE type = 'text' AND LOWER(value) LIKE LOWER(?))`,
+        tokenParams: [`%${value}%`]
       };
     }
 
     case TokenType.FULL_TEXT_STARTS_WITH: {
-      if (searchableFields.length === 0) {
-        return { clause: null, tokenParams: [] };
-      }
-      const clauses = searchableFields.map(f =>
-        `LOWER(COALESCE(json_extract(data, '$.${f}'), '')) LIKE LOWER(?)`
-      );
-      const pattern = `${value}%`;
       return {
-        clause: `(${clauses.join(' OR ')})`,
-        tokenParams: searchableFields.map(() => pattern)
+        clause: `EXISTS (SELECT 1 FROM json_tree(data) WHERE type = 'text' AND LOWER(value) LIKE LOWER(?))`,
+        tokenParams: [`${value}%`]
       };
     }
 
     case TokenType.FULL_TEXT_ENDS_WITH: {
-      if (searchableFields.length === 0) {
-        return { clause: null, tokenParams: [] };
-      }
-      const clauses = searchableFields.map(f =>
-        `LOWER(COALESCE(json_extract(data, '$.${f}'), '')) LIKE LOWER(?)`
-      );
-      const pattern = `%${value}`;
       return {
-        clause: `(${clauses.join(' OR ')})`,
-        tokenParams: searchableFields.map(() => pattern)
+        clause: `EXISTS (SELECT 1 FROM json_tree(data) WHERE type = 'text' AND LOWER(value) LIKE LOWER(?))`,
+        tokenParams: [`%${value}`]
       };
     }
 

--- a/packages/mock-server/src/search-engine.js
+++ b/packages/mock-server/src/search-engine.js
@@ -41,17 +41,12 @@ export function buildSearchConditions(queryParams = {}, searchableFields = []) {
     params.push(...qParams);
   }
 
-  // Handle legacy 'search' parameter (searches across multiple fields)
-  // This provides backward compatibility
-  if (queryParams.search && searchableFields.length > 0) {
-    const searchClauses = searchableFields.map(field =>
-      `LOWER(COALESCE(json_extract(data, '$.${field}'), '')) LIKE LOWER(?)`
+  // Handle legacy 'search' parameter — searches all string values at any depth
+  if (queryParams.search) {
+    whereClauses.push(
+      `EXISTS (SELECT 1 FROM json_tree(data) WHERE type = 'text' AND LOWER(value) LIKE LOWER(?))`
     );
-    whereClauses.push(`(${searchClauses.join(' OR ')})`);
-
-    // Add search pattern for each field
-    const searchPattern = `%${queryParams.search}%`;
-    searchableFields.forEach(() => params.push(searchPattern));
+    params.push(`%${queryParams.search}%`);
   }
 
   // Handle specific field filters (exact match) - legacy support

--- a/packages/mock-server/tests/unit/query-parser.test.js
+++ b/packages/mock-server/tests/unit/query-parser.test.js
@@ -243,26 +243,24 @@ function runTests() {
   // ============================================================
   console.log('\n--- tokensToSqlConditions ---\n');
 
-  test('generates full-text exact match SQL', () => {
+  test('generates full-text exact match SQL using json_tree', () => {
     const tokens = [{ type: TokenType.FULL_TEXT, field: null, value: 'john' }];
-    const searchableFields = ['name', 'email'];
-    const { whereClauses, params } = tokensToSqlConditions(tokens, searchableFields);
+    const { whereClauses, params } = tokensToSqlConditions(tokens, ['name', 'email']);
 
     assertEqual(whereClauses.length, 1);
-    assertEqual(params.length, 2);
+    assertEqual(params.length, 1);
     assertEqual(params[0], 'john');
-    assertEqual(params[1], 'john');
+    assertEqual(whereClauses[0].includes('json_tree'), true);
   });
 
-  test('generates full-text contains SQL (*value*)', () => {
+  test('generates full-text contains SQL (*value*) using json_tree', () => {
     const tokens = [{ type: TokenType.FULL_TEXT_CONTAINS, field: null, value: 'john' }];
-    const searchableFields = ['name', 'email'];
-    const { whereClauses, params } = tokensToSqlConditions(tokens, searchableFields);
+    const { whereClauses, params } = tokensToSqlConditions(tokens, ['name', 'email']);
 
     assertEqual(whereClauses.length, 1);
-    assertEqual(params.length, 2);
+    assertEqual(params.length, 1);
     assertEqual(params[0], '%john%');
-    assertEqual(params[1], '%john%');
+    assertEqual(whereClauses[0].includes('json_tree'), true);
   });
 
   test('generates full-text starts with SQL (value*)', () => {
@@ -398,14 +396,13 @@ function runTests() {
   test('full pipeline: q=john status:active -deleted:*', () => {
     const q = 'john status:active -deleted:*';
     const tokens = parseQueryString(q);
-    const searchableFields = ['name', 'email'];
-    const { whereClauses, params } = tokensToSqlConditions(tokens, searchableFields);
+    const { whereClauses, params } = tokensToSqlConditions(tokens, ['name', 'email']);
 
     assertEqual(tokens.length, 3);
     assertEqual(whereClauses.length, 3);
-    // Full text exact match adds params for each searchable field
-    assertEqual(params.slice(0, 2), ['john', 'john']);
-    assertEqual(params[2], 'active');
+    // Full-text match uses json_tree — one param for the search value
+    assertEqual(params[0], 'john');
+    assertEqual(params[1], 'active');
   });
 
   test('full pipeline: q=programs:snap,tanf state:TX,CA', () => {

--- a/packages/mock-server/tests/unit/search-engine-conditions.test.js
+++ b/packages/mock-server/tests/unit/search-engine-conditions.test.js
@@ -22,11 +22,20 @@ test('buildSearchConditions', async (t) => {
     console.log('  ✓ Produces exact-match clause for simple field');
   });
 
-  await t.test('skips reserved parameters (limit, offset, page, q, search)', () => {
-    const { whereClauses } = buildSearchConditions({ limit: '10', offset: '0', page: '1', q: 'foo', search: 'bar' });
+  await t.test('skips pagination parameters (limit, offset, page)', () => {
+    const { whereClauses } = buildSearchConditions({ limit: '10', offset: '0', page: '1' });
 
-    assert.strictEqual(whereClauses.length, 0, 'Should produce no WHERE clauses for reserved params');
-    console.log('  ✓ Skips reserved parameters');
+    assert.strictEqual(whereClauses.length, 0, 'Should produce no WHERE clauses for pagination params');
+    console.log('  ✓ Skips pagination parameters');
+  });
+
+  await t.test('search parameter produces json_tree clause', () => {
+    const { whereClauses, params } = buildSearchConditions({ search: 'bar' });
+
+    assert.strictEqual(whereClauses.length, 1);
+    assert.ok(whereClauses[0].includes('json_tree'), 'Should use json_tree for search');
+    assert.ok(params[0].includes('bar'), 'Param should contain the search term');
+    console.log('  ✓ search parameter produces json_tree clause');
   });
 
   await t.test('empty value produces no clause', () => {

--- a/packages/mock-server/tests/unit/search-engine-conditions.test.js
+++ b/packages/mock-server/tests/unit/search-engine-conditions.test.js
@@ -1,11 +1,28 @@
 /**
- * Unit tests for buildSearchConditions
- * Tests field filtering logic including special-case parameters like traceid
+ * Unit tests for buildSearchConditions and executeSearch (nested field coverage)
+ * Tests field filtering logic including special-case parameters like traceid,
+ * and verifies that json_tree() actually finds values in nested JSON fields.
  */
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { buildSearchConditions } from '../../src/search-engine.js';
+import Database from 'better-sqlite3';
+import { buildSearchConditions, executeSearch } from '../../src/search-engine.js';
+
+/**
+ * Create a minimal in-memory SQLite database seeded with one record.
+ * @param {Object} resource - The JSON resource to insert
+ * @returns {Database} In-memory database instance
+ */
+function makeDb(resource) {
+  const db = new Database(':memory:');
+  db.prepare('CREATE TABLE resources (id TEXT PRIMARY KEY, data TEXT NOT NULL)').run();
+  db.prepare('INSERT INTO resources (id, data) VALUES (?, ?)').run(
+    resource.id,
+    JSON.stringify(resource)
+  );
+  return db;
+}
 
 test('buildSearchConditions', async (t) => {
 
@@ -88,6 +105,65 @@ test('buildSearchConditions', async (t) => {
     console.log('  ✓ traceid and other filters combine correctly');
   });
 
+});
+
+// ==========================================================================
+// executeSearch — actual SQLite execution with nested JSON
+// Verifies that json_tree() finds values at any nesting depth.
+// ==========================================================================
+
+test('executeSearch — nested field search', async (t) => {
+  const record = {
+    id: 'test-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    name: {
+      firstName: 'Avery',
+      lastName: 'Johnson',
+    },
+    household: {
+      members: [
+        { name: { firstName: 'Morgan', lastName: 'Lee' } },
+      ],
+    },
+    status: 'active',
+  };
+
+  const db = makeDb(record);
+
+  await t.test('search finds value in top-level nested object (name.firstName)', () => {
+    const result = executeSearch(db, { search: 'Avery' }, []);
+    assert.strictEqual(result.total, 1, 'Should find record by nested firstName');
+    assert.strictEqual(result.items[0].id, 'test-1');
+    console.log('  ✓ Finds value in top-level nested object');
+  });
+
+  await t.test('search finds value deep in array of objects (household.members[].name.firstName)', () => {
+    const result = executeSearch(db, { search: 'Morgan' }, []);
+    assert.strictEqual(result.total, 1, 'Should find record by deeply nested firstName');
+    assert.strictEqual(result.items[0].id, 'test-1');
+    console.log('  ✓ Finds value deep in array of objects');
+  });
+
+  await t.test('search is case-insensitive', () => {
+    const result = executeSearch(db, { search: 'avery' }, []);
+    assert.strictEqual(result.total, 1, 'Search should be case-insensitive');
+    console.log('  ✓ Search is case-insensitive');
+  });
+
+  await t.test('search returns no results for non-matching term', () => {
+    const result = executeSearch(db, { search: 'Nonexistent' }, []);
+    assert.strictEqual(result.total, 0, 'Should return no results for non-matching term');
+    console.log('  ✓ Returns no results for non-matching term');
+  });
+
+  await t.test('q full-text finds value in nested field', () => {
+    const result = executeSearch(db, { q: '*Avery*' }, []);
+    assert.strictEqual(result.total, 1, 'q full-text should find nested value');
+    console.log('  ✓ q full-text finds value in nested field');
+  });
+
+  db.close();
 });
 
 console.log('\n✓ All buildSearchConditions tests passed\n');


### PR DESCRIPTION
## Summary

- Replace per-field LIKE queries with `json_tree()` in `search-engine.js` and `query-parser.js`
- The `search` parameter and unqualified `q` terms previously only searched hardcoded `searchableFields` via `json_extract()`, missing values in nested objects not in that list
- `json_tree()` walks all string values in the JSON document at any depth — no field list needed
- Add `executeSearch` integration tests against a real in-memory SQLite database to verify the fix at the query level, not just the SQL structure level

## How to validate

Start the mock server: `npm run mock:start`

Seed a person with a nested name:
```
curl -s -X POST http://localhost:1080/persons \
  -H 'Content-Type: application/json' \
  -d '{"name":{"firstName":"Zephyr","lastName":"Quinn"},"email":"z@example.com"}' | jq '.id'
```

Search by first name (nested field, not a top-level field):
```
curl -s 'http://localhost:1080/platform/search?search=Zephyr' | jq '.total'
# → 1
```

Confirm the result has the right person:
```
curl -s 'http://localhost:1080/platform/search?search=Zephyr' | jq '.items[0].title'
# → "Zephyr Quinn"
```

Before this fix the search would have returned `total: 0` because `name.firstName` is nested inside the `name` object and was not matched by the old per-field LIKE approach.

Also confirm case-insensitivity and a non-matching term returns zero:
```
curl -s 'http://localhost:1080/platform/search?search=zephyr' | jq '.total'
# → 1

curl -s 'http://localhost:1080/platform/search?search=Nonexistent99' | jq '.total'
# → 0
```

Closes #224
