### PR TITLE
Bump versions for 1.3.0 release

### DIFF
--- a/packages/clients/CHANGELOG.md
+++ b/packages/clients/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-04
+
+### Changed
+
+- TypeScript client generator now skips OpenAPI specs marked `x-status: deprecated`. Deprecated specs were previously included in generated clients and Zod artifacts even when retired, producing unnecessary surface area for consumers.
+
 ## [1.1.1] - 2026-03-17
 
 ### Fixed

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/safety-net-blueprint-clients",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Generated API clients and collections for Safety Net APIs",
   "type": "module",
   "files": [

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-04
+
+### Added
+
+- **Intake domain** (`intake-openapi.yaml`, `intake-state-machine.yaml`, `intake-rules.yaml`): Application lifecycle (draft → submitted → under_review → withdrawn/closed), `complete-review` trigger emitting `application.review_completed`, sub-resource paths for `ApplicationDocument` (`/applications/{id}/documents`) and `Interview` (`/applications/{id}/interview`), and `intake-application-document-state-machine.yaml` (requested → verified)
+- **CloudEvents 1.0 envelope** for all domain events: `specversion`, `type`, `source`, `subject`, `time`, `datacontenttype`. Type derivation: `org.codeforamerica.safety-net-blueprint.{domain}.{object}.{action}`
+- **CloudEvents Auth Context extension**: `authid` and `authtype` envelope attributes for event actor provenance (required for FTI-governed events per IRS Pub. 1075)
+- **Distributed tracing contract**: `traceparent` propagation from inbound requests to all emitted events; documented in `inter-domain-communication.md` and `api-patterns.yaml`
+- **Cross-domain event wiring**: `on:` field on rule sets makes them event-triggered; new platform action types `createResource` and `triggerTransition` defined as named `$defs` in `rules-schema.yaml`
+- **Rules engine extensions**: `all-match` evaluation alongside `first-match-wins`; `forEach` action with `in`/`as`/`filter` for per-collection-item iteration; `appendToArray` action; collection context bindings; JSON Logic `{var: "..."}` form for context binding `from:` paths
+- **Context enrichment for rules**: per-ruleSet context bindings with `domain/resource` entity format, `this` alias for the calling resource, multi-hop chaining via `from`, `optional: true` flag for non-required bindings
+- **`workflow-config.yaml`**: queue catalog (`snap-intake`, `general-intake`) with stable UUIDs, schema-validated via `workflow-config-schema.yaml` extending generic `schemas/config-schema.yaml`. Config-managed resources get `source: system` and reject DELETE with 409 `CONFIG_MANAGED`
+- **Generic platform actions documented**: `ActionCreateResource`, `ActionTriggerTransition`, `ActionForEach`, `ActionAppendToArray` as reusable `$defs`
+- **`taskType` field** on Task schema (open string, used for routing rules and lifecycle branches)
+- **`evidence` array** on `ApplicationDocument` (populated when `document-management.document.verified` fires)
+- **`x-data-classification`** convention for marking PII/FTI/PHI fields
+- **`x-environments`** extension for filtering specs by deployment environment
+- **`x-domain`, `x-status`, `x-visibility`** required info-block fields documented in `required_info_fields` pattern
+- **`enum_extensibility` pattern**: domain values use enums with overlay extension, not open strings
+- **Sub-resource path patterns** in `api-patterns.yaml`: collection (`/parents/{id}/children`) and singleton (`/parents/{id}/child`) conventions
+- **`validate-rules.js`**: static cross-reference validator checking entity paths against discoverable API resources and `from` fields against calling-resource schemas; added to `npm run validate`
+- **Data Exchange domain design** (`docs/architecture/domains/data-exchange.md`): facade pattern, ExternalService catalog + ExternalServiceCall lifecycle, 13 design decisions; external service reference docs for IRS, SSA, USCIS SAVE, CMS FDSH, state wage records
+- **Identity & Access architecture record** (`docs/architecture/cross-cutting/identity-access.md`): three-layer auth model (IdP → User Service → Domain APIs), OAuth scope granularity, service-to-service auth, API security declarations
+- **`api:new` `--domain` flag** (defaults to `--name`) and required info-field scaffolding
+
+### Changed
+
+- **`api-patterns.yaml`**: added `auto_emit`, `traceparent`, `x_data_classification`, `enum_extensibility`, `required_info_fields`, `cloudevents_envelope`, `x_extensions` catalog, sub-resource path patterns, `config_managed_resources`
+- **Workflow state machine**: removed `type: event, action: created` from `onCreate` (now auto-emitted by create handler); added `data.assignedToId` to claim event
+- **`TaskCreatedEvent`**: now `$ref` Task schema (full snapshot in event payload)
+- **`TaskClaimedEvent`**: gained required `assignedToId` field
+- **Components events.yaml**: `DomainEvent` replaced with `FieldChange`, `ResourceUpdatedEvent`, `ResourceDeletedEvent` shared schemas (used by all domains)
+- **Workflow rules**: SNAP-only routing now requires `programs.length === 1` (multi-program apps fall through to general-intake)
+- **Rules schema**: `ruleType` is optional on event-triggered rule sets; `entity` is optional on context bindings (collection bindings); usage-example comment blocks before each `$def`
+- **Documentation reorganization**: `state-overlays.md` → `overlay-guide.md`, `state-setup-guide.md` → `setup-guide.md`; `creating-apis.md` rewritten and trimmed (-409 lines); resolver pipeline doc gains stages 5 (`x-environments` filtering) and 6 (placeholder substitution)
+
+### Removed
+
+- **`x-api-type`** extension (superseded by contract-driven architecture); removed from `applications`, `households`, `incomes`, `persons`, `users` specs
+- **`applications-openapi.yaml`** marked `x-status: deprecated`; excluded from mock, validator, and pattern checks (replaced by intake-openapi.yaml)
+- **`onCreate` event effect** from workflow state machine (events now auto-emitted from create handler)
+
+### Fixed
+
+- **Rule evaluation results not persisting on task create**: before-snapshot was captured after `processRuleEvaluations` mutated the resource, making the diff always empty; rule-driven fields (`priority`, `queueId`) are now persisted correctly
+- **`resolve.js`**: skips deprecated specs (`x-status: deprecated`) before parsing; type-guards `x-enum-source` to handle non-string values without crashing
+- **`export-contract-tables.js`**: handles JSON Logic `in` operator with `{var: "..."}` second argument (was crashing on `.map is not a function`)
+
 ## [1.2.0] - 2026-03-17
 
 ### Added

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/safety-net-blueprint-contracts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Behavioral contracts, OpenAPI specs, validation, and overlay resolution for Safety Net APIs",
   "type": "module",
   "files": [

--- a/packages/explorer/CHANGELOG.md
+++ b/packages/explorer/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to `@codeforamerica/safety-net-blueprint-explorer` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Note:** This package is not currently published to npm. Versions are tracked for internal release coordination and may begin shipping to npm in a future release.
+
+## [Unreleased]
+
+## [1.3.0] - 2026-05-04
+
+### Added
+
+- **Initial workspace package release.** Promotes `packages/explorer` (renamed from `packages/design`) to a proper workspace package with `package.json`, build scripts (`build`, `build:context-map`, `build:service-blueprints`), and dependencies (`ajv`, `js-yaml`, optional `puppeteer` and `jszip` for PNG export)
+- **Context map** (`context-map/`): interactive HTML diagram of bounded contexts and event-driven relationships (DDD Context Map pattern). Overview shows 11 domains color-coded by design status with a cross-cutting concerns banner. Click a domain to drill into a centered detail view with all partner domains and event/API inventories on each connection. Build pipeline: render fragments → assemble HTML → scan gaps → export PNGs and zip
+- **Service blueprints** (`service-blueprints/`): generates service blueprint diagrams from blueprint contract data. Outputs both a Figma plugin (`figma-plugin/dist/`) and an SVG file (`output/<domain>.svg`) from the same blueprint data. Includes a baseline intake blueprint with 5-phase swim-lane structure (caseworker content, design notes, system row, SNAP/Medicaid differentiated in determination phase)
+- **Project palette applied to context map**: indigo (#2B1A78) primary, sand (#F3F3F3) banner, teal (#00AD93) for implemented, purple (#5650BE) for planned, red (#AF121D) for gaps; uniform sand lifelines across all actors
+- **Per-operand `par` fragment labels** in flow sequence diagrams (rendered as HTML divs so lifelines don't paint over the text)
+- **Sequence flow diagrams** with hover integration details and responsive scaling
+- **Adoption Model artifact** (`adoption-model/`): visual representation of the adoption model with PNG export pipeline (`export:adoption-model` script)
+- **Determination flow** in the context map: `submit-for-determination` section, supervisor approval with task-claim pattern, `determination.recorded → communications` for NOA, `self: case_management` creates case
+- **Federal verification flow** rendered as direct API calls (FDSH, IEVS, SAVE, SSA) outside the `par` fragment, reflecting that they are not event-driven subscriptions
+
+### Changed
+
+- **Directory layout standardized**: each tool uses `src/`, `config/`, `output/`, and `dist/` consistently. Generated outputs (HTML, SVG, zip) are committed; intermediate fragments and PNGs in `dist/` are gitignored
+- **Federal verification calls** moved out of the `par` fragment in the Application Submission flow — they are direct API calls from intake, not event-driven subscriptions, and now render as a sequential step after verification items are created
+- **Hex click reliability** improved: hex polygon and labels are wrapped in a `<g>` so the whole group is clickable, not just the polygon
+- **`par`/`opt` fragment separators** no longer overlap at nested fragment boundaries
+- **Withdrawal flow** removed from the context map (still documented in `docs/architecture/`)
+- **`context-schema.json`** renamed to `config/annotations-schema.json` (service blueprints)
+- **Service blueprint zip export** moved from `output/` to `dist/`
+
+### Removed
+
+- Pre-existing `proto-hex.html` prototype (no longer needed)

--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/safety-net-blueprint-explorer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Context map and service blueprint tooling for the Safety Net Blueprint",
   "type": "module",
   "scripts": {

--- a/packages/mock-server/CHANGELOG.md
+++ b/packages/mock-server/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-04
+
+### Added
+
+- **`emit-event.js`**: shared CloudEvents 1.0 envelope construction utility. Persists to the events collection, broadcasts via SSE event bus, propagates `traceparent` from request headers, and derives event types as `org.codeforamerica.safety-net-blueprint.{domain}.{object}.{action}`
+- **CRUD lifecycle event auto-emit**: every POST emits `{object}.created` (full resource snapshot), every PATCH emits `{object}.updated` (field-level diff with `before`/`after`), every DELETE emits `{object}.deleted`
+- **`emitEventEnvelope()`** for injecting pre-built CloudEvents envelopes (used by `POST /platform/events` for integration testing)
+- **`POST /platform/events`** endpoint: accepts a CloudEvents 1.0 envelope and fires it to the event bus, enabling integration tests to simulate events from external domains
+- **Event subscription engine** (`event-subscription.js`): listens on the event bus, matches rule sets by `on:` field (full or short-form CloudEvents type), resolves context bindings with the event envelope as `this`, evaluates rules, and dispatches actions
+- **`state-machine-runner.js`**: extracted core transition logic from the HTTP handler so programmatic callers (event-triggered transitions, `triggerTransition` action) share the same machinery
+- **`platform-action-handlers.js`**: generic platform actions available to all domains — `createResource` (with JSON Logic field resolution and full onCreate pipeline), `triggerTransition` (system-identity transitions on related entities), `forEach` (per-collection-item iteration), `appendToArray` (append values to array fields)
+- **`workflow-action-handlers.js`**: domain-specific actions extracted from the merged registry — `assignToQueue`, `setPriority`
+- **`evaluateAllMatchRuleSet`**: collects all matching rules instead of stopping at first match; dispatched by `processRuleEvaluations` and event subscriptions when `ruleSet.evaluation === 'all-match'`
+- **Context enrichment in rule evaluation**: `resolveContextEntities` fetches related entities by ID from the DB before rule evaluation; supports JSON Logic `{var: "..."}` form for `from:`, collection bindings (no entity lookup), `optional: true` for non-required bindings, and chaining (each binding can reference previously resolved entities)
+- **Sub-resource route generation**: collection sub-resources (`/parents/{id}/children`) and singleton sub-resources (`/parents/{id}/child`) classified and routed correctly; parent existence enforced (404 on missing parent); singleton GET/PATCH look up by parent field
+- **`collection-utils.js`**: shared `deriveCollectionName` utility (extracted to break a circular dependency); handles parent-singular prefixing for sub-collections (`application-documents`) and pluralization for singletons (`interviews`)
+- **Multi-state-machine domain support**: a single domain can register multiple state machines (e.g., `Application` and `ApplicationDocument` both under `intake`); state machines are matched per collection via kebab-plural comparison
+- **Config-managed resources**: `config-loader.js` discovers `*-config.yaml` files and seeds entries with `source: system`; `config-registry.js` tracks config-managed IDs in memory; DELETE returns 409 `CONFIG_MANAGED` for those IDs; POST sets `source: user` on runtime-created resources in collections that have config entries
+- **`json_tree()`-based nested field search**: `search` parameter and full-text query tokens now match values at any nesting depth (e.g., `name.firstName`), replacing the per-field LIKE approach
+- **SLA engine resolved entities**: `initializeSlaInfo` and `updateSlaInfo` accept a `resolvedEntities` map so SLA conditions can reference fields on related entities
+
+### Changed
+
+- **All domain events now use the CloudEvents 1.0 envelope**. The legacy custom envelope (`domain`, `resource`, `action`, `resourceId`, `occurredAt`) is replaced by `specversion`, `type`, `source`, `subject`, `time`. Event filters now use `?subject=` (was `?q=resourceId:`); event consumers should read `e.type.endsWith('.created')` (was `e.action === 'created'`), `e.subject` (was `e.resourceId`), `e.time` (was `e.occurredAt`)
+- **Transition handler**: now a thin HTTP adapter delegating to `state-machine-runner.executeTransition`
+- **`action-handlers.js`**: split into `platform-action-handlers.js` and `workflow-action-handlers.js`; the file now merges both registries
+- **Integration test assertions**: updated to CloudEvents fields (`type`, `subject`, `time`, `specversion`)
+
+### Fixed
+
+- **Initial state not applied on resource create**: resources created with a state machine were getting `status: null`. The create handler now reads `initialState` from the state machine and persists it on creation
+- **Rule evaluation results not persisting on task create**: the before-snapshot was captured after rule evaluation mutated the resource; capturing it before fixes the diff so rule-driven fields (`priority`, `queueId`) are written back to the DB
+- **`POST /platform/events`** with missing required CloudEvents fields now returns 422 `VALIDATION_ERROR` (was 400)
+- **Postman generator**: sub-collection POSTs are no longer misclassified as state machine RPC transitions
+- **`resolve.js` and `generate-clients-typescript.js`**: skip deprecated specs (`x-status: deprecated`) before parsing
+
 ## [1.2.0] - 2026-03-17
 
 ### Added

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codeforamerica/safety-net-blueprint-mock-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Mock API server for Safety Net API development and testing",
   "type": "module",
   "files": [


### PR DESCRIPTION
Version bumps across all four workspace packages, with CHANGELOG entries for each.

- `contracts` 1.2.0 → **1.3.0** — intake domain, CloudEvents 1.0 envelope, cross-domain event wiring, rules engine extensions (all-match, forEach, collection bindings), context enrichment, workflow-config queue catalog, Data Exchange and Identity & Access design records
- `mock-server` 1.2.0 → **1.3.0** — emit-event utility, CRUD lifecycle auto-emit, event subscription engine, sub-resource route generation, config-managed resources, json_tree nested search, plus the initial-state and rule-eval-on-create bug fixes
- `clients` 1.1.1 → **1.1.2** — patch for the deprecated-spec filter
- `explorer` 1.2.0 → **1.3.0** — initial workspace package release covering context map, service blueprints, and adoption model (not yet published to npm)

The two big releases are `contracts` and `mock-server`, which together complete the event-driven cross-domain coordination model. `clients` gets a patch for the one substantive change since 1.1.1; `explorer` aligns with the others for coordinated release versioning.
