### PR TITLE
Extend rules engine: all-match evaluation, forEach action, collection bindings

### DIFF
--- a/docs/contract-tables/workflow/overview.md
+++ b/docs/contract-tables/workflow/overview.md
@@ -134,13 +134,21 @@ Data sent when calling a trigger endpoint. Required fields must always be includ
 
 Rules are evaluated automatically at key lifecycle moments (on create, on update, and after certain transitions). They determine how tasks are routed and prioritized.
 
+### Task creation
+
+Evaluation strategy: **first-match-wins**
+
+| # | Condition | Action | Fallback |
+|---|-----------|--------|----------|
+| 1 | true | createResource: {"entity":"workflow/tasks","fields":{"taskType":"application_review","name":"Application review","status":"pending","subjectType":"application","subjectId":{"var":"this.subject"}}} | — |
+
 ### Assignment
 
 Evaluation strategy: **first-match-wins**
 
 | # | Condition | Action | Fallback |
 |---|-----------|--------|----------|
-| 1 | application.programs.snap = true | Assign to **snap-intake** queue | Assign to **general-intake** queue |
+| 1 | application.programs.length = 1 and "snap" in application.programs | Assign to **snap-intake** queue | Assign to **general-intake** queue |
 | 2 | true | Assign to **general-intake** queue | — |
 
 ### Priority
@@ -149,7 +157,7 @@ Evaluation strategy: **first-match-wins**
 
 | # | Condition | Action | Fallback |
 |---|-----------|--------|----------|
-| 1 | task.isExpedited = true | Set priority to **expedited** | — |
+| 1 | this.isExpedited = true | Set priority to **expedited** | — |
 | 2 | true | Set priority to **normal** | — |
 
 ---

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "start": "node packages/mock-server/scripts/server.js --spec=packages/contracts",
-    "validate": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts && node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts && node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts",
+    "validate": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts && node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts && node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts && node packages/contracts/scripts/validate-rules.js --spec=packages/contracts",
     "validate:syntax": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts",
     "validate:patterns": "node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts",
     "validate:schemas": "node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts",

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -10,10 +10,10 @@ ruleSets:
     context:
       - as: task
         entity: workflow/tasks
-        from: subject
+        from: {var: "subject"}
       - as: application
         entity: intake/applications
-        from: task.subjectId
+        from: {var: "task.subjectId"}
         optional: true
     rules:
       - id: open-application-on-intake-task-claim

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -10,10 +10,12 @@ ruleSets:
     context:
       - as: task
         entity: workflow/tasks
-        from: {var: "subject"}
+        from:
+          var: subject
       - as: application
         entity: intake/applications
-        from: {var: "task.subjectId"}
+        from:
+          var: task.subjectId
         optional: true
     rules:
       - id: open-application-on-intake-task-claim

--- a/packages/contracts/schemas/rules-schema.yaml
+++ b/packages/contracts/schemas/rules-schema.yaml
@@ -39,19 +39,69 @@ properties:
 
 $defs:
   # ---------------------------------------------------------------------------
-  # Action types — platform-level primitives available to all domains.
-  # Domain-specific actions (assignToQueue, setPriority) are also defined here
-  # so the schema is the single source of truth for what each action expects.
+  # ActionForEach — iterate a collection, execute an inner action per item
+  #
+  # Create an income verification task for each SNAP-enrolled member:
+  # action:
+  #   forEach:
+  #     in: {var: "members"}
+  #     as: member
+  #     filter:
+  #       in: [snap, {var: "member.programs"}]
+  #     createResource:
+  #       entity: workflow/tasks
+  #       fields:
+  #         taskType: income_verification
+  #         subjectType: member
+  #         subjectId: {var: "member.id"}
+  #         applicationId: {var: "application.id"}
+  #         status: pending
   # ---------------------------------------------------------------------------
+  ActionForEach:
+    type: object
+    description: >
+      Iterates over a collection and executes an action for each item that satisfies
+      an optional filter condition. The collection is resolved from the rule context
+      using a JSON Logic expression. The filter is a JSON Logic condition evaluated
+      per item. The inner action (createResource or triggerTransition) executes once
+      per matching item with the item bound to the alias declared in `as`.
+    required: [in, as]
+    properties:
+      in:
+        description: >
+          JSON Logic expression that resolves to the collection to iterate over.
+          Typically references a context alias (e.g., {var: "members"}).
+      as:
+        type: string
+        description: >
+          Alias bound to each item during iteration. Available in filter conditions
+          and inner action field values (e.g., {var: "member.id"}).
+      filter:
+        description: >
+          Optional JSON Logic condition evaluated per item. Only items for which
+          this condition is true will have the inner action executed.
+      createResource:
+        $ref: "#/$defs/ActionCreateResource"
+      triggerTransition:
+        $ref: "#/$defs/ActionTriggerTransition"
+    additionalProperties: false
 
+  # ---------------------------------------------------------------------------
+  # ActionCreateResource — create a new resource with literal or JSON Logic field values
+  #
+  # action:
+  #   createResource:
+  #     entity: workflow/tasks
+  #     fields:
+  #       taskType: application_review
+  #       status: pending
+  #       subjectId: {var: "this.subject"}
+  # ---------------------------------------------------------------------------
   ActionCreateResource:
     type: object
     description: >
-      Creates a new resource in the specified domain/collection. Generic platform
-      action — any domain's rules can use this to create any resource type.
-      Field values may be literals or JSON Logic expressions evaluated against
-      the current rule context (e.g., { var: "this.subject" } to reference the
-      event subject).
+      Creates a new resource in the specified domain/collection. Field values may be
+      literals or JSON Logic expressions evaluated against the current rule context.
     required: [entity, fields]
     properties:
       entity:
@@ -67,12 +117,20 @@ $defs:
         additionalProperties: true
     additionalProperties: false
 
+  # ---------------------------------------------------------------------------
+  # ActionTriggerTransition — trigger a state machine transition on a related entity
+  #
+  # action:
+  #   triggerTransition:
+  #     entity: intake/applications
+  #     idFrom: this.subject
+  #     transition: open
+  # ---------------------------------------------------------------------------
   ActionTriggerTransition:
     type: object
     description: >
-      Triggers a state machine transition on a related entity. Generic platform
-      action — any domain's rules can invoke a transition on any entity type.
-      The entity ID is resolved from the current rule context using idFrom.
+      Triggers a state machine transition on a related entity. The entity ID is
+      resolved from the current rule context using idFrom.
     required: [entity, idFrom, transition]
     properties:
       entity:
@@ -82,45 +140,71 @@ $defs:
       idFrom:
         type: string
         description: >
-          Dot-path in the rule context whose value is the ID of the entity to
-          transition. Examples: "application.id", "this.subjectId".
+          Dot-path in the rule context whose value is the ID of the entity to transition.
       transition:
         type: string
         description: The transition trigger to invoke (e.g., "open", "submit").
     additionalProperties: false
 
   # ---------------------------------------------------------------------------
-  # Context, rule sets, and rules
+  # ContextBinding — declare entities and collections available during rule evaluation
+  #
+  # Entity binding — fetch by ID; entity is domain/resource format:
+  #   context:
+  #     - as: application
+  #       entity: intake/applications    # domain/resource
+  #       from: {var: "subject"}         # JSON Logic expression resolving to the ID
+  #
+  # Collection binding — bind array value directly (no entity lookup):
+  #   context:
+  #     - as: members
+  #       from: {var: "application.members"}
+  #
+  # Optional binding — skip if not found rather than aborting the rule set:
+  #   context:
+  #     - as: profile
+  #       entity: intake/profiles
+  #       from: {var: "application.profileId"}
+  #       optional: true
   # ---------------------------------------------------------------------------
-
   ContextBinding:
     type: object
     description: >
-      Declares a related entity to resolve before rule evaluation. The entity is fetched
-      by ID from the declared source and made available in rule conditions under the given alias.
+      Declares a related entity or collection to resolve before rule evaluation.
+      When `entity` is present, the value resolved by `from` is treated as an ID and
+      the entity is fetched by that ID — made available under the alias for use in
+      rule conditions. When `entity` is absent, the value resolved by `from` is bound
+      directly as the alias (collection binding — used when `from` resolves to an array,
+      e.g., `{var: "application.members"}`).
       The calling resource is always available as "this" — no binding needed.
       For event-triggered rule sets, "this" is the event envelope; from-paths resolve
       against envelope fields (subject, type, source, data, time).
-    required: [as, entity, from]
+    required: [as, from]
     properties:
       as:
         type: string
-        description: Alias used to reference this entity in rule conditions (e.g., "application").
+        description: >
+          Alias used to reference this entity or collection in rule conditions
+          (e.g., "application", "members").
       entity:
         type: string
         pattern: "^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$"
         description: >
           Source entity in domain/resource format (e.g., intake/applications).
+          When present, `from` must resolve to an ID used to fetch this entity.
+          When absent, `from` resolves directly to the bound value (collection binding).
           Must match an API resource path discoverable in the contracts directory.
           Validated by validate-rules.js.
       from:
-        type: string
         description: >
-          Dot-path on "this" (or a previously resolved entity) whose value is the ID
-          to look up. For event-triggered rule sets, resolves against the event envelope
-          (e.g., "subject" resolves to the event's subject field).
-          For on-demand rule sets, resolves against the calling resource schema.
-          Validated against the resource schema by validate-rules.js for on-demand sets.
+          JSON Logic expression or bare dot-path evaluated against the current context
+          to produce the ID (when `entity` is present) or the value (when `entity` is
+          absent) to bind to the alias. Bare dot-paths are shorthand for
+          `{var: "path"}` — both forms are valid, but the JSON Logic form is preferred
+          for consistency with condition expressions.
+        oneOf:
+          - type: string
+          - type: object
       optional:
         type: boolean
         description: >
@@ -130,6 +214,28 @@ $defs:
           Defaults to false — bindings are required unless explicitly marked optional.
     additionalProperties: false
 
+  # ---------------------------------------------------------------------------
+  # RuleSet — a group of rules sharing an evaluation strategy
+  #
+  # On-demand (evaluated when resource is created or transitions state):
+  #   - id: queue-assignment
+  #     ruleType: assignment
+  #     evaluation: first-match-wins
+  #     rules: [...]
+  #
+  # Event-triggered (evaluated when a domain event fires):
+  #   - id: document-checklist
+  #     ruleType: task-creation
+  #     on: intake.application.submitted
+  #     evaluation: all-match
+  #     context:
+  #       - as: application
+  #         entity: intake/applications
+  #         from: {var: "subject"}
+  #       - as: members
+  #         from: {var: "application.members"}
+  #     rules: [...]
+  # ---------------------------------------------------------------------------
   RuleSet:
     type: object
     description: >
@@ -161,13 +267,23 @@ $defs:
         type: string
         enum:
           - first-match-wins
-        description: How rules are evaluated — first match stops.
+          - all-match
+        description: >
+          How rules in this set are evaluated.
+          `first-match-wins` — rules are evaluated in order; the first matching rule
+          fires and evaluation stops. Use for mutually exclusive outcomes (e.g., queue
+          assignment, priority).
+          `all-match` — all rules whose conditions match are fired; evaluation does not
+          stop at the first match. Use when multiple outcomes may apply simultaneously
+          (e.g., generating document checklists where multiple document types may be
+          required).
       context:
         type: array
         description: >
-          Related entities to resolve before evaluating this rule set.
-          Each binding resolves one entity by ID and makes it available under its alias.
-          The calling resource (or event envelope) is always available as "this" without declaration.
+          Entities and collections to resolve before evaluating this rule set.
+          Each binding resolves one entity by ID (when `entity` is present) or binds a
+          collection value directly (when `entity` is absent). The calling resource
+          (or event envelope) is always available as "this" without declaration.
         items:
           $ref: "#/$defs/ContextBinding"
       rules:
@@ -177,6 +293,25 @@ $defs:
         minItems: 1
     additionalProperties: false
 
+  # ---------------------------------------------------------------------------
+  # Rule — a condition/action pair within a rule set
+  #
+  # - id: snap-expedited
+  #   order: 1
+  #   description: Expedite SNAP applications with zero income
+  #   condition:
+  #     and:
+  #       - in: [snap, {var: "application.programs"}]
+  #       - "==": [{var: "application.monthlyIncome"}, 0]
+  #   action:
+  #     setPriority: expedited
+  #
+  # - id: default
+  #   order: 99
+  #   condition: true
+  #   action:
+  #     assignToQueue: general-intake
+  # ---------------------------------------------------------------------------
   Rule:
     type: object
     description: A single rule with a condition and action.
@@ -218,6 +353,8 @@ $defs:
             $ref: "#/$defs/ActionCreateResource"
           triggerTransition:
             $ref: "#/$defs/ActionTriggerTransition"
+          forEach:
+            $ref: "#/$defs/ActionForEach"
         additionalProperties: true
       fallbackAction:
         type: object

--- a/packages/contracts/scripts/export-contract-tables.js
+++ b/packages/contracts/scripts/export-contract-tables.js
@@ -434,7 +434,9 @@ function jsonLogicToFeel(expr) {
     case 'or':  return (Array.isArray(args) ? args : [args]).map(jsonLogicToFeel).join(' or ');
     case 'not': return `not(${jsonLogicToFeel(Array.isArray(args) ? args[0] : args)})`;
     case '!':   return `not(${jsonLogicToFeel(Array.isArray(args) ? args[0] : args)})`;
-    case 'in':  return `${jsonLogicToFeel(args[0])} in [${args[1].map(v => jsonLogicToFeel(v)).join(', ')}]`;
+    case 'in':  return Array.isArray(args[1])
+      ? `${jsonLogicToFeel(args[0])} in [${args[1].map(v => jsonLogicToFeel(v)).join(', ')}]`
+      : `${jsonLogicToFeel(args[0])} in ${jsonLogicToFeel(args[1])}`;
     default: return JSON.stringify(expr);
   }
 }

--- a/packages/contracts/scripts/validate-rules.js
+++ b/packages/contracts/scripts/validate-rules.js
@@ -207,20 +207,34 @@ function validateRulesFile(filePath, rules, resourceIndex) {
     const resolvedSchemas = new Map();
 
     for (const binding of ruleSet.context || []) {
-      if (!binding.as || !binding.entity || !binding.from) continue;
+      if (!binding.as || !binding.from) continue;
 
-      // 1. Validate entity path exists
-      if (!resourceIndex.has(binding.entity)) {
-        errors.push(
-          `${label} ruleSet "${ruleSet.id}": entity "${binding.entity}" does not match any discoverable API resource`
-        );
-      } else {
-        // Register this entity's schema for chaining validation
-        resolvedSchemas.set(binding.as, resourceIndex.get(binding.entity));
+      // Extract dot-path string from from field.
+      // Accepts bare string ("subjectId") or JSON Logic {var: "path"} form.
+      // Complex JSON Logic expressions (non-var) are skipped — no static path to validate.
+      const fromPath = typeof binding.from === 'string'
+        ? binding.from
+        : (typeof binding.from?.var === 'string' ? binding.from.var : null);
+
+      // 1. Validate entity path exists (entity bindings only — collection bindings have no entity)
+      if (binding.entity) {
+        if (!resourceIndex.has(binding.entity)) {
+          errors.push(
+            `${label} ruleSet "${ruleSet.id}": entity "${binding.entity}" does not match any discoverable API resource`
+          );
+        } else {
+          // Register this entity's schema for chaining validation
+          resolvedSchemas.set(binding.as, resourceIndex.get(binding.entity));
+        }
       }
 
-      // 2. Validate from path exists on the calling resource or a previously resolved entity
-      const fromParts = binding.from.split('.');
+      // 2. Validate from path exists on the calling resource or a previously resolved entity.
+      // Skip for:
+      //   - event-triggered rule sets: "this" is the event envelope, not the calling resource schema
+      //   - complex JSON Logic expressions: no static dot-path to validate
+      if (ruleSet.on || fromPath === null) continue;
+
+      const fromParts = fromPath.split('.');
       const fromRoot = fromParts[0];
       const fromField = fromParts.length > 1 ? fromParts.slice(1).join('.') : null;
 
@@ -230,12 +244,12 @@ function validateRulesFile(filePath, rules, resourceIndex) {
         if (!chainSchema) {
           errors.push(
             `${label} ruleSet "${ruleSet.id}" binding "${binding.as}": ` +
-            `"from" path "${binding.from}" references "${fromRoot}" which is not a previously resolved entity alias`
+            `"from" path "${fromPath}" references "${fromRoot}" which is not a previously resolved entity alias`
           );
         } else if (chainSchema.size > 0 && !chainSchema.has(fromField)) {
           errors.push(
             `${label} ruleSet "${ruleSet.id}" binding "${binding.as}": ` +
-            `"from" path "${binding.from}" — field "${fromField}" not found on "${fromRoot}" schema`
+            `"from" path "${fromPath}" — field "${fromField}" not found on "${fromRoot}" schema`
           );
         }
       } else {

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -10,7 +10,7 @@ ruleSets:
     context:
       - as: application
         entity: intake/applications
-        from: subject
+        from: {var: "subject"}
     rules:
       - id: create-intake-review-task
         order: 1
@@ -32,7 +32,7 @@ ruleSets:
     context:
       - as: application
         entity: intake/applications
-        from: subjectId
+        from: {var: "subjectId"}
         optional: true
     rules:
       - id: snap-only-to-snap-queue

--- a/packages/contracts/workflow-rules.yaml
+++ b/packages/contracts/workflow-rules.yaml
@@ -10,7 +10,8 @@ ruleSets:
     context:
       - as: application
         entity: intake/applications
-        from: {var: "subject"}
+        from:
+          var: subject
     rules:
       - id: create-intake-review-task
         order: 1
@@ -32,7 +33,8 @@ ruleSets:
     context:
       - as: application
         entity: intake/applications
-        from: {var: "subjectId"}
+        from:
+          var: subjectId
         optional: true
     rules:
       - id: snap-only-to-snap-queue

--- a/packages/mock-server/src/event-subscription.js
+++ b/packages/mock-server/src/event-subscription.js
@@ -13,7 +13,7 @@
 
 import { eventBus } from './event-bus.js';
 import { create, update, findAll } from './database-manager.js';
-import { buildRuleContext, evaluateRuleSet, resolvePath } from './rules-engine.js';
+import { buildRuleContext, evaluateRuleSet, evaluateAllMatchRuleSet, resolvePath } from './rules-engine.js';
 import { resolveContextEntities } from './handlers/rule-evaluation.js';
 import { executeActions } from './action-handlers.js';
 import { executeTransition } from './state-machine-runner.js';
@@ -133,15 +133,20 @@ export function registerEventSubscriptions(allRules, allStateMachines, allSlaTyp
         // Build rule context: this = event envelope, plus resolved entities
         const ruleContext = buildRuleContext(event, resolvedEntities);
 
-        // Evaluate rules
-        const result = evaluateRuleSet(ruleSet, ruleContext);
-        if (!result.matched) continue;
-
         // Build rich deps for platform actions
         const deps = buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes);
 
-        // Execute actions
-        executeActions(result.action, event, deps, result.fallbackAction);
+        // Evaluate rules and execute actions
+        if (ruleSet.evaluation === 'all-match') {
+          const results = evaluateAllMatchRuleSet(ruleSet, ruleContext);
+          for (const result of results) {
+            executeActions(result.action, event, deps, result.fallbackAction);
+          }
+        } else {
+          const result = evaluateRuleSet(ruleSet, ruleContext);
+          if (!result.matched) continue;
+          executeActions(result.action, event, deps, result.fallbackAction);
+        }
       } catch (e) {
         console.error(`Event subscription "${ruleSet.id}" failed for event "${event.type}":`, e.message);
       }

--- a/packages/mock-server/src/handlers/rule-evaluation.js
+++ b/packages/mock-server/src/handlers/rule-evaluation.js
@@ -5,7 +5,7 @@
 
 import { findAll, findById } from '../database-manager.js';
 import { findRuleSet } from '../rules-loader.js';
-import { buildRuleContext, evaluateRuleSet, resolvePath } from '../rules-engine.js';
+import { buildRuleContext, evaluateRuleSet, evaluateAllMatchRuleSet, resolvePath } from '../rules-engine.js';
 import { executeActions } from '../action-handlers.js';
 
 /**
@@ -39,43 +39,71 @@ export function resolveContextEntities(contextBindings, resource) {
   const resolved = {};
 
   for (const binding of contextBindings || []) {
-    if (typeof binding !== 'object' || !binding.as || !binding.entity || !binding.from) continue;
+    if (typeof binding !== 'object' || !binding.as || !binding.from) continue;
 
-    // Parse domain/resource format — collection name is the last path segment
-    const collectionName = binding.entity.split('/').pop();
+    // Extract dot-path from from field (string or JSON Logic {var: "path"} form)
+    const fromPath = typeof binding.from === 'string'
+      ? binding.from
+      : (typeof binding.from?.var === 'string' ? binding.from.var : null);
+
+    if (fromPath === null) {
+      console.warn(`Context binding "${binding.as}": complex JSON Logic "from" is not supported — skipping binding`);
+      continue;
+    }
 
     // Resolve the from path against resource fields + previously resolved entities (chaining)
     const lookupContext = { ...resource, ...resolved };
-    const entityId = resolvePath(lookupContext, binding.from);
+    const fromValue = resolvePath(lookupContext, fromPath);
 
-    if (!entityId) {
-      if (binding.optional) {
-        console.warn(
-          `Context binding "${binding.as}": "${binding.from}" resolved to no value — skipping binding (optional)`
+    if (binding.entity) {
+      // Entity binding — fromValue is an ID; fetch the entity by that ID
+      const collectionName = binding.entity.split('/').pop();
+
+      if (!fromValue) {
+        if (binding.optional) {
+          console.warn(
+            `Context binding "${binding.as}": "${fromPath}" resolved to no value — skipping binding (optional)`
+          );
+          continue;
+        }
+        console.error(
+          `Context binding "${binding.as}": "${fromPath}" resolved to no value — skipping rule set`
         );
-        continue;
+        return null;
       }
-      console.error(
-        `Context binding "${binding.as}": "${binding.from}" resolved to no value — skipping rule set`
-      );
-      return null;
-    }
 
-    const entity = findById(collectionName, entityId);
-    if (!entity) {
-      if (binding.optional) {
-        console.warn(
-          `Context binding "${binding.as}": "${binding.entity}" with id "${entityId}" not found — skipping binding (optional)`
+      const entity = findById(collectionName, fromValue);
+      if (!entity) {
+        if (binding.optional) {
+          console.warn(
+            `Context binding "${binding.as}": "${binding.entity}" with id "${fromValue}" not found — skipping binding (optional)`
+          );
+          continue;
+        }
+        console.error(
+          `Context binding "${binding.as}": "${binding.entity}" with id "${fromValue}" not found — skipping rule set`
         );
-        continue;
+        return null;
       }
-      console.error(
-        `Context binding "${binding.as}": "${binding.entity}" with id "${entityId}" not found — skipping rule set`
-      );
-      return null;
-    }
 
-    resolved[binding.as] = entity;
+      resolved[binding.as] = entity;
+    } else {
+      // Collection binding — fromValue is bound directly (no entity lookup)
+      if (fromValue === undefined || fromValue === null) {
+        if (binding.optional) {
+          console.warn(
+            `Context binding "${binding.as}": "${fromPath}" resolved to no value — skipping binding (optional)`
+          );
+          continue;
+        }
+        console.error(
+          `Context binding "${binding.as}": "${fromPath}" resolved to no value — skipping rule set`
+        );
+        return null;
+      }
+
+      resolved[binding.as] = fromValue;
+    }
   }
 
   return resolved;
@@ -103,10 +131,17 @@ export function processRuleEvaluations(pendingRuleEvaluations, resource, rules, 
     if (resolvedEntities === null) continue; // required entity not found — skip rule set
 
     const contextData = buildRuleContext(resource, resolvedEntities);
-    const result = evaluateRuleSet(ruleSet, contextData);
 
-    if (result.matched) {
-      executeActions(result.action, resource, deps, result.fallbackAction);
+    if (ruleSet.evaluation === 'all-match') {
+      const results = evaluateAllMatchRuleSet(ruleSet, contextData);
+      for (const result of results) {
+        executeActions(result.action, resource, deps, result.fallbackAction);
+      }
+    } else {
+      const result = evaluateRuleSet(ruleSet, contextData);
+      if (result.matched) {
+        executeActions(result.action, resource, deps, result.fallbackAction);
+      }
     }
   }
 }

--- a/packages/mock-server/src/platform-action-handlers.js
+++ b/packages/mock-server/src/platform-action-handlers.js
@@ -152,7 +152,72 @@ function triggerTransition(actionValue, resource, deps) {
   }
 }
 
+/**
+ * Iterate over a collection and execute an inner action for each item that
+ * satisfies an optional filter condition. The item is bound to `as` in the
+ * rule context for both the filter and the inner action's field resolution.
+ *
+ * @param {Object} actionValue - { in: <JSON Logic>, as: string, filter?: <JSON Logic>,
+ *                                  createResource?: {...}, triggerTransition?: {...} }
+ * @param {Object} resource    - The current "this" context
+ * @param {Object} deps        - Same deps as createResource/triggerTransition
+ */
+function forEach(actionValue, resource, deps) {
+  const { in: inExpr, as: alias, filter, createResource: crValue, triggerTransition: ttValue } = actionValue || {};
+
+  if (!inExpr || !alias) {
+    console.error('forEach: missing required fields "in" or "as"');
+    return;
+  }
+
+  if (!crValue && !ttValue) {
+    console.error('forEach: missing inner action (createResource or triggerTransition)');
+    return;
+  }
+
+  // Resolve the collection from the rule context
+  const ctx = deps.context || {};
+  let collection;
+  try {
+    collection = jsonLogic.apply(inExpr, ctx);
+  } catch (err) {
+    console.error(`forEach: failed to resolve "in" expression: ${err.message}`);
+    return;
+  }
+
+  if (!Array.isArray(collection)) {
+    console.warn(`forEach: "in" expression resolved to a non-array value — skipping`);
+    return;
+  }
+
+  for (const item of collection) {
+    // Bind the item to the alias in the context for filter and field resolution
+    const itemCtx = { ...ctx, [alias]: item };
+
+    // Apply per-item filter if present
+    if (filter !== undefined) {
+      let matches;
+      try {
+        matches = jsonLogic.apply(filter, itemCtx);
+      } catch (err) {
+        console.warn(`forEach: filter evaluation failed for item: ${err.message}`);
+        continue;
+      }
+      if (!matches) continue;
+    }
+
+    // Execute the inner action with item-scoped context
+    const itemDeps = { ...deps, context: itemCtx };
+    if (crValue) {
+      createResource(crValue, resource, itemDeps);
+    } else if (ttValue) {
+      triggerTransition(ttValue, resource, itemDeps);
+    }
+  }
+}
+
 export const platformActionRegistry = new Map([
   ['createResource', createResource],
-  ['triggerTransition', triggerTransition]
+  ['triggerTransition', triggerTransition],
+  ['forEach', forEach]
 ]);

--- a/packages/mock-server/src/rules-engine.js
+++ b/packages/mock-server/src/rules-engine.js
@@ -38,17 +38,14 @@ export function evaluateRuleSet(ruleSet, contextData) {
     return { matched: false };
   }
 
-  // Sort rules by order to ensure correct evaluation sequence
   const sortedRules = [...ruleSet.rules].sort((a, b) => a.order - b.order);
 
   for (const rule of sortedRules) {
     let conditionMet = false;
 
     if (rule.condition === true) {
-      // Catch-all rule — always matches
       conditionMet = true;
     } else {
-      // Evaluate JSON Logic condition
       try {
         conditionMet = jsonLogic.apply(rule.condition, contextData);
       } catch (err) {
@@ -68,4 +65,43 @@ export function evaluateRuleSet(ruleSet, contextData) {
   }
 
   return { matched: false };
+}
+
+/**
+ * Evaluate a ruleSet against context data. Uses all-match semantics —
+ * all rules whose conditions match are collected and returned.
+ * @param {Object} ruleSet - RuleSet definition with rules array
+ * @param {Object} contextData - Context object built by buildRuleContext
+ * @returns {Array<{ ruleId: string, action: Object, fallbackAction: Object|null }>}
+ */
+export function evaluateAllMatchRuleSet(ruleSet, contextData) {
+  if (!ruleSet || !ruleSet.rules) return [];
+
+  const sortedRules = [...ruleSet.rules].sort((a, b) => a.order - b.order);
+  const matched = [];
+
+  for (const rule of sortedRules) {
+    let conditionMet = false;
+
+    if (rule.condition === true) {
+      conditionMet = true;
+    } else {
+      try {
+        conditionMet = jsonLogic.apply(rule.condition, contextData);
+      } catch (err) {
+        console.warn(`Rule "${rule.id}" condition evaluation failed: ${err.message}`);
+        continue;
+      }
+    }
+
+    if (conditionMet) {
+      matched.push({
+        ruleId: rule.id,
+        action: rule.action,
+        fallbackAction: rule.fallbackAction || null
+      });
+    }
+  }
+
+  return matched;
 }

--- a/packages/mock-server/tests/unit/action-handlers.test.js
+++ b/packages/mock-server/tests/unit/action-handlers.test.js
@@ -95,3 +95,87 @@ test('executeActions — skips unknown action types', () => {
   executeActions({ unknownAction: 'value' }, resource, {});
   assert.strictEqual(Object.keys(resource).length, 0);
 });
+
+// =============================================================================
+// forEach
+// =============================================================================
+
+function makeForEachDeps(created) {
+  return {
+    context: {
+      this: { id: 'event-1' },
+      members: [
+        { id: 'member-1', programs: ['snap'] },
+        { id: 'member-2', programs: ['medicaid'] }
+      ]
+    },
+    dbCreate(collection, fields) {
+      const record = { id: `new-${created.length}`, ...fields };
+      created.push({ collection, fields: { ...fields } });
+      return record;
+    },
+    dbUpdate() {},
+    findStateMachine: () => null,
+    emitCreatedEvent: () => {}
+  };
+}
+
+test('executeActions — forEach creates resource for each item in collection', () => {
+  const created = [];
+  executeActions(
+    {
+      forEach: {
+        in: { var: 'members' },
+        as: 'member',
+        createResource: {
+          entity: 'workflow/tasks',
+          fields: { memberId: { var: 'member.id' }, status: 'pending' }
+        }
+      }
+    },
+    {},
+    makeForEachDeps(created)
+  );
+  assert.strictEqual(created.length, 2);
+  assert.strictEqual(created[0].fields.memberId, 'member-1');
+  assert.strictEqual(created[1].fields.memberId, 'member-2');
+});
+
+test('executeActions — forEach filter excludes non-matching items', () => {
+  const created = [];
+  executeActions(
+    {
+      forEach: {
+        in: { var: 'members' },
+        as: 'member',
+        filter: { in: ['snap', { var: 'member.programs' }] },
+        createResource: {
+          entity: 'workflow/tasks',
+          fields: { memberId: { var: 'member.id' }, status: 'pending' }
+        }
+      }
+    },
+    {},
+    makeForEachDeps(created)
+  );
+  // Only member-1 has snap
+  assert.strictEqual(created.length, 1);
+  assert.strictEqual(created[0].fields.memberId, 'member-1');
+});
+
+test('executeActions — forEach with empty collection executes no actions', () => {
+  const created = [];
+  const deps = { ...makeForEachDeps(created), context: { this: {}, members: [] } };
+  executeActions(
+    {
+      forEach: {
+        in: { var: 'members' },
+        as: 'member',
+        createResource: { entity: 'workflow/tasks', fields: { memberId: { var: 'member.id' } } }
+      }
+    },
+    {},
+    deps
+  );
+  assert.strictEqual(created.length, 0);
+});

--- a/packages/mock-server/tests/unit/rule-evaluation.test.js
+++ b/packages/mock-server/tests/unit/rule-evaluation.test.js
@@ -213,3 +213,128 @@ test('processRuleEvaluations — calling resource fields accessible as "this.*" 
   processRuleEvaluations([{ ruleType: 'assignment' }], task, rules, 'workflow');
   assert.strictEqual(task.queueId, 'q-snap'); // isExpedited true → snap-intake
 });
+
+// =============================================================================
+// JSON Logic from: form — {var: "path"} accepted alongside bare string
+// =============================================================================
+
+test('processRuleEvaluations — JSON Logic {var: "..."} from: resolves entity correctly', () => {
+  clearAll('applications');
+  clearAll('tasks');
+  seedQueues();
+
+  insertResource('applications', { id: 'app-1', programs: ['snap'] });
+  const task = { id: 'task-1', subjectId: 'app-1', queueId: null };
+
+  const rules = makeRules(
+    [{ as: 'application', entity: 'intake/applications', from: { var: 'subjectId' } }],
+    { in: ['snap', { var: 'application.programs' }] },
+    { assignToQueue: 'snap-intake' }
+  );
+
+  processRuleEvaluations([{ ruleType: 'assignment' }], task, rules, 'workflow');
+  assert.strictEqual(task.queueId, 'q-snap');
+});
+
+// =============================================================================
+// Collection binding — entity absent, from resolves to a value bound directly
+// =============================================================================
+
+test('processRuleEvaluations — collection binding binds array value without entity lookup', () => {
+  clearAll('tasks');
+  seedQueues();
+
+  // members is an embedded array on the task — no separate entity to fetch
+  const task = {
+    id: 'task-1',
+    members: [{ id: 'm-1', programs: ['snap'] }, { id: 'm-2', programs: ['medicaid'] }],
+    queueId: null
+  };
+
+  const rules = [
+    {
+      domain: 'workflow',
+      ruleSets: [
+        {
+          id: 'test-collection-binding',
+          ruleType: 'assignment',
+          evaluation: 'first-match-wins',
+          context: [{ as: 'members', from: { var: 'members' } }],
+          rules: [
+            {
+              id: 'has-snap-member',
+              order: 1,
+              condition: { some: [{ var: 'members' }, { in: ['snap', { var: 'programs' }] }] },
+              action: { assignToQueue: 'snap-intake' }
+            },
+            { id: 'catch-all', order: 2, condition: true, action: { assignToQueue: 'general-intake' } }
+          ]
+        }
+      ]
+    }
+  ];
+
+  processRuleEvaluations([{ ruleType: 'assignment' }], task, rules, 'workflow');
+  assert.strictEqual(task.queueId, 'q-snap');
+});
+
+// =============================================================================
+// all-match evaluation — all matching rules fire
+// =============================================================================
+
+test('processRuleEvaluations — all-match fires all matching rules', () => {
+  clearAll('tasks');
+
+  // Both snap and medicaid rules match. With all-match, both fire in order —
+  // rule 2 overwrites rule 1 so final priority is 'high'.
+  const task = { id: 'task-1', programs: ['snap', 'medicaid'], priority: null };
+
+  const rules = [
+    {
+      domain: 'workflow',
+      ruleSets: [
+        {
+          id: 'test-all-match',
+          ruleType: 'priority',
+          evaluation: 'all-match',
+          rules: [
+            { id: 'snap-rule', order: 1, condition: { in: ['snap', { var: 'this.programs' }] }, action: { setPriority: 'expedited' } },
+            { id: 'medicaid-rule', order: 2, condition: { in: ['medicaid', { var: 'this.programs' }] }, action: { setPriority: 'high' } }
+          ]
+        }
+      ]
+    }
+  ];
+
+  processRuleEvaluations([{ ruleType: 'priority' }], task, rules, 'workflow');
+  // Both rules fired: expedited then high → final value is 'high'
+  assert.strictEqual(task.priority, 'high');
+});
+
+test('processRuleEvaluations — first-match-wins stops at first matching rule', () => {
+  clearAll('tasks');
+
+  // Same rules as above, but first-match-wins: only rule 1 fires → 'expedited'
+  const task = { id: 'task-1', programs: ['snap', 'medicaid'], priority: null };
+
+  const rules = [
+    {
+      domain: 'workflow',
+      ruleSets: [
+        {
+          id: 'test-first-match',
+          ruleType: 'priority',
+          evaluation: 'first-match-wins',
+          rules: [
+            { id: 'snap-rule', order: 1, condition: { in: ['snap', { var: 'this.programs' }] }, action: { setPriority: 'expedited' } },
+            { id: 'medicaid-rule', order: 2, condition: { in: ['medicaid', { var: 'this.programs' }] }, action: { setPriority: 'high' } }
+          ]
+        }
+      ]
+    }
+  ];
+
+  processRuleEvaluations([{ ruleType: 'priority' }], task, rules, 'workflow');
+  // Only snap-rule fired → 'expedited'
+  assert.strictEqual(task.priority, 'expedited');
+});

--- a/packages/mock-server/tests/unit/rules-engine.test.js
+++ b/packages/mock-server/tests/unit/rules-engine.test.js
@@ -5,7 +5,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { evaluateRuleSet, buildRuleContext, resolvePath } from '../../src/rules-engine.js';
+import { evaluateRuleSet, evaluateAllMatchRuleSet, buildRuleContext, resolvePath } from '../../src/rules-engine.js';
 
 // =============================================================================
 // resolvePath
@@ -181,6 +181,59 @@ test('evaluateRuleSet — handles null/empty ruleSet', () => {
   assert.deepStrictEqual(evaluateRuleSet({}, {}), { matched: false });
   assert.deepStrictEqual(evaluateRuleSet({ rules: [] }, {}), { matched: false });
 });
+
+// =============================================================================
+// evaluateAllMatchRuleSet
+// =============================================================================
+
+test('evaluateAllMatchRuleSet — returns all matching rules, not just first', () => {
+  const ruleSet = {
+    rules: [
+      { id: 'snap-doc', order: 1, condition: { in: ['snap', { var: 'application.programs' }] }, action: { setPriority: 'expedited' } },
+      { id: 'medicaid-doc', order: 2, condition: { in: ['medicaid', { var: 'application.programs' }] }, action: { setPriority: 'high' } },
+      { id: 'no-match', order: 3, condition: { '==': [1, 2] }, action: { setPriority: 'low' } }
+    ]
+  };
+  const context = buildRuleContext({}, { application: { programs: ['snap', 'medicaid'] } });
+  const results = evaluateAllMatchRuleSet(ruleSet, context);
+  assert.strictEqual(results.length, 2);
+  assert.strictEqual(results[0].ruleId, 'snap-doc');
+  assert.strictEqual(results[1].ruleId, 'medicaid-doc');
+});
+
+test('evaluateAllMatchRuleSet — returns empty array when no rules match', () => {
+  const ruleSet = {
+    rules: [
+      { id: 'snap-doc', order: 1, condition: { in: ['snap', { var: 'application.programs' }] }, action: {} }
+    ]
+  };
+  const context = buildRuleContext({}, { application: { programs: ['medicaid'] } });
+  assert.deepStrictEqual(evaluateAllMatchRuleSet(ruleSet, context), []);
+});
+
+test('evaluateAllMatchRuleSet — handles null/empty ruleSet', () => {
+  assert.deepStrictEqual(evaluateAllMatchRuleSet(null, {}), []);
+  assert.deepStrictEqual(evaluateAllMatchRuleSet({}, {}), []);
+  assert.deepStrictEqual(evaluateAllMatchRuleSet({ rules: [] }, {}), []);
+});
+
+test('evaluateAllMatchRuleSet — catch-all with condition: true matches alongside specific rules', () => {
+  const ruleSet = {
+    rules: [
+      { id: 'snap-rule', order: 1, condition: { in: ['snap', { var: 'application.programs' }] }, action: { setPriority: 'expedited' } },
+      { id: 'catch-all', order: 2, condition: true, action: { setPriority: 'normal' } }
+    ]
+  };
+  const context = buildRuleContext({}, { application: { programs: ['snap'] } });
+  const results = evaluateAllMatchRuleSet(ruleSet, context);
+  assert.strictEqual(results.length, 2);
+  assert.strictEqual(results[0].ruleId, 'snap-rule');
+  assert.strictEqual(results[1].ruleId, 'catch-all');
+});
+
+// =============================================================================
+// evaluateRuleSet — boolean equality with isExpedited via "this"
+// =============================================================================
 
 test('evaluateRuleSet — boolean equality with isExpedited via "this"', () => {
   const ruleSet = {


### PR DESCRIPTION
Closes #234

## Summary
- **Schema**: Add `all-match` to `RuleSet.evaluation` enum; add `forEach:` action with `in`/`as`/`filter` and nested `createResource`/`triggerTransition`; make `entity:` optional in `ContextBinding` for collection bindings; expand `from:` to accept JSON Logic `{var: "path"}` form alongside bare strings; add usage comment blocks before each `$def`
- **Validation**: Update `validate-rules.js` to handle JSON Logic `from:`, skip entity check for collection bindings, skip `from`-path validation for event-triggered rule sets; add `validate-rules.js` to `npm run validate`
- **Rules engine**: Add `evaluateAllMatchRuleSet`; update `resolveContextEntities` for JSON Logic `from:` and collection bindings; dispatch by `ruleSet.evaluation` in both `processRuleEvaluations` and event subscriptions
- **Action handlers**: Add `forEach` to platform registry — resolves collection, applies per-item filter, executes inner action with item bound to alias
- **Tests**: 11 new tests covering `evaluateAllMatchRuleSet`, `forEach`, collection bindings, and JSON Logic `from:` form
- **Bugfix**: Fix `export-contract-tables.js` crash when `in` operator's second arg is a `{var: "..."}` expression rather than a literal array

## Notes for reviewer
This branch is based on `feat/cross-domain-event-wiring` (PR #225), not `main` — the `on:` field in `RuleSet` comes from that branch. Merge #225 first.

Validation steps are in the issue.