### PR TITLE
Rename field "gender" to "sex" to reflect what it refers to (marker on gov documents)

### DIFF
--- a/docs/architecture/domains/intake.md
+++ b/docs/architecture/domains/intake.md
@@ -100,7 +100,7 @@ A person linked to an application. May be the primary applicant, a household mem
 
 SNAP requires all household members to be listed regardless of whether they are individually applying (7 CFR § 273.1).
 
-**Key fields:** `firstName`, `lastName`, `dateOfBirth`, `gender`, `SSN`, `relationship`, `roles`, `programsApplyingFor`, `resolvedPersonId`
+**Key fields:** `firstName`, `lastName`, `dateOfBirth`, `sex`, `SSN`, `relationship`, `roles`, `programsApplyingFor`, `resolvedPersonId`
 
 See [Decision 1](#decision-1-role-vs-relationship-on-applicationmember), [Decision 2](#decision-2-programs-applied-for--placement), [Decision 4](#decision-4-authorized-representative--modeling), [Decision 10](#decision-10-person-identity-matching).
 

--- a/docs/guides/state-overlays.md
+++ b/docs/guides/state-overlays.md
@@ -44,7 +44,7 @@ info:
 
 actions:
   # Replace enum values
-  - target: $.Person.properties.gender.enum
+  - target: $.Person.properties.sex.enum
     description: California Gender Recognition Act compliance
     update:
       - male
@@ -416,7 +416,7 @@ All commands below respect the `STATE` environment variable. When set, they auto
 Always include a `description` for each action:
 
 ```yaml
-- target: $.Person.properties.gender.enum
+- target: $.Person.properties.sex.enum
   description: California Gender Recognition Act compliance  # Good
   update: [...]
 ```

--- a/packages/mock-server/tests/unit/overlay-resolver.test.js
+++ b/packages/mock-server/tests/unit/overlay-resolver.test.js
@@ -779,7 +779,7 @@ test('Overlay Resolver Tests', async (t) => {
     const file1 = {
       Person: {
         properties: {
-          gender: {
+          sex: {
             type: 'string',
             enum: ['male', 'female']
           }
@@ -793,7 +793,7 @@ test('Overlay Resolver Tests', async (t) => {
       }
     };
 
-    const target = '$.Person.properties.gender.enum';
+    const target = '$.Person.properties.sex.enum';
     const result1 = checkPathExists(file1, target);
     const result2 = checkPathExists(file2, target);
 


### PR DESCRIPTION
The federal (and most state) governments uses the term "sex" on official documents (passport, drivers license, birth certificate). That is the term to which safety net applications refer, as it is used only for identify verification relative to gov documents.

While some states (e.g. California) have passed laws like California Gender Recognition Act, they refer to the words "sex identifier" on birth certificates and identity cards.