### PR TITLE
Support electronic verification service calls for intake application submission

### DIFF
--- a/docs/architecture/domains/data-exchange.md
+++ b/docs/architecture/domains/data-exchange.md
@@ -6,6 +6,18 @@ The Data Exchange domain defines the contract surface for all interactions betwe
 
 The Data Exchange domain acts as a facade for all external service interactions. Calling domains (Eligibility, Workflow, Client Management) initiate requests — directly via Data Exchange endpoints or via rules in their own domain that trigger a submission when a relevant event occurs. Data Exchange executes the call, tracks the lifecycle, and emits result events that calling domains subscribe to in order to resume. It owns the catalog of available external services and the lifecycle of every external call made. It does not own the policy decisions that determine whether external data is needed, when to request it, or what to do with the result — those stay in the calling domain.
 
+### How the pattern works
+
+Three actors collaborate on every external service call:
+
+**Calling domain** (e.g., Intake) submits a service call with two fields: the configured service to run (`serviceId`) and the ID of the record that triggered the call (`requestingResourceId`). No PII — no SSN, name, or date of birth — travels through the Data Exchange API surface. The calling domain also attaches any context it needs to resume when the result arrives (e.g., which verification obligation to update) as metadata on the service call.
+
+**Adapter** (state-implemented code behind the Data Exchange endpoints) receives the submission, looks up the resource type for that service from the ExternalService catalog (`data-exchange-config.yaml`), fetches the sensitive input fields it needs directly from the source domain using system credentials, and calls the external service. The adapter is the only actor that ever touches PII.
+
+**ExternalService catalog** (`data-exchange-config.yaml`) declares the resource path adapters fetch for each service type (e.g., `fdsh_ssa` → `intake/applications/members`), the default call mode, and the programs each service supports. States overlay this file to add their endpoint URLs. No credentials live here.
+
+When the external service responds, the adapter posts the result back, a `call.completed` event fires, and the calling domain's rules resume — reading the metadata it attached earlier to route the result to the right record.
+
 ## What happens during a data exchange request
 
 1. A caseworker or automated process determines that external data is needed — to verify income, confirm identity, check immigration status, or confirm no duplicate enrollment exists across programs or states. (7 CFR § 272.8, 42 CFR § 435.940)

--- a/docs/contract-tables/intake/rules-application-submitted-data-exchange.csv
+++ b/docs/contract-tables/intake/rules-application-submitted-data-exchange.csv
@@ -1,5 +1,5 @@
 Order,Condition,Action,Fallback,Description
 1,true,"{""createResource"":{""entity"":""data-exchange/service-calls"",""fields"":{""applicationId"":{""var"":""application.id""},""requestedAt"":{""var"":""this.time""}}}}",,"Initiate electronic verification when an application is submitted (Decision 18).
 Forward subscription — the data exchange domain fans out per-member checks internally
-(FDSH, IEVS, SAVE, SSA) and emits data-exchange.service-call.completed per result.
+(FDSH, IEVS, SAVE, SSA) and emits data_exchange.call.completed per result.
 "

--- a/docs/guides/mock-server.md
+++ b/docs/guides/mock-server.md
@@ -117,6 +117,86 @@ The override affects:
 
 **Simulating pause/resume scenarios:** Pause duration is computed as the difference between the `X-Mock-Now` value at resume and the `X-Mock-Now` value at pause. Both steps must use the same clock — if you pause without `X-Mock-Now` and resume with it (or vice versa), the duration will be wrong. To simulate a 3-day pause: set `X-Mock-Now` at the pause step, then set it to 3 days later at the resume step. To test breach after resuming, send a third request with `X-Mock-Now` set past the extended deadline (returned in the resume response).
 
+## Domain Events
+
+### SSE Event Stream
+
+Subscribe to live domain events as they fire:
+
+```bash
+curl -N http://localhost:1080/platform/events/stream
+```
+
+Each event is a Server-Sent Events message with the full CloudEvents 1.0 envelope as JSON.
+
+### Injecting External Events
+
+To simulate an event from another domain (e.g., a data exchange result arriving):
+
+```bash
+curl -X POST http://localhost:1080/platform/events \
+  -H "Content-Type: application/json" \
+  -d '{
+    "specversion": "1.0",
+    "type": "org.codeforamerica.safety-net-blueprint.data_exchange.call.completed",
+    "source": "/data-exchange",
+    "subject": "<service-call-id>",
+    "data": { "result": "conclusive", "serviceType": "fdsh_ssa" }
+  }'
+```
+
+This fires the event to the event bus, triggering any subscribed rule sets exactly as if it came from a real adapter.
+
+### Mock Stub Registry
+
+For event-driven flows where the mock server itself needs to respond to events (e.g., simulating an external service responding to a service call), use the stub registry to pre-program responses before triggering the flow.
+
+**How it works:** Mock simulation rules subscribe to domain events and call `applyStub`. When `applyStub` fires, it checks the stub registry for a matching pre-registered response, pops it (FIFO), and fires the response event. If no stub matches, the rule's `fallback` fires instead. See [`packages/mock-server/mock-rules/README.md`](../../packages/mock-server/mock-rules/README.md) for how mock simulation rules are written and loaded.
+
+**Register a stub:**
+
+```bash
+curl -X POST http://localhost:1080/mock/stubs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "on": "data_exchange.service_call.created",
+    "match": { "data.serviceType": "fdsh_ssa" },
+    "respond": {
+      "type": "data_exchange.call.completed",
+      "subject": { "var": "this.subject" },
+      "data": {
+        "serviceCallId": { "var": "this.subject" },
+        "serviceType": "fdsh_ssa",
+        "requestingResourceId": { "var": "this.data.requestingResourceId" },
+        "result": "inconclusive"
+      }
+    }
+  }'
+```
+
+- `on` — the CloudEvents type suffix to match (underscores, no platform prefix)
+- `match` — optional dot-path field matchers against the event envelope; all must match
+- `respond` — the event to fire when matched; field values may be JSON Logic expressions resolved against the triggering event envelope
+
+**Stubs are consumed in order (FIFO).** Register multiple stubs to script a sequence — the first matching stub is popped each time a matching event fires.
+
+**Stub IDs** are human-readable: `service_call.created-1`, `service_call.created-2`, etc.
+
+**Other stub endpoints:**
+
+```bash
+# List active stubs
+curl http://localhost:1080/mock/stubs
+
+# Remove a specific stub
+curl -X DELETE http://localhost:1080/mock/stubs/service_call.created-1
+
+# Clear all stubs
+curl -X DELETE http://localhost:1080/mock/stubs
+```
+
+**Without stubs:** If no stub matches, each mock simulation rule defines its own `fallback` — typically a default fixture response so flows work out of the box. Stubs are only needed when you want to test specific outcomes. Check the relevant rule file in `packages/mock-server/mock-rules/` to see what the fallback returns.
+
 ## Search Query Syntax
 
 Use the `q` parameter for filtering. See [Search Patterns](../decisions/search-patterns.md) for full syntax reference.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "start": "node packages/mock-server/scripts/server.js --spec=packages/contracts",
-    "validate": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts && node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts && node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts && node packages/contracts/scripts/validate-rules.js --spec=packages/contracts",
+    "validate": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts && node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts && node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts && node packages/contracts/scripts/validate-rules.js --spec=packages/contracts && npm run validate -w @codeforamerica/safety-net-blueprint-mock-server",
     "validate:syntax": "node packages/contracts/scripts/validate-openapi.js --spec=packages/contracts",
     "validate:patterns": "node packages/contracts/scripts/validate-patterns.js --spec=packages/contracts",
     "validate:schemas": "node packages/contracts/scripts/validate-schemas.js --spec=packages/contracts",

--- a/packages/contracts/components/common.yaml
+++ b/packages/contracts/components/common.yaml
@@ -7,6 +7,9 @@
 #   identity.yaml — Name, SocialSecurityNumber
 #   auth.yaml     — BackendAuthContext, JwtClaims, Role, RoleType
 
+Domain:
+  $ref: "../schemas/common.yaml#/$defs/Domain"
+
 EmployerInfo:
   type: object
   description: Employer identification and contact information.
@@ -33,13 +36,7 @@ Language:
   pattern: "^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*$"
 
 Program:
-  type: string
-  description: Public assistance program type.
-  enum:
-    - snap
-    - tanf
-    - adult_financial
-    - medical_assistance
+  $ref: "../schemas/common.yaml#/$defs/Program"
 
 Signature:
   type: object

--- a/packages/contracts/data-exchange-config-schema.yaml
+++ b/packages/contracts/data-exchange-config-schema.yaml
@@ -1,0 +1,82 @@
+# JSON Schema for data-exchange-config.yaml
+# Extends the generic config envelope (schemas/config-schema.yaml)
+# with ExternalService catalog entry validation.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Data Exchange Config
+description: Schema for data-exchange-config.yaml. Validates the ExternalService catalog.
+
+allOf:
+  - $ref: "schemas/config-schema.yaml"
+
+type: object
+required:
+  - services
+
+properties:
+  domain:
+    const: data-exchange
+    description: Must be "data-exchange".
+
+  services:
+    type: array
+    description: >
+      ExternalService catalog. Defines the external data sources available across
+      all deployments. All entries in a config file are config-managed: they are
+      seeded by the mock server on startup with source "system" and cannot be
+      deleted via the API. States overlay this file to add endpoint configuration
+      and state-specific services.
+    minItems: 1
+    items:
+      $ref: "#/$defs/ExternalServiceConfig"
+
+unevaluatedProperties: false
+
+$defs:
+  ExternalServiceConfig:
+    type: object
+    description: An external service catalog entry.
+    required:
+      - id
+      - name
+      - serviceType
+      - defaultCallMode
+      - programs
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: >
+          Stable identifier. Referenced by ExternalServiceCall submissions (serviceId)
+          and by calling domain rules. Use a fixed UUID so overlay authors and rules
+          can reference specific services portably across deployments.
+      name:
+        type: string
+        minLength: 1
+        maxLength: 200
+        description: Human-readable name (e.g., "SSA Composite via FDSH").
+      serviceType:
+        $ref: "schemas/common.yaml#/$defs/ServiceType"
+      defaultCallMode:
+        type: string
+        description: Default call mode for submissions against this service. Can be overridden per call.
+        enum:
+          - async
+          - sync
+      programs:
+        type: array
+        description: Programs that use this service.
+        minItems: 1
+        items:
+          $ref: "schemas/common.yaml#/$defs/Program"
+      endpoint:
+        $ref: "schemas/common.yaml#/$defs/Endpoint"
+        description: >
+          Connection parameters for this service. States fill in this object
+          via overlay. Omit in the blueprint baseline — adapters will fail to
+          call external services until a state provides endpoint configuration.
+      description:
+        type: string
+        maxLength: 2000
+        description: Human-readable description of what this service returns and when it is used.

--- a/packages/contracts/data-exchange-config.yaml
+++ b/packages/contracts/data-exchange-config.yaml
@@ -1,0 +1,154 @@
+$schema: ./data-exchange-config-schema.yaml
+version: "1.0"
+domain: data-exchange
+
+# ExternalService catalog — all entries are config-managed and cannot be deleted via API.
+# States overlay this file to add their endpoint URLs and any state-specific services.
+# Blueprint entries cover known federal services used across all deployments.
+services:
+  # FDSH services — routed through the CMS Federal Data Services Hub
+
+  # States overlay this file to add endpoint configuration for each service.
+  # Example overlay entry for an FDSH service (FDSH uses mutual TLS — client
+  # certificates, not API keys):
+  #
+  #   - id: 65b5d4d9-3578-4a58-a4bd-c404ca380e08
+  #     endpoint:
+  #       url: https://hub.cms.gov/fdsh/ssa
+  #       timeoutMs: 30000
+  #       apiVersion: "2.0"
+  #       credentialEnvVar: FDSH_CLIENT_CERT_PATH   # path to your state's client cert
+  #
+  # See schemas/common.yaml Endpoint definition for full credential guidance.
+
+  - id: 65b5d4d9-3578-4a58-a4bd-c404ca380e08
+    name: SSA Composite via FDSH
+    serviceType: fdsh_ssa
+    defaultCallMode: async
+    programs:
+      - snap
+      - medicaid
+    description: >
+      SSA Composite query via the CMS Federal Data Services Hub. Verifies SSN
+      validity, U.S.-born citizenship status, Title II (RSDI/SSDI) benefit amounts,
+      and incarceration status. Callers select sub-components via the data field.
+      Satisfies identity and citizenship verification obligations for both SNAP
+      and Medicaid.
+
+  - id: 4ecf1b2f-3559-4956-9c74-184588905f7a
+    name: Verify Lawful Presence via FDSH
+    serviceType: fdsh_vlp
+    defaultCallMode: async
+    programs:
+      - medicaid
+    description: >
+      Verify Lawful Presence (VLP) query via FDSH. Checks immigration status
+      for non-citizen Medicaid applicants. Requires A-Number and immigration
+      document number. Use save as fallback when VLP cannot resolve.
+
+  - id: 17a43588-336e-475b-bec9-fb676b581053
+    name: IRS Federal Tax Information via FDSH
+    serviceType: fdsh_fti
+    defaultCallMode: async
+    programs:
+      - medicaid
+    description: >
+      IRS / Federal Tax Information (FTI) query via FDSH. Returns a MAGI income
+      compatibility result (compatible or not), filing status, and household size.
+      Returns a flag, not raw income figures.
+
+  - id: 72bcaca1-270e-4329-9910-d01086f05cde
+    name: Medicare Enrollment via FDSH
+    serviceType: fdsh_medicare
+    defaultCallMode: async
+    programs:
+      - medicaid
+    description: >
+      Medicare enrollment status query via FDSH. Returns Part A and Part B
+      enrollment status.
+
+  # IEVS sources — 7 CFR § 272.8 requires states to query all four for SNAP
+
+  - id: e248ab46-b470-40cb-95a9-472288d3a06b
+    name: SSA SVES/SOLQ via IEVS
+    serviceType: ssa_ievs
+    defaultCallMode: async
+    programs:
+      - snap
+      - medicaid
+    description: >
+      SSA SVES/SOLQ query via the IEVS framework. Validates SSN; returns Title II
+      (RSDI/SSDI) and Title XVI (SSI) benefit data and 40-quarter work history.
+      Callers select response record types via the data field.
+
+  - id: 8960e213-b9d0-4efb-a65e-7df4a65bb26c
+    name: IRS Unearned Income via IEVS
+    serviceType: irs_ievs
+    defaultCallMode: async
+    programs:
+      - snap
+    description: >
+      IRS direct IEVS batch query. Returns prior-year unearned income — interest,
+      dividends, and capital gains. Raw figures, unlike fdsh_fti.
+
+  - id: 6b2b03b0-dc9b-4122-a9de-138960bb610f
+    name: State Wage Information (SWICA)
+    serviceType: swica
+    defaultCallMode: async
+    programs:
+      - snap
+    description: >
+      State Wage Information Collection Agency query. Returns quarterly
+      employer-reported wages by employer.
+
+  - id: 4d29b8b1-8b5d-4bf5-b98c-2a88fb6bdc69
+    name: Unemployment Insurance Benefits
+    serviceType: uib
+    defaultCallMode: async
+    programs:
+      - snap
+    description: >
+      State unemployment system query. Returns UI claim status, weekly benefit
+      amount, and claim dates.
+
+  # Other federal services
+
+  # USCIS SAVE uses a different auth model from FDSH — states authenticate via
+  # SAVE Web Services credentials (username/password or API key depending on
+  # the access tier). Example overlay:
+  #
+  #   - id: 9efdf5fd-b335-41a5-9393-4c91979a3e9f
+  #     endpoint:
+  #       url: https://save.uscis.gov/webservices
+  #       apiKeyHeader: Authorization
+  #       credentialEnvVar: SAVE_API_CREDENTIALS
+  - id: 9efdf5fd-b335-41a5-9393-4c91979a3e9f
+    name: USCIS SAVE
+    serviceType: save
+    defaultCallMode: async
+    programs:
+      - medicaid
+    description: >
+      USCIS Systematic Alien Verification for Entitlements (SAVE) direct query.
+      Used as fallback when fdsh_vlp cannot resolve immigration status. Step 2
+      is initiated by USCIS response, not the caller.
+
+  - id: 23b2df6a-193c-4a1b-b59a-703919912918
+    name: Interstate Enrollment Check
+    serviceType: enrollment_check
+    defaultCallMode: async
+    programs:
+      - all
+    description: >
+      Inter-state enrollment hub query. Checks for duplicate enrollment across
+      states and programs.
+
+  - id: ab22559a-3c58-4468-9d36-dbfc72cb23f7
+    name: SSA Incarceration Check
+    serviceType: incarceration_check
+    defaultCallMode: async
+    programs:
+      - all
+    description: >
+      SSA Prison Verification System (PUPS) batch query. Returns confinement
+      status matched against SSA beneficiary records.

--- a/packages/contracts/data-exchange-openapi.yaml
+++ b/packages/contracts/data-exchange-openapi.yaml
@@ -1,0 +1,678 @@
+openapi: 3.1.0
+info:
+  title: Data Exchange API
+  version: 0.1.0
+  x-domain: data-exchange
+  x-status: alpha
+  x-visibility: internal
+  description: |
+    REST API for the Data Exchange domain — the facade for all interactions
+    between the blueprint and external agencies and data sources (IRS, SSA,
+    USCIS SAVE, state wage databases, and others).
+
+    Calling domains initiate service calls by POSTing to `/service-calls`.
+    The request carries no PII — adapters retrieve sensitive fields from the
+    source domain using `requestingResourceId` and the resource type declared
+    in the ExternalService catalog. Results are delivered via the
+    `data_exchange.call.completed` event and queryable via the event log.
+
+    Context passthrough: calling domains attach namespace-keyed metadata to
+    a service call (e.g., `PUT /service-calls/{id}/metadata/intake`) before
+    or at submission. That metadata is echoed back in the result event so
+    the calling domain's rules can route the result to the right record.
+
+    > **Status: Alpha** — Breaking changes expected.
+
+  contact:
+    name: API Support
+    email: support@example.com
+
+servers:
+  - url: https://api.example.com/data-exchange
+    description: Production server
+  - url: http://localhost:1080/data-exchange
+    description: Local development server
+
+tags:
+  - name: Services
+    description: ExternalService catalog — the configured external data sources available in this deployment.
+  - name: ServiceCalls
+    description: External service call lifecycle — submission through resolution.
+
+x-events:
+  call.submitted:
+    type: org.codeforamerica.safety-net-blueprint.data_exchange.call.submitted
+    summary: Emitted when an async service call is submitted and enters the pending state
+    payload:
+      $ref: "#/components/schemas/CallSubmittedEvent"
+  call.completed:
+    type: org.codeforamerica.safety-net-blueprint.data_exchange.call.completed
+    summary: Emitted when an external service responds successfully; carries the full result payload
+    payload:
+      $ref: "#/components/schemas/CallCompletedEvent"
+  call.failed:
+    type: org.codeforamerica.safety-net-blueprint.data_exchange.call.failed
+    summary: Emitted when an external service returns an error or rejection
+    payload:
+      $ref: "#/components/schemas/CallFailedEvent"
+  call.timed_out:
+    type: org.codeforamerica.safety-net-blueprint.data_exchange.call.timed_out
+    summary: Emitted when no response is received within the configured window
+    payload:
+      $ref: "#/components/schemas/CallTimedOutEvent"
+
+paths:
+  /services:
+    get:
+      summary: List external services
+      description: |
+        Retrieve the catalog of external services available in this deployment.
+        All entries are config-managed — defined in `data-exchange-config.yaml`
+        and seeded at startup. States add entries via overlay; no write endpoints
+        are provided.
+      operationId: listServices
+      tags:
+        - Services
+      parameters:
+        - $ref: "./components/parameters.yaml#/SearchQueryParam"
+        - $ref: "./components/parameters.yaml#/LimitParam"
+        - $ref: "./components/parameters.yaml#/OffsetParam"
+        - name: serviceType
+          in: query
+          description: Filter by service type.
+          schema:
+            $ref: "#/components/schemas/ServiceType"
+        - name: program
+          in: query
+          description: Filter by program (returns services that apply to this program or all programs).
+          schema:
+            $ref: "./components/common.yaml#/Program"
+      responses:
+        "200":
+          description: A paginated list of external services.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceList"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /services/{serviceId}:
+    parameters:
+      - $ref: "#/components/parameters/ServiceIdParam"
+
+    get:
+      summary: Get an external service
+      description: Retrieve a single external service catalog entry by identifier.
+      operationId: getService
+      tags:
+        - Services
+      responses:
+        "200":
+          description: External service retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalService"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /service-calls:
+    get:
+      summary: List service calls
+      description: Retrieve a paginated list of external service calls.
+      operationId: listServiceCalls
+      tags:
+        - ServiceCalls
+      parameters:
+        - $ref: "./components/parameters.yaml#/SearchQueryParam"
+        - $ref: "./components/parameters.yaml#/LimitParam"
+        - $ref: "./components/parameters.yaml#/OffsetParam"
+        - name: requestingResourceId
+          in: query
+          description: Filter by the requesting resource ID.
+          schema:
+            type: string
+            format: uuid
+        - name: serviceType
+          in: query
+          description: Filter by service type (e.g., `fdsh_ssa`, `ssa_ievs`).
+          schema:
+            $ref: "#/components/schemas/ServiceType"
+        - name: status
+          in: query
+          description: Filter by call status.
+          schema:
+            $ref: "#/components/schemas/ExternalServiceCallStatus"
+      responses:
+        "200":
+          description: A paginated list of service calls.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceCallList"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    post:
+      summary: Submit a service call
+      description: |
+        Submit a request to call an external service. The request body carries
+        no PII — adapters retrieve sensitive fields from the source domain using
+        `requestingResourceId` and the resource type declared in the ExternalService
+        catalog entry.
+
+        Submissions are deduplicated by `requestingResourceId` + `serviceId`. If a
+        `pending` call already exists for the same pair, the server returns the
+        existing call record rather than submitting a duplicate.
+      operationId: createServiceCall
+      tags:
+        - ServiceCalls
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExternalServiceCallCreate"
+      responses:
+        "201":
+          description: Service call submitted successfully.
+          headers:
+            Location:
+              description: URL of the newly created service call resource.
+              schema:
+                type: string
+                format: uri
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceCall"
+        "200":
+          description: Duplicate submission — an equivalent pending call already exists. Returns the existing call record.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceCall"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /service-calls/{serviceCallId}:
+    parameters:
+      - $ref: "#/components/parameters/ServiceCallIdParam"
+
+    get:
+      summary: Get a service call
+      description: Retrieve a single service call by identifier.
+      operationId: getServiceCall
+      tags:
+        - ServiceCalls
+      responses:
+        "200":
+          description: Service call retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceCall"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /service-calls/{serviceCallId}/metadata/{domain}:
+    parameters:
+      - $ref: "#/components/parameters/ServiceCallIdParam"
+      - name: domain
+        in: path
+        required: true
+        description: The calling domain attaching its metadata namespace.
+        schema:
+          $ref: "./components/common.yaml#/Domain"
+
+    put:
+      summary: Set domain metadata on a service call
+      description: |
+        Attach namespace-keyed metadata from the calling domain to a service call.
+        Used for context passthrough — the calling domain stores identifiers it
+        needs to resume when a result arrives (e.g., the verification ID to update).
+        The metadata object is echoed back verbatim in the result event under
+        `event.data.metadata.{domain}`.
+
+        Replaces any existing metadata for the given domain namespace. Other
+        domains' namespaces are unaffected.
+      operationId: setServiceCallMetadata
+      tags:
+        - ServiceCalls
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Arbitrary domain-defined key-value pairs. Must be a flat or nested object — no arrays at the top level.
+              additionalProperties: true
+              example:
+                verificationId: ver-abc-123
+      responses:
+        "200":
+          description: Metadata set successfully. Returns the updated service call.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExternalServiceCall"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    delete:
+      summary: Remove domain metadata from a service call
+      description: Remove the calling domain's entire metadata namespace from a service call.
+      operationId: deleteServiceCallMetadata
+      tags:
+        - ServiceCalls
+      responses:
+        "204":
+          description: Metadata removed successfully.
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+components:
+  parameters:
+    ServiceCallIdParam:
+      name: serviceCallId
+      in: path
+      required: true
+      description: Unique identifier of the service call.
+      schema:
+        type: string
+        format: uuid
+
+    ServiceIdParam:
+      name: serviceId
+      in: path
+      required: true
+      description: Unique identifier of the external service catalog entry.
+      schema:
+        type: string
+        format: uuid
+
+  schemas:
+    ExternalService:
+      type: object
+      description: |
+        A configured external data source available in this deployment. Entries
+        are defined in `data-exchange-config.yaml` at deployment time — not
+        created via API. The blueprint defines entries for known federal services;
+        states overlay to add endpoint configuration and any state-specific services.
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - serviceType
+        - defaultCallMode
+        - programs
+        - source
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Stable identifier. Referenced by ExternalServiceCall submissions.
+        name:
+          type: string
+          description: Human-readable name (e.g., "SSA Composite via FDSH").
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+          description: The federal service interface this entry represents.
+        defaultCallMode:
+          $ref: "#/components/schemas/CallMode"
+          description: Default call mode for submissions against this service. Can be overridden per call.
+        programs:
+          type: array
+          description: Programs that use this service.
+          items:
+            $ref: "./components/common.yaml#/Program"
+        source:
+          type: string
+          description: '"system" entries are defined in data-exchange-config.yaml and cannot be deleted via the API. "user" entries are added by states at runtime.'
+          enum:
+            - system
+            - user
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ExternalServiceList:
+      type: object
+      description: A paginated list of external service catalog entries.
+      additionalProperties: false
+      required:
+        - items
+        - total
+        - limit
+        - offset
+        - hasNext
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExternalService"
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasNext:
+          type: boolean
+
+    ExternalServiceCall:
+      type: object
+      description: |
+        A single external service call from submission through resolution.
+        Governs the call lifecycle and serves as the correlation handle adapters
+        use when calling back with a result.
+      additionalProperties: false
+      required:
+        - id
+        - serviceId
+        - serviceType
+        - requestingResourceId
+        - callMode
+        - status
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier.
+        serviceId:
+          type: string
+          format: uuid
+          description: ID of the ExternalService catalog entry being called.
+          x-relationship:
+            resource: ExternalService
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+          description: Service type copied from the catalog entry at submission time; present for direct querying without a catalog join.
+        requestingResourceId:
+          type: string
+          format: uuid
+          description: ID of the resource that triggered the call (e.g., an ApplicationMember ID). Combined with `serviceId`, forms the idempotency key.
+          x-relationship:
+            resource: Polymorphic
+        requestingResourceType:
+          type: string
+          description: Resource type of the requesting resource, copied from the ExternalService catalog entry at submission time. Together with `requestingResourceId`, tells adapters where to fetch sensitive input fields.
+          example: intake/applications/members
+        callMode:
+          $ref: "#/components/schemas/CallMode"
+          description: Whether this call is synchronous or asynchronous.
+        status:
+          $ref: "#/components/schemas/ExternalServiceCallStatus"
+          description: Current state in the call lifecycle.
+        data:
+          type: object
+          description: Optional per-call non-PII context (e.g., which FDSH sub-components to request). Polymorphic on `serviceType`.
+          additionalProperties: true
+          nullable: true
+        metadata:
+          type: object
+          description: Namespace-keyed metadata attached by calling domains for context passthrough. Keys are domain names; values are arbitrary objects.
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: When the call was submitted.
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the call status last changed.
+
+    ExternalServiceCallCreate:
+      type: object
+      description: Fields required to submit a new external service call.
+      additionalProperties: false
+      required:
+        - serviceId
+        - requestingResourceId
+      properties:
+        serviceId:
+          type: string
+          format: uuid
+          description: ID of the ExternalService catalog entry to call.
+          x-relationship:
+            resource: ExternalService
+        requestingResourceId:
+          type: string
+          format: uuid
+          description: ID of the resource triggering the call. Adapters use this to fetch required input data from the source domain.
+          x-relationship:
+            resource: Polymorphic
+        callMode:
+          $ref: "#/components/schemas/CallMode"
+          description: Override the ExternalService default call mode for this submission. If omitted, the catalog default is used.
+        data:
+          type: object
+          description: Optional per-call non-PII context. Polymorphic on the `serviceType` of the referenced ExternalService.
+          additionalProperties: true
+          nullable: true
+        metadata:
+          type: object
+          description: Initial domain-keyed metadata to attach at submission time. Equivalent to calling PUT /metadata/{domain} immediately after creation.
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true
+
+    ExternalServiceCallList:
+      type: object
+      description: A paginated list of external service calls.
+      additionalProperties: false
+      required:
+        - items
+        - total
+        - limit
+        - offset
+        - hasNext
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExternalServiceCall"
+        total:
+          type: integer
+          description: Total number of matching records.
+        limit:
+          type: integer
+          description: Maximum number of records per page.
+        offset:
+          type: integer
+          description: Zero-based offset of the first returned record.
+        hasNext:
+          type: boolean
+          description: Whether additional records exist beyond this page.
+
+    # --- Enums ---
+
+    CallMode:
+      type: string
+      description: Whether the call blocks until a result is returned (sync) or enters an async waiting state (async).
+      enum:
+        - async
+        - sync
+
+    ExternalServiceCallStatus:
+      type: string
+      description: Lifecycle state of an external service call.
+      enum:
+        - pending
+        - completed
+        - failed
+        - timed_out
+
+    ServiceType:
+      $ref: "./schemas/common.yaml#/$defs/ServiceType"
+
+    # --- Events ---
+
+    CallSubmittedEvent:
+      type: object
+      description: Payload for the data_exchange.call.submitted event.
+      additionalProperties: false
+      required:
+        - serviceCallId
+        - serviceType
+        - requestingResourceId
+      properties:
+        serviceCallId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: ExternalServiceCall
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+        requestingResourceId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: Polymorphic
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true
+
+    CallCompletedEvent:
+      type: object
+      description: |
+        Payload for the data_exchange.call.completed event. Carries the full
+        result from the external service. The `result` field is polymorphic
+        on `serviceType`. Calling domains subscribe to this event and use
+        `metadata.{domain}` fields to route the result to the correct record.
+      additionalProperties: false
+      required:
+        - serviceCallId
+        - serviceType
+        - requestingResourceId
+        - result
+      properties:
+        serviceCallId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: ExternalServiceCall
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+        requestingResourceId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: Polymorphic
+        result:
+          type: string
+          description: High-level outcome of the service call.
+          enum:
+            - conclusive
+            - inconclusive
+            - partial
+        metadata:
+          type: object
+          description: Domain-keyed metadata echoed back from the service call record. Enables calling domains to resume without querying the service call.
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true
+        serviceResult:
+          type: object
+          description: Service-type-specific result payload. Polymorphic on `serviceType`.
+          additionalProperties: true
+          nullable: true
+
+    CallFailedEvent:
+      type: object
+      description: Payload for the data_exchange.call.failed event.
+      additionalProperties: false
+      required:
+        - serviceCallId
+        - serviceType
+        - requestingResourceId
+        - failureReason
+      properties:
+        serviceCallId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: ExternalServiceCall
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+        requestingResourceId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: Polymorphic
+        failureReason:
+          type: string
+          description: Classification of the failure to help calling domains decide whether to retry, escalate, or proceed without the data.
+          enum:
+            - connection_error
+            - service_error
+            - authentication_error
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true
+
+    CallTimedOutEvent:
+      type: object
+      description: Payload for the data_exchange.call.timed_out event.
+      additionalProperties: false
+      required:
+        - serviceCallId
+        - serviceType
+        - requestingResourceId
+      properties:
+        serviceCallId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: ExternalServiceCall
+        serviceType:
+          $ref: "#/components/schemas/ServiceType"
+        requestingResourceId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: Polymorphic
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          nullable: true

--- a/packages/contracts/data-exchange-openapi.yaml
+++ b/packages/contracts/data-exchange-openapi.yaml
@@ -538,141 +538,17 @@ components:
       $ref: "./schemas/common.yaml#/$defs/ServiceType"
 
     # --- Events ---
-
-    CallSubmittedEvent:
-      type: object
-      description: Payload for the data_exchange.call.submitted event.
-      additionalProperties: false
-      required:
-        - serviceCallId
-        - serviceType
-        - requestingResourceId
-      properties:
-        serviceCallId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: ExternalServiceCall
-        serviceType:
-          $ref: "#/components/schemas/ServiceType"
-        requestingResourceId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: Polymorphic
-        metadata:
-          type: object
-          additionalProperties:
-            type: object
-            additionalProperties: true
-          nullable: true
+    # Payload schemas live in schemas/data-exchange-events.yaml for reuse across
+    # OpenAPI and future AsyncAPI specs. These are passthroughs.
 
     CallCompletedEvent:
-      type: object
-      description: |
-        Payload for the data_exchange.call.completed event. Carries the full
-        result from the external service. The `result` field is polymorphic
-        on `serviceType`. Calling domains subscribe to this event and use
-        `metadata.{domain}` fields to route the result to the correct record.
-      additionalProperties: false
-      required:
-        - serviceCallId
-        - serviceType
-        - requestingResourceId
-        - result
-      properties:
-        serviceCallId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: ExternalServiceCall
-        serviceType:
-          $ref: "#/components/schemas/ServiceType"
-        requestingResourceId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: Polymorphic
-        result:
-          type: string
-          description: High-level outcome of the service call.
-          enum:
-            - conclusive
-            - inconclusive
-            - partial
-        metadata:
-          type: object
-          description: Domain-keyed metadata echoed back from the service call record. Enables calling domains to resume without querying the service call.
-          additionalProperties:
-            type: object
-            additionalProperties: true
-          nullable: true
-        serviceResult:
-          type: object
-          description: Service-type-specific result payload. Polymorphic on `serviceType`.
-          additionalProperties: true
-          nullable: true
+      $ref: "./schemas/data-exchange-events.yaml#/$defs/CallCompletedEvent"
 
     CallFailedEvent:
-      type: object
-      description: Payload for the data_exchange.call.failed event.
-      additionalProperties: false
-      required:
-        - serviceCallId
-        - serviceType
-        - requestingResourceId
-        - failureReason
-      properties:
-        serviceCallId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: ExternalServiceCall
-        serviceType:
-          $ref: "#/components/schemas/ServiceType"
-        requestingResourceId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: Polymorphic
-        failureReason:
-          type: string
-          description: Classification of the failure to help calling domains decide whether to retry, escalate, or proceed without the data.
-          enum:
-            - connection_error
-            - service_error
-            - authentication_error
-        metadata:
-          type: object
-          additionalProperties:
-            type: object
-            additionalProperties: true
-          nullable: true
+      $ref: "./schemas/data-exchange-events.yaml#/$defs/CallFailedEvent"
+
+    CallSubmittedEvent:
+      $ref: "./schemas/data-exchange-events.yaml#/$defs/CallSubmittedEvent"
 
     CallTimedOutEvent:
-      type: object
-      description: Payload for the data_exchange.call.timed_out event.
-      additionalProperties: false
-      required:
-        - serviceCallId
-        - serviceType
-        - requestingResourceId
-      properties:
-        serviceCallId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: ExternalServiceCall
-        serviceType:
-          $ref: "#/components/schemas/ServiceType"
-        requestingResourceId:
-          type: string
-          format: uuid
-          x-relationship:
-            resource: Polymorphic
-        metadata:
-          type: object
-          additionalProperties:
-            type: object
-            additionalProperties: true
-          nullable: true
+      $ref: "./schemas/data-exchange-events.yaml#/$defs/CallTimedOutEvent"

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -82,7 +82,7 @@ ruleSets:
         description: |
           Initiate electronic verification when an application is submitted (Decision 18).
           Forward subscription — the data exchange domain fans out per-member checks internally
-          (FDSH, IEVS, SAVE, SSA) and emits data-exchange.service-call.completed per result.
+          (FDSH, IEVS, SAVE, SSA) and emits data_exchange.call.completed per result.
   - id: application-submitted-document-checklist
     "on": intake.application.submitted
     evaluation: all-match
@@ -149,7 +149,7 @@ ruleSets:
               category: identity
         description: Request identity documentation for Medicaid applicants (Decision 16).
   - id: verification-result-write-back
-    "on": data-exchange.service-call.completed
+    "on": data_exchange.call.completed
     evaluation: first-match-wins
     rules:
       - id: append-verification-to-member
@@ -171,7 +171,7 @@ ruleSets:
                 var: this.time
         description: Write electronic verification result back to ApplicationMember.verifications (Decision 17)
   - id: fdsh-inconclusive-citizenship-document
-    "on": data-exchange.service-call.completed
+    "on": data_exchange.call.completed
     evaluation: first-match-wins
     rules:
       - id: create-citizenship-document-on-fdsh-inconclusive
@@ -218,7 +218,7 @@ ruleSets:
           Only fires when the appointment's subjectType is "interview", ensuring non-interview
           appointments scheduled via the shared scheduling domain are ignored.
   - id: document-verified-write-back
-    "on": document-management.document.verified
+    "on": document_management.document.verified
     evaluation: first-match-wins
     context:
       - as: applicationDocument

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -49,6 +49,15 @@ naming:
   # Example: user-profiles.yaml, common-parameters.yaml
   files: kebab-case
 
+  # CloudEvents type segments: snake_case (underscores for multi-word segments)
+  # Full format: org.codeforamerica.safety-net-blueprint.{domain}.{object}.{action}
+  # Example: org.codeforamerica.safety-net-blueprint.data_exchange.service_call.created
+  # Rule: URL paths use hyphens (kebab-case); CloudEvents type segments use underscores (snake_case).
+  # Never mix conventions — data-exchange in a path becomes data_exchange in an event type.
+  # The `on:` field in rules files uses the short suffix form (omit the platform prefix) but
+  # must still use underscores: on: data_exchange.call.completed, not data-exchange.call.completed.
+  event_type_segments: snake_case
+
 # =============================================================================
 # Spec Authoring Style
 # =============================================================================

--- a/packages/contracts/schemas/common.yaml
+++ b/packages/contracts/schemas/common.yaml
@@ -1,0 +1,97 @@
+# Shared type definitions referenced by both OpenAPI components and JSON Schema
+# config validators. Extracting shared types here avoids duplication between
+# components/common.yaml (OpenAPI) and schemas/*-schema.yaml (JSON Schema).
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Shared Common Types
+
+$defs:
+  Domain:
+    type: string
+    description: >
+      Blueprint domain identifier. Used as the {domain} path parameter on
+      metadata mutation endpoints (PUT/DELETE /{resources}/{id}/metadata/{domain})
+      and as the value type for x-domain annotations on domain OpenAPI specs.
+    enum:
+      - data-exchange
+      - document-management
+      - eligibility
+      - intake
+      - workflow
+
+  Endpoint:
+    type: object
+    description: >
+      Connection parameters for an external service. States overlay their
+      domain config files (e.g., data-exchange-config.yaml) to fill in these
+      fields for each service. No credentials live here — secrets are injected
+      at deploy time via environment variables or a state-configured secrets
+      manager, and referenced by name in the endpoint block.
+    additionalProperties: true
+    required:
+      - url
+    properties:
+      url:
+        type: string
+        format: uri
+        description: Base URL for the external service endpoint.
+        example: https://hub.cms.gov/fdsh/ssa
+      timeoutMs:
+        type: integer
+        description: Request timeout in milliseconds. Defaults to adapter implementation default if omitted.
+        minimum: 0
+        example: 30000
+      apiVersion:
+        type: string
+        description: Service API version, if the external service requires explicit versioning.
+        example: "2.0"
+    # Credential configuration — add these fields in your state overlay.
+    # Do NOT store credential values here; store only the reference name.
+    # Your adapter reads whichever field you configure and resolves the value
+    # from the environment or secrets manager at runtime. Examples:
+    #
+    #   credentialEnvVar: MY_SERVICE_CERT_PATH    # env var holding a cert file path
+    #   credentialSecretPath: secrets/my-service  # secrets manager path (Vault, AWS, etc.)
+    #
+    # Services that use API keys instead of certificates:
+    #
+    #   apiKeyHeader: X-API-Key                   # HTTP header the adapter puts the key in
+    #   credentialEnvVar: MY_SERVICE_API_KEY       # env var holding the key value
+    #
+    # See the domain config file (e.g., data-exchange-config.yaml) for
+    # service-specific credential guidance.
+
+  Program:
+    type: string
+    description: >
+      Federal public assistance program. Uses federal program names — states
+      display their own program branding (e.g., "Medical Assistance",
+      "Medi-Cal") in the UI layer.
+    enum:
+      - snap
+      - medicaid
+      - tanf
+      - all
+
+  ServiceType:
+    type: string
+    description: >
+      The specific federal service interface being called. Each type has a
+      distinct adapter interface, input schema, and result schema.
+
+      FDSH services are prefixed fdsh_ — they route through the CMS Federal
+      Data Services Hub. IEVS sources are separate systems with distinct
+      interfaces. See the Data Exchange architecture doc for the full reference.
+    enum:
+      - fdsh_ssa
+      - fdsh_vlp
+      - fdsh_fti
+      - fdsh_medicare
+      - fdsh_vci
+      - ssa_ievs
+      - irs_ievs
+      - swica
+      - uib
+      - save
+      - enrollment_check
+      - incarceration_check

--- a/packages/contracts/schemas/config-schema.yaml
+++ b/packages/contracts/schemas/config-schema.yaml
@@ -20,5 +20,4 @@ properties:
     description: Schema version for change tracking.
 
   domain:
-    type: string
-    description: Domain namespace (e.g., workflow, data-exchange).
+    $ref: "common.yaml#/$defs/Domain"

--- a/packages/contracts/schemas/data-exchange-events.yaml
+++ b/packages/contracts/schemas/data-exchange-events.yaml
@@ -1,0 +1,148 @@
+# Event payload schemas for the Data Exchange domain.
+# Referenced by data-exchange-openapi.yaml (x-events and components/schemas passthroughs)
+# and available for future AsyncAPI consumption.
+#
+# All schemas use JSON Schema draft 2020-12 so they can be used standalone
+# (e.g., in AsyncAPI message validation) without an OpenAPI resolver.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Data Exchange Event Schemas
+
+$defs:
+  CallCompletedEvent:
+    type: object
+    description: |
+      Payload for the data_exchange.call.completed event. Carries the full
+      result from the external service. The `result` field is polymorphic
+      on `serviceType`. Calling domains subscribe to this event and use
+      `metadata.{domain}` fields to route the result to the correct record.
+    additionalProperties: false
+    required:
+      - serviceCallId
+      - serviceType
+      - requestingResourceId
+      - result
+    properties:
+      serviceCallId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: ExternalServiceCall
+      serviceType:
+        $ref: "./common.yaml#/$defs/ServiceType"
+      requestingResourceId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: Polymorphic
+      result:
+        type: string
+        description: High-level outcome of the service call.
+        enum:
+          - conclusive
+          - inconclusive
+          - partial
+      metadata:
+        type: object
+        description: Domain-keyed metadata echoed back from the service call record. Enables calling domains to resume without querying the service call.
+        additionalProperties:
+          type: object
+          additionalProperties: true
+        nullable: true
+      serviceResult:
+        type: object
+        description: Service-type-specific result payload. Polymorphic on `serviceType`.
+        additionalProperties: true
+        nullable: true
+
+  CallFailedEvent:
+    type: object
+    description: Payload for the data_exchange.call.failed event.
+    additionalProperties: false
+    required:
+      - serviceCallId
+      - serviceType
+      - requestingResourceId
+      - failureReason
+    properties:
+      serviceCallId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: ExternalServiceCall
+      serviceType:
+        $ref: "./common.yaml#/$defs/ServiceType"
+      requestingResourceId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: Polymorphic
+      failureReason:
+        type: string
+        description: Classification of the failure to help calling domains decide whether to retry, escalate, or proceed without the data.
+        enum:
+          - connection_error
+          - service_error
+          - authentication_error
+      metadata:
+        type: object
+        additionalProperties:
+          type: object
+          additionalProperties: true
+        nullable: true
+
+  CallSubmittedEvent:
+    type: object
+    description: Payload for the data_exchange.call.submitted event.
+    additionalProperties: false
+    required:
+      - serviceCallId
+      - serviceType
+      - requestingResourceId
+    properties:
+      serviceCallId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: ExternalServiceCall
+      serviceType:
+        $ref: "./common.yaml#/$defs/ServiceType"
+      requestingResourceId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: Polymorphic
+      metadata:
+        type: object
+        additionalProperties:
+          type: object
+          additionalProperties: true
+        nullable: true
+
+  CallTimedOutEvent:
+    type: object
+    description: Payload for the data_exchange.call.timed_out event.
+    additionalProperties: false
+    required:
+      - serviceCallId
+      - serviceType
+      - requestingResourceId
+    properties:
+      serviceCallId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: ExternalServiceCall
+      serviceType:
+        $ref: "./common.yaml#/$defs/ServiceType"
+      requestingResourceId:
+        type: string
+        format: uuid
+        x-relationship:
+          resource: Polymorphic
+      metadata:
+        type: object
+        additionalProperties:
+          type: object
+          additionalProperties: true
+        nullable: true

--- a/packages/contracts/schemas/rules-schema.yaml
+++ b/packages/contracts/schemas/rules-schema.yaml
@@ -39,6 +39,50 @@ properties:
 
 $defs:
   # ---------------------------------------------------------------------------
+  # ActionFireEvent — emit an arbitrary outbound event from a rule action
+  #
+  # Emit a data exchange completion event from an intake rule:
+  # action:
+  #   fireEvent:
+  #     type: data_exchange.call.completed
+  #     subject: {var: "this.subject"}
+  #     data:
+  #       serviceCallId: {var: "this.data.serviceCallId"}
+  #       result: conclusive
+  # ---------------------------------------------------------------------------
+  ActionFireEvent:
+    type: object
+    description: >
+      Emits an arbitrary outbound CloudEvent from a rule action. Allows rules
+      to publish domain events directly without requiring a state machine
+      transition as intermediary — needed for cross-domain fanout.
+      Field values in `data`, `subject`, and `source` may be literals or JSON
+      Logic expressions resolved against the current rule context.
+    required: [type]
+    properties:
+      type:
+        type: string
+        description: >
+          CloudEvents type suffix (e.g., "data_exchange.call.completed"). The
+          platform prefix (org.codeforamerica.safety-net-blueprint.) is prepended
+          automatically if not already present.
+      subject:
+        description: >
+          CloudEvents subject (typically a resource ID). May be a literal or a
+          JSON Logic expression resolved against the current rule context.
+      source:
+        description: >
+          CloudEvents source. Defaults to "/system" if omitted. May be a literal
+          or a JSON Logic expression.
+      data:
+        type: object
+        description: >
+          Event payload. Each top-level value may be a literal or a JSON Logic
+          expression resolved against the current rule context.
+        additionalProperties: true
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
   # ActionForEach — iterate a collection, execute an inner action per item
   #
   # Create an income verification task for each SNAP-enrolled member:
@@ -383,10 +427,12 @@ $defs:
             $ref: "#/$defs/ActionCreateResource"
           appendToArray:
             $ref: "#/$defs/ActionAppendToArray"
-          triggerTransition:
-            $ref: "#/$defs/ActionTriggerTransition"
+          fireEvent:
+            $ref: "#/$defs/ActionFireEvent"
           forEach:
             $ref: "#/$defs/ActionForEach"
+          triggerTransition:
+            $ref: "#/$defs/ActionTriggerTransition"
         additionalProperties: true
       fallbackAction:
         type: object
@@ -401,6 +447,8 @@ $defs:
             $ref: "#/$defs/ActionCreateResource"
           appendToArray:
             $ref: "#/$defs/ActionAppendToArray"
+          fireEvent:
+            $ref: "#/$defs/ActionFireEvent"
           triggerTransition:
             $ref: "#/$defs/ActionTriggerTransition"
         additionalProperties: true

--- a/packages/contracts/src/validation/openapi-loader.js
+++ b/packages/contracts/src/validation/openapi-loader.js
@@ -133,6 +133,18 @@ export function extractMetadata(spec, resourceName) {
       metadata.schemas[schemaName] = schema;
     }
   }
+
+  // Extract event schemas: map full event type → resolved payload schema.
+  // The spec is already dereferenced by $RefParser, so payload is the inline schema object.
+  metadata.eventSchemas = {};
+  if (spec['x-events']) {
+    for (const eventDef of Object.values(spec['x-events'])) {
+      const fullType = eventDef.type;
+      const schema = eventDef.payload;
+      if (!fullType || !schema || typeof schema !== 'object') continue;
+      metadata.eventSchemas[fullType] = schema;
+    }
+  }
   
   // Extract error responses
   if (spec.components?.responses) {

--- a/packages/mock-server/mock-rules/README.md
+++ b/packages/mock-server/mock-rules/README.md
@@ -36,3 +36,32 @@ The mock server calls `discoverRules()` twice at startup: once for
 `packages/contracts/` (production rules) and once for this directory (mock rules).
 Both are merged and registered as event subscriptions. Production rules are never
 aware of the mock rules alongside them.
+
+## Mock stub registry
+
+Stubs let you pre-program specific outcomes before triggering a flow. Register a
+stub before creating the service call; when the `service_call.created` event fires,
+the stub is consumed and its result event fires instead of the default fallback.
+
+The response event is built from the contract: the `x-events` payload schema for
+the response type drives field population. Fields with matching names are copied
+from the trigger event's data; `serviceCallId` is derived from the trigger's
+`subject`. Only specify what changes:
+
+```bash
+# Pre-program an inconclusive result for fdsh_ssa calls
+curl -s -X POST http://localhost:1080/mock/stubs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "on": "data_exchange.service_call.created",
+    "match": { "data.serviceType": "fdsh_ssa" },
+    "respond": {
+      "type": "data_exchange.call.completed",
+      "data": { "result": "inconclusive" }
+    }
+  }'
+```
+
+The `match` field is optional — omit it to match any service call regardless of type.
+
+When multiple stubs match the same event, they are consumed in registration order (FIFO). Register stubs in the order you expect events to arrive.

--- a/packages/mock-server/mock-rules/README.md
+++ b/packages/mock-server/mock-rules/README.md
@@ -1,0 +1,38 @@
+# Mock Simulation Rules
+
+Rule sets in this directory simulate external system behavior (adapters) during
+local development and integration testing. They use the same schema as production
+rules (`packages/contracts/schemas/rules-schema.yaml`) but are loaded exclusively
+by the mock server — never deployed to production.
+
+## Purpose
+
+In production, external adapters subscribe to domain events and call real services
+(SSA, FDSH, USCIS SAVE, etc.), then emit result events. Mock simulation rules
+replace that adapter behavior by subscribing to the same trigger events and
+immediately firing the equivalent result events with plausible fixture data.
+
+Example flow with mock rules active:
+1. Intake rules create a `data-exchange/service-calls` record
+   → mock server emits `data_exchange.service_call.created`
+2. A mock rule fires on `data_exchange.service_call.created`
+   → fires `data_exchange.call.completed` with fixture result data
+3. Intake rules react to `data_exchange.call.completed` as normal
+
+## Conventions
+
+- **File naming:** `{domain}-mock-rules.yaml` (e.g., `data-exchange-mock-rules.yaml`)
+- **Rule set IDs:** Must be prefixed with `mock.` (e.g., `mock.simulate-call-completion`)
+  to prevent ID collision with production rule sets if both are loaded together
+- **Event types:** Use the same CloudEvents type names that real adapters would emit —
+  downstream subscribers must not know or care whether the event came from a real
+  adapter or a mock rule
+- **CloudEvents naming:** All event type segments use snake_case (underscores).
+  `on: data_exchange.call.completed`, not `on: data-exchange.call.completed`
+
+## Loading
+
+The mock server calls `discoverRules()` twice at startup: once for
+`packages/contracts/` (production rules) and once for this directory (mock rules).
+Both are merged and registered as event subscriptions. Production rules are never
+aware of the mock rules alongside them.

--- a/packages/mock-server/mock-rules/data-exchange-mock-rules.yaml
+++ b/packages/mock-server/mock-rules/data-exchange-mock-rules.yaml
@@ -1,0 +1,33 @@
+$schema: "./mock-rules-schema.yaml"
+version: "1.0"
+domain: data-exchange
+resource: data-exchange/service-calls
+
+ruleSets:
+  # When a service call is created, check the stub registry for a pre-programmed
+  # response. If a matching stub exists it is consumed and its event fired.
+  # If no stub matches, fall back to a generic conclusive result so development
+  # can proceed without pre-registering stubs for every call.
+  - id: mock.simulate-call-completion
+    "on": data_exchange.service_call.created
+    evaluation: first-match-wins
+    rules:
+      - id: apply-stub-or-default
+        order: 1
+        condition: true
+        action:
+          applyStub:
+            fallback:
+              fireEvent:
+                type: data_exchange.call.completed
+                subject: {var: "this.subject"}
+                data:
+                  serviceCallId: {var: "this.subject"}
+                  serviceType: {var: "this.data.serviceType"}
+                  requestingResourceId: {var: "this.data.requestingResourceId"}
+                  result: conclusive
+                  metadata: {var: "this.data.metadata"}
+        description: |
+          Check stub registry for a pre-programmed response (POST /mock/stubs before
+          triggering the flow). Falls back to a generic conclusive result if no stub
+          matches, so scenarios work out of the box without pre-registration.

--- a/packages/mock-server/mock-rules/mock-rules-schema.yaml
+++ b/packages/mock-server/mock-rules/mock-rules-schema.yaml
@@ -1,0 +1,242 @@
+# JSON Schema for mock simulation rule YAML files.
+# Extends the production rules schema (packages/contracts/schemas/rules-schema.yaml)
+# with the applyStub platform action, which is available only in the mock server.
+#
+# Differences from production rules-schema.yaml:
+#   - RuleSet.id must be prefixed with "mock." to prevent ID collisions
+#   - Rule.action adds applyStub (ActionApplyStub)
+#
+# Validated by: node packages/contracts/scripts/validate-schemas.js --spec=packages/mock-server/mock-rules
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Mock Rules
+description: Schema for mock simulation rule YAML files loaded exclusively by the mock server.
+type: object
+required:
+  - version
+  - domain
+  - resource
+  - ruleSets
+additionalProperties: false
+
+properties:
+  version:
+    type: string
+    description: Schema version for change tracking.
+
+  domain:
+    type: string
+    description: Domain namespace (e.g., data-exchange).
+
+  resource:
+    type: string
+    pattern: "^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)+$"
+    description: The calling resource type in domain/resource format (e.g., data-exchange/service-calls).
+
+  ruleSets:
+    type: array
+    description: Grouped sets of rules, filterable by ruleType.
+    items:
+      $ref: "#/$defs/RuleSet"
+    minItems: 1
+
+$defs:
+  # ---------------------------------------------------------------------------
+  # ActionApplyStub — check the stub registry and fire a pre-programmed response
+  #
+  # action:
+  #   applyStub:
+  #     fallback:
+  #       fireEvent:
+  #         type: data_exchange.call.completed
+  #         subject: {var: "this.subject"}
+  #         data:
+  #           result: conclusive
+  # ---------------------------------------------------------------------------
+  ActionApplyStub:
+    type: object
+    description: >
+      Checks the stub registry for a pre-programmed response to the current event.
+      If a matching stub is found it is consumed (FIFO) and its respond event is fired.
+      If no stub matches, the `fallback` action is executed instead.
+      Only meaningful in event-triggered rule sets — `resource` is the event envelope.
+      Stubs are registered via POST /mock/stubs before triggering the flow.
+    properties:
+      fallback:
+        type: object
+        description: Action to execute when no stub matches.
+        properties:
+          fireEvent:
+            $ref: "#/$defs/ActionFireEvent"
+        additionalProperties: false
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # ActionFireEvent — emit an arbitrary outbound event from a rule action
+  # ---------------------------------------------------------------------------
+  ActionFireEvent:
+    type: object
+    description: >
+      Emits an arbitrary outbound CloudEvent from a rule action. Field values in
+      `data`, `subject`, and `source` may be literals or JSON Logic expressions
+      resolved against the current rule context.
+    required: [type]
+    properties:
+      type:
+        type: string
+        description: >
+          CloudEvents type suffix (e.g., "data_exchange.call.completed"). The
+          platform prefix (org.codeforamerica.safety-net-blueprint.) is prepended
+          automatically if not already present.
+      subject:
+        description: CloudEvents subject. May be a literal or a JSON Logic expression.
+      source:
+        description: CloudEvents source. Defaults to "/system" if omitted.
+      data:
+        type: object
+        description: Event payload. Each top-level value may be a literal or a JSON Logic expression.
+        additionalProperties: true
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # ActionCreateResource — create a new resource with literal or JSON Logic fields
+  # ---------------------------------------------------------------------------
+  ActionCreateResource:
+    type: object
+    description: Creates a new resource in the specified domain/collection.
+    required: [entity, fields]
+    properties:
+      entity:
+        type: string
+        pattern: "^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)+$"
+        description: Target entity in domain/resource format (e.g., workflow/tasks).
+      fields:
+        type: object
+        description: Field name/value pairs. Values may be literals or JSON Logic expressions.
+        minProperties: 1
+        additionalProperties: true
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # ActionTriggerTransition — trigger a state machine transition on a related entity
+  # ---------------------------------------------------------------------------
+  ActionTriggerTransition:
+    type: object
+    description: Triggers a state machine transition on a related entity.
+    required: [entity, idFrom, transition]
+    properties:
+      entity:
+        type: string
+        pattern: "^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)+$"
+      idFrom:
+        type: string
+        description: Dot-path in the rule context whose value is the ID of the entity to transition.
+      transition:
+        type: string
+        description: The transition trigger to invoke (e.g., "open", "submit").
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # ContextBinding — declare entities and collections available during rule evaluation
+  # ---------------------------------------------------------------------------
+  ContextBinding:
+    type: object
+    description: Declares a related entity or collection to resolve before rule evaluation.
+    required: [as, from]
+    properties:
+      as:
+        type: string
+      entity:
+        type: string
+        pattern: "^[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)+$"
+      from:
+        oneOf:
+          - type: string
+          - type: object
+            required: [var]
+            properties:
+              var:
+                type: string
+            additionalProperties: false
+      optional:
+        type: boolean
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # RuleSet — rule set IDs must be prefixed with "mock." to avoid collision
+  #           with production rule sets when both are loaded together.
+  # ---------------------------------------------------------------------------
+  RuleSet:
+    type: object
+    description: >
+      A group of rules with a shared type and evaluation strategy.
+      Rule set IDs must be prefixed with "mock." to avoid ID collisions with
+      production rule sets when both are loaded together.
+    required:
+      - id
+      - evaluation
+      - rules
+    properties:
+      id:
+        type: string
+        pattern: "^mock\\."
+        description: Unique identifier, must be prefixed with "mock." (e.g., "mock.simulate-call-completion").
+      ruleType:
+        type: string
+      "on":
+        type: string
+        description: >
+          CloudEvents type suffix to subscribe to (underscores, no platform prefix).
+          e.g., "data_exchange.service_call.created" — not "data-exchange.service-call.created".
+      evaluation:
+        type: string
+        enum:
+          - first-match-wins
+          - all-match
+      context:
+        type: array
+        items:
+          $ref: "#/$defs/ContextBinding"
+      rules:
+        type: array
+        items:
+          $ref: "#/$defs/Rule"
+        minItems: 1
+    additionalProperties: false
+
+  # ---------------------------------------------------------------------------
+  # Rule — same as production, with applyStub added to action.properties
+  # ---------------------------------------------------------------------------
+  Rule:
+    type: object
+    description: A single rule with a condition and action.
+    required:
+      - id
+      - order
+      - condition
+      - action
+    properties:
+      id:
+        type: string
+      order:
+        type: integer
+        minimum: 1
+      condition:
+        description: JSON Logic expression or `true` for a catch-all rule.
+      action:
+        type: object
+        description: One or more actions to execute when this rule matches.
+        minProperties: 1
+        properties:
+          applyStub:
+            $ref: "#/$defs/ActionApplyStub"
+          createResource:
+            $ref: "#/$defs/ActionCreateResource"
+          fireEvent:
+            $ref: "#/$defs/ActionFireEvent"
+          triggerTransition:
+            $ref: "#/$defs/ActionTriggerTransition"
+        additionalProperties: true
+      description:
+        type: string
+    additionalProperties: false

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -20,6 +20,7 @@
     "validate:seed": "node scripts/validate-seed.js --spec=../contracts --seed=./seed",
     "setup": "node scripts/setup.js --spec=../contracts",
     "reset": "node scripts/reset.js --spec=../contracts",
+    "validate": "node ../contracts/scripts/validate-schemas.js --spec=mock-rules",
     "test": "node tests/run-all-tests.js --unit",
     "test:unit": "node tests/run-all-tests.js --unit",
     "test:integration": "node tests/run-all-tests.js --integration",

--- a/packages/mock-server/scripts/server.js
+++ b/packages/mock-server/scripts/server.js
@@ -18,6 +18,7 @@ import { closeAll } from '../src/database-manager.js';
 import { validateJSON } from '../src/validator.js';
 import { createSseHandler } from '../src/handlers/sse-handler.js';
 import { emitEventEnvelope } from '../src/emit-event.js';
+import { registerStub, listStubs, removeStub, clearStubs } from '../src/mock-stub-engine.js';
 
 const HOST = process.env.MOCK_SERVER_HOST || 'localhost';
 const PORT = parseInt(process.env.MOCK_SERVER_PORT || '1080', 10);
@@ -166,6 +167,34 @@ async function startMockServer(specDirs = null, seedDir = null) {
       }
     });
     console.log('  POST   /platform/events - Inject external domain event (testing)');
+
+    // Mock stub registry endpoints — for pre-programming event responses in tests.
+    // See packages/mock-server/mock-rules/README.md for full usage documentation.
+    app.post('/mock/stubs', (req, res) => {
+      try {
+        const stub = registerStub(req.body);
+        res.status(201).json(stub);
+      } catch (err) {
+        res.status(422).json({ code: 'VALIDATION_ERROR', message: err.message });
+      }
+    });
+    app.get('/mock/stubs', (req, res) => {
+      const items = listStubs();
+      res.json({ items, total: items.length });
+    });
+    app.delete('/mock/stubs', (req, res) => {
+      clearStubs();
+      res.status(204).end();
+    });
+    app.delete('/mock/stubs/:id', (req, res) => {
+      const removed = removeStub(req.params.id);
+      if (!removed) return res.status(404).json({ code: 'NOT_FOUND', message: `Stub "${req.params.id}" not found` });
+      res.status(204).end();
+    });
+    console.log('  POST   /mock/stubs - Register a stub response');
+    console.log('  GET    /mock/stubs - List active stubs');
+    console.log('  DELETE /mock/stubs/:id - Remove a stub');
+    console.log('  DELETE /mock/stubs - Clear all stubs');
 
     // Register event subscriptions (event-triggered rule sets)
     registerEventSubscriptions(allRules, allStateMachines, allSlaTypes);

--- a/packages/mock-server/scripts/server.js
+++ b/packages/mock-server/scripts/server.js
@@ -19,6 +19,7 @@ import { validateJSON } from '../src/validator.js';
 import { createSseHandler } from '../src/handlers/sse-handler.js';
 import { emitEventEnvelope } from '../src/emit-event.js';
 import { registerStub, listStubs, removeStub, clearStubs } from '../src/mock-stub-engine.js';
+import { findById } from '../src/database-manager.js';
 
 const HOST = process.env.MOCK_SERVER_HOST || 'localhost';
 const PORT = parseInt(process.env.MOCK_SERVER_PORT || '1080', 10);
@@ -197,7 +198,23 @@ async function startMockServer(specDirs = null, seedDir = null) {
     console.log('  DELETE /mock/stubs - Clear all stubs');
 
     // Register event subscriptions (event-triggered rule sets)
-    registerEventSubscriptions(allRules, allStateMachines, allSlaTypes);
+    registerEventSubscriptions(allRules, allStateMachines, allSlaTypes, apiSpecs);
+
+    // Enrich service call creation with catalog-derived fields (after schema validation).
+    // Copies serviceType and callMode from the referenced ExternalService, sets status to pending.
+    // Uses req.enrichmentData so these fields bypass ExternalServiceCallCreate validation
+    // (they're server-derived, not client-provided) but are stored in the resource.
+    app.post('/data-exchange/service-calls', (req, res, next) => {
+      const service = req.body?.serviceId ? findById('services', req.body.serviceId) : null;
+      if (service) {
+        req.enrichmentData = {
+          serviceType: service.serviceType,
+          callMode: req.body.callMode ?? service.defaultCallMode,
+          status: 'pending',
+        };
+      }
+      next();
+    });
 
     // Register API routes dynamically
     const baseUrl = `http://${HOST}:${PORT}`;

--- a/packages/mock-server/src/emit-event.js
+++ b/packages/mock-server/src/emit-event.js
@@ -12,6 +12,8 @@ import { randomUUID } from 'crypto';
 import { create, insertResource } from './database-manager.js';
 import { eventBus } from './event-bus.js';
 
+export const CLOUDEVENTS_TYPE_PREFIX = 'org.codeforamerica.safety-net-blueprint.';
+
 /**
  * Emit a pre-built CloudEvents 1.0 envelope directly to the event bus.
  * Used by POST /platform/events to inject externally-sourced domain events
@@ -54,7 +56,9 @@ export function emitEventEnvelope(envelope) {
  */
 export function emitEvent({ domain, object, action, resourceId, source, data = null, callerId = null, traceparent = null, now = null }) {
   const timestamp = now || new Date().toISOString();
-  const type = `org.codeforamerica.safety-net-blueprint.${domain}.${object}.${action}`;
+  const normalizedDomain = domain.replace(/-/g, '_');
+  const normalizedObject = object.replace(/-/g, '_');
+  const type = `${CLOUDEVENTS_TYPE_PREFIX}${normalizedDomain}.${normalizedObject}.${action}`;
 
   const envelope = {
     specversion: '1.0',

--- a/packages/mock-server/src/event-subscription.js
+++ b/packages/mock-server/src/event-subscription.js
@@ -60,7 +60,12 @@ function findStateMachineForEntity(entity, allStateMachines) {
  * Build rich deps for platform actions (createResource, triggerTransition).
  * These actions need access to the full server context: DB, state machines, rules.
  */
-function buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes) {
+function buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes, apiSpecs = []) {
+  // Build a combined map of full event type → payload schema from all loaded specs
+  const eventSchemas = {};
+  for (const spec of apiSpecs) {
+    if (spec.eventSchemas) Object.assign(eventSchemas, spec.eventSchemas);
+  }
   return {
     // For assignToQueue / setPriority (existing on-demand deps)
     findByField(collection, field, value) {
@@ -93,6 +98,9 @@ function buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes)
       }
     },
 
+    // For applyStub — schema-aware response construction
+    eventSchemas,
+
     // For triggerTransition / appendToArray
     resolvePath,
     dbFindById: findById,
@@ -108,7 +116,7 @@ function buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes)
  * @param {Array} allStateMachines - from discoverStateMachines()
  * @param {Array} [allSlaTypes]    - from discoverSlaTypes()
  */
-export function registerEventSubscriptions(allRules, allStateMachines, allSlaTypes = []) {
+export function registerEventSubscriptions(allRules, allStateMachines, allSlaTypes = [], apiSpecs = []) {
   // Collect all event-triggered rule sets across all rule files
   const subscriptions = [];
   for (const ruleFile of allRules) {
@@ -139,7 +147,7 @@ export function registerEventSubscriptions(allRules, allStateMachines, allSlaTyp
         const ruleContext = buildRuleContext(event, resolvedEntities);
 
         // Build rich deps for platform actions (needed for both evaluation paths)
-        const deps = buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes);
+        const deps = buildPlatformDeps(ruleContext, allRules, allStateMachines, allSlaTypes, apiSpecs);
 
         if (ruleSet.evaluation === 'all-match') {
           // Execute every matching rule's action in order

--- a/packages/mock-server/src/event-subscription.js
+++ b/packages/mock-server/src/event-subscription.js
@@ -19,10 +19,8 @@ import { executeActions } from './action-handlers.js';
 import { executeTransition } from './state-machine-runner.js';
 import { applyEffects } from './state-machine-engine.js';
 import { processRuleEvaluations } from './handlers/rule-evaluation.js';
-import { emitEvent } from './emit-event.js';
+import { emitEvent, CLOUDEVENTS_TYPE_PREFIX } from './emit-event.js';
 import { deriveCollectionName } from './collection-utils.js';
-
-const FULL_TYPE_PREFIX = 'org.codeforamerica.safety-net-blueprint.';
 
 /**
  * Test whether a CloudEvents type matches the `on:` field value.
@@ -35,7 +33,7 @@ function eventTypeMatches(eventType, onValue) {
   if (!onValue || !eventType) return false;
   if (eventType === onValue) return true;
   // Short form: accept if the event type ends with the declared suffix
-  return eventType === FULL_TYPE_PREFIX + onValue;
+  return eventType === CLOUDEVENTS_TYPE_PREFIX + onValue;
 }
 
 /**

--- a/packages/mock-server/src/handlers/create-handler.js
+++ b/packages/mock-server/src/handlers/create-handler.js
@@ -44,8 +44,10 @@ export function createCreateHandler(apiMetadata, endpoint, baseUrl, stateMachine
         }
       }
 
-      // Create resource in database
-      const resource = create(endpoint.collectionName, req.body);
+      // Create resource in database — merge any enrichment data set by pre-create middleware
+      // (e.g. catalog-derived fields that aren't in the create schema)
+      const createData = req.enrichmentData ? { ...req.body, ...req.enrichmentData } : req.body;
+      const resource = create(endpoint.collectionName, createData);
 
       // Mark runtime-created resources as user-sourced when the collection
       // also has config-managed (system) entries, so consumers can distinguish them

--- a/packages/mock-server/src/mock-stub-engine.js
+++ b/packages/mock-server/src/mock-stub-engine.js
@@ -1,0 +1,126 @@
+/**
+ * Mock stub engine — in-memory registry for pre-programmed event responses.
+ *
+ * Stubs let developers register expected responses before running a scenario.
+ * When a domain event fires, the stub engine scans registered stubs in order
+ * (FIFO) and pops the first one whose `on` and `match` criteria fit the event.
+ * If no stub matches, the caller falls back to its default behavior.
+ *
+ * Stubs are ephemeral — cleared on server restart or via DELETE /mock/stubs.
+ *
+ * See packages/mock-server/mock-rules/README.md for usage patterns.
+ */
+
+import { CLOUDEVENTS_TYPE_PREFIX } from './emit-event.js';
+
+/** Ordered list of registered stubs. */
+const stubs = [];
+
+/** Per-event-suffix counters for generating human-readable IDs. */
+const idCounters = new Map();
+
+/**
+ * Derive a human-readable stub ID from the `on` event type.
+ * "data_exchange.service_call.created" → "service_call.created-1"
+ */
+function nextId(on) {
+  const short = on.startsWith(CLOUDEVENTS_TYPE_PREFIX)
+    ? on.slice(CLOUDEVENTS_TYPE_PREFIX.length)
+    : on;
+  const parts = short.split('.');
+  const prefix = parts.slice(-2).join('.');
+  const n = (idCounters.get(prefix) ?? 0) + 1;
+  idCounters.set(prefix, n);
+  return `${prefix}-${n}`;
+}
+
+/**
+ * Resolve a dot-path against an object.
+ * "data.serviceType" → obj.data.serviceType
+ */
+function getPath(obj, path) {
+  return path.split('.').reduce((cur, key) => cur?.[key], obj);
+}
+
+/**
+ * Test whether a stub's `on` value matches the given CloudEvents type.
+ * Accepts the full type or a short suffix (same logic as eventTypeMatches).
+ */
+function onMatches(eventType, on) {
+  if (!on || !eventType) return false;
+  if (eventType === on) return true;
+  return eventType === CLOUDEVENTS_TYPE_PREFIX + on;
+}
+
+/**
+ * Test whether a stub's `match` criteria all match the event envelope.
+ * Each key in match is a dot-path into the envelope; each value is the
+ * expected value. Omitting `match` (or passing an empty object) matches
+ * any event of the matching type.
+ */
+function matchCriteria(stub, envelope) {
+  if (!stub.match || Object.keys(stub.match).length === 0) return true;
+  for (const [path, expected] of Object.entries(stub.match)) {
+    if (getPath(envelope, path) !== expected) return false;
+  }
+  return true;
+}
+
+/**
+ * Register a stub. Returns the stored stub with its assigned ID.
+ *
+ * @param {Object} stub
+ * @param {string} stub.on       - CloudEvents type suffix to match (e.g., "data_exchange.service_call.created")
+ * @param {Object} [stub.match]  - Dot-path field matchers against the event envelope (e.g., { "data.serviceType": "fdsh_ssa" })
+ * @param {Object} stub.respond  - Event to fire when matched: { type, subject?, source?, data? }
+ * @returns {Object} The registered stub with id assigned
+ */
+export function registerStub(stub) {
+  const { on, respond } = stub;
+  if (!on || !respond?.type) {
+    throw new Error('Stub requires "on" (event type suffix) and "respond.type" (response event type)');
+  }
+  const registered = { ...stub, id: nextId(on) };
+  stubs.push(registered);
+  return registered;
+}
+
+/**
+ * Scan stubs in registration order, find and remove the first one that
+ * matches the given event type and envelope fields.
+ *
+ * @param {string} eventType  - Full CloudEvents type of the triggering event
+ * @param {Object} envelope   - The full event envelope (for match field resolution)
+ * @returns {Object|null} The matched stub, or null if none matched
+ */
+export function matchAndPop(eventType, envelope) {
+  const idx = stubs.findIndex(s => onMatches(eventType, s.on) && matchCriteria(s, envelope));
+  if (idx === -1) return null;
+  return stubs.splice(idx, 1)[0];
+}
+
+/**
+ * Return a snapshot of all registered stubs.
+ */
+export function listStubs() {
+  return [...stubs];
+}
+
+/**
+ * Remove a specific stub by ID.
+ * @returns {boolean} true if found and removed, false if not found
+ */
+export function removeStub(id) {
+  const idx = stubs.findIndex(s => s.id === id);
+  if (idx === -1) return false;
+  stubs.splice(idx, 1);
+  return true;
+}
+
+/**
+ * Remove all registered stubs and reset ID counters.
+ */
+export function clearStubs() {
+  stubs.length = 0;
+  idCounters.clear();
+}

--- a/packages/mock-server/src/platform-action-handlers.js
+++ b/packages/mock-server/src/platform-action-handlers.js
@@ -6,6 +6,8 @@
 
 import jsonLogic from 'json-logic-js';
 import { deriveCollectionName } from './collection-utils.js';
+import { emitEventEnvelope, CLOUDEVENTS_TYPE_PREFIX } from './emit-event.js';
+import { matchAndPop } from './mock-stub-engine.js';
 
 /**
  * Create a new resource in the specified domain/collection.
@@ -252,9 +254,127 @@ function forEach(actionValue, resource, deps) {
   }
 }
 
+/**
+ * Fire an arbitrary outbound event from a rule action.
+ * Allows rules to emit domain events directly without requiring a state machine
+ * transition as intermediary — needed for cross-domain fanout.
+ *
+ * Field values in `data` may be literals or JSON Logic expressions resolved
+ * against the current rule context. `subject` and `source` follow the same pattern.
+ *
+ * @param {Object} actionValue - {
+ *   type: string,              // short event type suffix (e.g., "data_exchange.call.completed")
+ *   subject?: literal|logic,   // CloudEvents subject (resource ID)
+ *   source?: literal|logic,    // CloudEvents source (defaults to "/system")
+ *   data?: { key: literal|logic, ... }  // event payload; each value resolved individually
+ * }
+ * @param {Object} resource - The current "this" context
+ * @param {Object} deps     - { context }
+ */
+function fireEvent(actionValue, resource, deps) {
+  const { type, subject, source, data } = actionValue || {};
+  if (!type) {
+    console.error('fireEvent: missing required field "type"');
+    return;
+  }
+
+  const ctx = deps.context || {};
+
+  const resolveValue = (v) => {
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      return jsonLogic.apply(v, ctx);
+    }
+    return v;
+  };
+
+  const resolvedSubject = subject !== undefined ? resolveValue(subject) : null;
+  const resolvedSource = source !== undefined ? resolveValue(source) : null;
+
+  let resolvedData = null;
+  if (data !== null && data !== undefined && typeof data === 'object' && !Array.isArray(data)) {
+    resolvedData = {};
+    for (const [k, v] of Object.entries(data)) {
+      resolvedData[k] = resolveValue(v);
+    }
+  }
+
+  const fullType = type.startsWith(CLOUDEVENTS_TYPE_PREFIX) ? type : CLOUDEVENTS_TYPE_PREFIX + type;
+
+  emitEventEnvelope({
+    type: fullType,
+    source: resolvedSource || '/system',
+    subject: resolvedSubject,
+    data: resolvedData
+  });
+}
+
+/**
+ * Check the stub registry for a pre-programmed response to the current event.
+ * If a matching stub is found it is popped (consumed) and its respond event is
+ * fired. If no stub matches, the `fallback` action (typically a fireEvent) is
+ * executed instead.
+ *
+ * Only meaningful in event-triggered rule sets — `resource` is the event
+ * envelope, which provides both the type for stub matching and the context for
+ * JSON Logic resolution in respond field values.
+ *
+ * @param {Object} actionValue - { fallback?: { fireEvent: {...} } }
+ * @param {Object} resource    - The current event envelope ("this" context)
+ * @param {Object} deps        - { context }
+ */
+function applyStub(actionValue, resource, deps) {
+  const eventType = resource?.type;
+  if (!eventType) {
+    console.warn('applyStub: no event type on resource — skipping stub lookup');
+    return;
+  }
+
+  const stub = matchAndPop(eventType, resource);
+
+  if (stub) {
+    const ctx = deps.context || {};
+    const resolveValue = (v) => {
+      if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+        return jsonLogic.apply(v, ctx);
+      }
+      return v;
+    };
+
+    const { type, subject, source, data } = stub.respond;
+    const fullType = type.startsWith(CLOUDEVENTS_TYPE_PREFIX) ? type : CLOUDEVENTS_TYPE_PREFIX + type;
+
+    let resolvedData = null;
+    if (data !== null && data !== undefined && typeof data === 'object' && !Array.isArray(data)) {
+      resolvedData = {};
+      for (const [k, v] of Object.entries(data)) {
+        resolvedData[k] = resolveValue(v);
+      }
+    }
+
+    emitEventEnvelope({
+      type: fullType,
+      source: source ? resolveValue(source) : '/system',
+      subject: subject !== undefined ? resolveValue(subject) : null,
+      data: resolvedData
+    });
+
+    console.log(`[stub] matched ${stub.id} → fired ${fullType}`);
+  } else {
+    // No stub matched — execute the fallback action if provided
+    const { fallback } = actionValue || {};
+    if (fallback?.fireEvent) {
+      fireEvent(fallback.fireEvent, resource, deps);
+    } else if (fallback) {
+      console.warn('applyStub: fallback action type not supported — only fireEvent is currently implemented');
+    }
+  }
+}
+
 export const platformActionRegistry = new Map([
-  ['createResource', createResource],
-  ['triggerTransition', triggerTransition],
+  ['applyStub', applyStub],
   ['appendToArray', appendToArray],
-  ['forEach', forEach]
+  ['createResource', createResource],
+  ['fireEvent', fireEvent],
+  ['forEach', forEach],
+  ['triggerTransition', triggerTransition],
 ]);

--- a/packages/mock-server/src/platform-action-handlers.js
+++ b/packages/mock-server/src/platform-action-handlers.js
@@ -340,21 +340,62 @@ function applyStub(actionValue, resource, deps) {
       return v;
     };
 
-    const { type, subject, source, data } = stub.respond;
+    const { type, subject, source, data: stubData } = stub.respond;
     const fullType = type.startsWith(CLOUDEVENTS_TYPE_PREFIX) ? type : CLOUDEVENTS_TYPE_PREFIX + type;
 
-    let resolvedData = null;
-    if (data !== null && data !== undefined && typeof data === 'object' && !Array.isArray(data)) {
-      resolvedData = {};
-      for (const [k, v] of Object.entries(data)) {
-        resolvedData[k] = resolveValue(v);
+    // Subject: use stub's explicit value, or echo trigger's subject.
+    const resolvedSubject = subject !== undefined ? resolveValue(subject) : resource.subject;
+
+    // Build response data using the payload schema for the response event type.
+    // For each schema field: match by name from trigger data, or derive from
+    // the trigger event's entity name for *Id fields (e.g. serviceCallId → subject).
+    // Stub's explicit data fields override anything derived from the schema.
+    const schema = deps.eventSchemas?.[fullType];
+    const triggerData = (resource.data && typeof resource.data === 'object') ? resource.data : {};
+    const resolvedStubData = {};
+    if (stubData && typeof stubData === 'object' && !Array.isArray(stubData)) {
+      for (const [k, v] of Object.entries(stubData)) {
+        resolvedStubData[k] = resolveValue(v);
       }
+    }
+
+    let resolvedData = null;
+    if (schema?.properties) {
+      // Derive entity name from trigger event type for *Id field resolution.
+      // "org...data_exchange.service_call.created" → "service_call" → "serviceCall"
+      const shortType = resource.type?.startsWith(CLOUDEVENTS_TYPE_PREFIX)
+        ? resource.type.slice(CLOUDEVENTS_TYPE_PREFIX.length)
+        : (resource.type || '');
+      const parts = shortType.split('.');
+      const entitySnake = parts.length >= 2 ? parts[parts.length - 2] : '';
+      const entityCamel = entitySnake.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      const entityIdField = entityCamel ? entityCamel + 'Id' : null;
+
+      resolvedData = {};
+      for (const field of Object.keys(schema.properties)) {
+        if (field in resolvedStubData) {
+          resolvedData[field] = resolvedStubData[field];
+        } else if (field in triggerData) {
+          resolvedData[field] = triggerData[field];
+        } else if (entityIdField && field === entityIdField) {
+          // e.g. serviceCallId → trigger subject (the resource's own ID)
+          resolvedData[field] = triggerData.id ?? resource.subject;
+        }
+        // Fields not derivable are omitted; stub must specify them explicitly.
+      }
+      // Include any stub-specified fields not in the schema (extra context, overrides).
+      for (const [k, v] of Object.entries(resolvedStubData)) {
+        if (!(k in resolvedData)) resolvedData[k] = v;
+      }
+    } else {
+      // No schema available — fall back to stub data only.
+      resolvedData = Object.keys(resolvedStubData).length > 0 ? resolvedStubData : null;
     }
 
     emitEventEnvelope({
       type: fullType,
       source: source ? resolveValue(source) : '/system',
-      subject: subject !== undefined ? resolveValue(subject) : null,
+      subject: resolvedSubject,
       data: resolvedData
     });
 

--- a/packages/mock-server/src/setup.js
+++ b/packages/mock-server/src/setup.js
@@ -14,7 +14,7 @@ import { discoverMetrics } from './metrics-loader.js';
 import { discoverConfigs } from './config-loader.js';
 import { insertResource } from './database-manager.js';
 import { registerConfigManaged } from './config-registry.js';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/mock-server/src/setup.js
+++ b/packages/mock-server/src/setup.js
@@ -90,10 +90,13 @@ export async function performSetup({ specsDir, seedDir, verbose = true, skipVali
     stateMachines.forEach(sm => console.log(`  - ${sm.domain}/${sm.object}`));
   }
 
-  // Discover rule contracts
-  const rules = discoverRules(specsDir);
+  // Discover rule contracts (production) and mock simulation rules (development-only)
+  const productionRules = discoverRules(specsDir);
+  const mockRulesDir = join(__dirname, '..', 'mock-rules');
+  const mockRules = discoverRules(mockRulesDir);
+  const rules = [...productionRules, ...mockRules];
   if (verbose && rules.length > 0) {
-    console.log(`\n✓ Discovered ${rules.length} rule set(s):`);
+    console.log(`\n✓ Discovered ${productionRules.length} production rule file(s) + ${mockRules.length} mock simulation rule file(s):`);
     rules.forEach(r => console.log(`  - ${r.domain} (${r.ruleSets.length} ruleSet(s))`));
   }
 

--- a/packages/mock-server/tests/integration/integration.test.js
+++ b/packages/mock-server/tests/integration/integration.test.js
@@ -276,7 +276,8 @@ async function testApi(api, examples) {
   }
 
   // Test 6: POST - Validation error (422)
-  const hasPostEndpoint = api.endpoints.some(e => e.method === 'POST');
+  // Only test if this specific collection path has a POST endpoint (not just any endpoint in the API).
+  const hasPostEndpoint = api.endpoints.some(e => e.method === 'POST' && e.path === apiPath);
   if (hasPostEndpoint) {
     try {
       console.log(`\n  6. POST ${apiPath} - validation error`);
@@ -1004,7 +1005,7 @@ async function runTests() {
       const response = await fetch(`${BASE_URL}${taskPath}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Caller-Id': 'worker-rule-2' },
-        body: JSON.stringify({ name: 'Medical Assistance task', status: 'pending', programType: 'medical_assistance', isExpedited: false })
+        body: JSON.stringify({ name: 'Medical Assistance task', status: 'pending', programType: 'medicaid', isExpedited: false })
       });
 
       if (response.status === 201) {

--- a/packages/mock-server/tests/integration/mock-stubs.test.js
+++ b/packages/mock-server/tests/integration/mock-stubs.test.js
@@ -141,15 +141,15 @@ async function testStubConsumedOnEvent() {
   console.log('\n--- Stub consumed by trigger event ---');
   await clearStubs();
 
-  // Register stub for the trigger event
+  // Register stub — only the delta from the trigger event is needed.
+  // subject and trigger data fields are echoed automatically.
   await fetch(`${BASE_URL}/mock/stubs`, {
     method: 'POST',
     body: {
       on: 'data_exchange.service_call.created',
       respond: {
         type: 'data_exchange.call.completed',
-        subject: { var: 'this.subject' },
-        data: { result: 'inconclusive', serviceType: 'fdsh_ssa' }
+        data: { result: 'inconclusive' }
       }
     }
   });

--- a/packages/mock-server/tests/integration/mock-stubs.test.js
+++ b/packages/mock-server/tests/integration/mock-stubs.test.js
@@ -1,0 +1,310 @@
+/**
+ * Integration tests for mock stub registry and inter-domain event simulation.
+ *
+ * Tests the full chain: register a stub → inject trigger event → verify stub
+ * was consumed and response event was stored. Also tests /mock/stubs CRUD and
+ * fallback behavior when no stub is registered.
+ *
+ * Run with: npm run test:integration
+ * (requires mock server running on port 1080)
+ */
+
+import http from 'http';
+import { URL } from 'url';
+
+const BASE_URL = 'http://localhost:1080';
+const PREFIX = 'org.codeforamerica.safety-net-blueprint.';
+
+// Simple http fetch wrapper (reused from integration.test.js pattern)
+async function fetch(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const requestOptions = {
+      hostname: urlObj.hostname,
+      port: urlObj.port || 80,
+      path: urlObj.pathname + urlObj.search,
+      method: options.method || 'GET',
+      headers: options.headers || {}
+    };
+
+    if (options.body) {
+      const bodyString = JSON.stringify(options.body);
+      requestOptions.headers['Content-Length'] = Buffer.byteLength(bodyString);
+      requestOptions.headers['Content-Type'] = requestOptions.headers['Content-Type'] || 'application/json';
+    }
+
+    const req = http.request(requestOptions, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          status: res.statusCode,
+          json: async () => JSON.parse(data),
+          text: async () => data
+        });
+      });
+    });
+
+    req.on('error', reject);
+    if (options.body) req.write(JSON.stringify(options.body));
+    req.end();
+  });
+}
+
+async function clearStubs() {
+  await fetch(`${BASE_URL}/mock/stubs`, { method: 'DELETE' });
+}
+
+async function injectEvent(type, data = {}, subject = 'sub-test-1') {
+  return fetch(`${BASE_URL}/platform/events`, {
+    method: 'POST',
+    body: {
+      specversion: '1.0',
+      type: PREFIX + type,
+      source: '/test',
+      subject,
+      data
+    }
+  });
+}
+
+// =============================================================================
+// /mock/stubs CRUD
+// =============================================================================
+
+async function testStubCrud() {
+  console.log('\n--- /mock/stubs CRUD ---');
+  await clearStubs();
+
+  // POST — register a stub
+  const postRes = await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: {
+      on: 'data_exchange.service_call.created',
+      respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+    }
+  });
+  assert(postRes.status === 201, `POST /mock/stubs → expected 201, got ${postRes.status}`);
+  const stub = await postRes.json();
+  assert(stub.id, 'stub should have an id');
+  assert(stub.id.startsWith('service_call.created-'), `unexpected id format: ${stub.id}`);
+  console.log('  ✓ POST /mock/stubs registers a stub with human-readable ID');
+
+  // GET — list stubs
+  const getRes = await fetch(`${BASE_URL}/mock/stubs`);
+  assert(getRes.status === 200, `GET /mock/stubs → expected 200, got ${getRes.status}`);
+  const list = await getRes.json();
+  assert(list.total === 1, `expected 1 stub, got ${list.total}`);
+  assert(list.items.length === 1);
+  console.log('  ✓ GET /mock/stubs lists registered stubs');
+
+  // Register a second stub
+  await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: { on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } } }
+  });
+
+  // DELETE /:id — remove a specific stub
+  const delOneRes = await fetch(`${BASE_URL}/mock/stubs/${stub.id}`, { method: 'DELETE' });
+  assert(delOneRes.status === 204, `DELETE /mock/stubs/:id → expected 204, got ${delOneRes.status}`);
+  const afterDel = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(afterDel.total === 1, 'one stub should remain after targeted delete');
+  console.log('  ✓ DELETE /mock/stubs/:id removes a specific stub');
+
+  // DELETE all
+  const delAllRes = await fetch(`${BASE_URL}/mock/stubs`, { method: 'DELETE' });
+  assert(delAllRes.status === 204, `DELETE /mock/stubs → expected 204, got ${delAllRes.status}`);
+  const afterClear = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(afterClear.total === 0, 'all stubs should be cleared');
+  console.log('  ✓ DELETE /mock/stubs clears all stubs');
+
+  // 422 on missing required fields
+  const badRes = await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: { on: 'data_exchange.service_call.created' }  // missing respond
+  });
+  assert(badRes.status === 422, `invalid stub → expected 422, got ${badRes.status}`);
+  console.log('  ✓ POST /mock/stubs returns 422 for invalid stub');
+
+  // 404 on unknown stub ID
+  const notFoundRes = await fetch(`${BASE_URL}/mock/stubs/nonexistent-id`, { method: 'DELETE' });
+  assert(notFoundRes.status === 404, `unknown stub → expected 404, got ${notFoundRes.status}`);
+  console.log('  ✓ DELETE /mock/stubs/:id returns 404 for unknown stub');
+}
+
+// =============================================================================
+// Stub consumed when trigger event fires
+// =============================================================================
+
+async function testStubConsumedOnEvent() {
+  console.log('\n--- Stub consumed by trigger event ---');
+  await clearStubs();
+
+  // Register stub for the trigger event
+  await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: {
+      on: 'data_exchange.service_call.created',
+      respond: {
+        type: 'data_exchange.call.completed',
+        subject: { var: 'this.subject' },
+        data: { result: 'inconclusive', serviceType: 'fdsh_ssa' }
+      }
+    }
+  });
+
+  const before = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(before.total === 1, 'stub should be registered');
+
+  // Inject the trigger event — mock rules fire applyStub synchronously
+  const injectRes = await injectEvent('data_exchange.service_call.created', { serviceType: 'fdsh_ssa' }, 'sc-001');
+  assert(injectRes.status === 202, `inject → expected 202, got ${injectRes.status}`);
+
+  // Stub should now be consumed
+  const after = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(after.total === 0, 'stub should be consumed after trigger event fires');
+  console.log('  ✓ Stub is consumed when matching trigger event fires');
+}
+
+// =============================================================================
+// FIFO — two stubs consumed in order
+// =============================================================================
+
+async function testStubFifo() {
+  console.log('\n--- Stub FIFO ordering ---');
+  await clearStubs();
+
+  await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: { on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } } }
+  });
+  await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: { on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } } }
+  });
+
+  assert((await (await fetch(`${BASE_URL}/mock/stubs`)).json()).total === 2, 'two stubs registered');
+
+  // First injection consumes first stub
+  await injectEvent('data_exchange.service_call.created', {}, 'sc-001');
+  const after1 = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(after1.total === 1, 'one stub should remain after first event');
+
+  // Second injection consumes second stub
+  await injectEvent('data_exchange.service_call.created', {}, 'sc-002');
+  const after2 = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(after2.total === 0, 'no stubs should remain after second event');
+
+  console.log('  ✓ Stubs are consumed in registration order (FIFO)');
+}
+
+// =============================================================================
+// Fallback fires when no stub registered
+// =============================================================================
+
+async function testFallbackNoStub() {
+  console.log('\n--- Fallback when no stub registered ---');
+  await clearStubs();
+
+  // No stub registered — mock rules should fire fallback (conclusive result)
+  const injectRes = await injectEvent('data_exchange.service_call.created', { serviceType: 'save' }, 'sc-003');
+  assert(injectRes.status === 202, `inject → expected 202, got ${injectRes.status}`);
+
+  // Stub count should still be 0 (no stub to consume or add)
+  const stubs = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(stubs.total === 0, 'stub count should remain 0');
+  console.log('  ✓ Fallback fires when no stub registered (no error thrown)');
+}
+
+// =============================================================================
+// field match filter — stub not consumed when match criteria miss
+// =============================================================================
+
+async function testMatchFilter() {
+  console.log('\n--- Stub match field filtering ---');
+  await clearStubs();
+
+  // Register stub that only matches fdsh_ssa calls
+  await fetch(`${BASE_URL}/mock/stubs`, {
+    method: 'POST',
+    body: {
+      on: 'data_exchange.service_call.created',
+      match: { 'data.serviceType': 'fdsh_ssa' },
+      respond: { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } }
+    }
+  });
+
+  // Inject with non-matching serviceType — stub should NOT be consumed
+  await injectEvent('data_exchange.service_call.created', { serviceType: 'save' }, 'sc-004');
+  const after = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(after.total === 1, 'stub should not be consumed when match criteria do not match');
+  console.log('  ✓ Stub with match filter not consumed when criteria miss');
+
+  // Inject with matching serviceType — stub should be consumed
+  await injectEvent('data_exchange.service_call.created', { serviceType: 'fdsh_ssa' }, 'sc-005');
+  const afterMatch = await (await fetch(`${BASE_URL}/mock/stubs`)).json();
+  assert(afterMatch.total === 0, 'stub should be consumed when match criteria satisfied');
+  console.log('  ✓ Stub with match filter consumed when criteria satisfied');
+
+  await clearStubs();
+}
+
+// =============================================================================
+// Test runner
+// =============================================================================
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+async function run() {
+  console.log('\n' + '='.repeat(70));
+  console.log('Mock Stubs Integration Tests');
+  console.log('='.repeat(70));
+
+  // Verify server is running
+  try {
+    const health = await fetch(`${BASE_URL}/health`);
+    if (!health.ok) throw new Error('health check failed');
+  } catch {
+    console.error('  Mock server is not running. Start it with: npm run mock:start');
+    process.exit(1);
+  }
+
+  const suites = [
+    testStubCrud,
+    testStubConsumedOnEvent,
+    testStubFifo,
+    testFallbackNoStub,
+    testMatchFilter
+  ];
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const suite of suites) {
+    try {
+      await suite();
+      passed++;
+    } catch (err) {
+      failed++;
+      console.error(`\n  ✗ ${suite.name}: ${err.message}`);
+    }
+  }
+
+  // Clean up
+  await clearStubs();
+
+  console.log('\n' + '='.repeat(70));
+  console.log(`Mock Stubs: ${passed} passed, ${failed} failed`);
+  console.log('='.repeat(70));
+
+  if (failed > 0) process.exit(1);
+  console.log('\n✓ All mock stubs integration tests passed!\n');
+}
+
+run().catch((err) => {
+  console.error('Integration test error:', err);
+  process.exit(1);
+});

--- a/packages/mock-server/tests/integration/mock-stubs.test.js
+++ b/packages/mock-server/tests/integration/mock-stubs.test.js
@@ -6,11 +6,16 @@
  * fallback behavior when no stub is registered.
  *
  * Run with: npm run test:integration
- * (requires mock server running on port 1080)
  */
 
 import http from 'http';
 import { URL } from 'url';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { startMockServer, stopServer, isServerRunning } from '../../scripts/server.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contractsDir = resolve(__dirname, '..', '..', '..', 'contracts');
 
 const BASE_URL = 'http://localhost:1080';
 const PREFIX = 'org.codeforamerica.safety-net-blueprint.';
@@ -263,13 +268,12 @@ async function run() {
   console.log('Mock Stubs Integration Tests');
   console.log('='.repeat(70));
 
-  // Verify server is running
-  try {
-    const health = await fetch(`${BASE_URL}/health`);
-    if (!health.ok) throw new Error('health check failed');
-  } catch {
-    console.error('  Mock server is not running. Start it with: npm run mock:start');
-    process.exit(1);
+  // Start the mock server if not already running
+  const alreadyRunning = await isServerRunning();
+  if (!alreadyRunning) {
+    console.log('\n  Starting mock server...');
+    await startMockServer([contractsDir]);
+    console.log('  ✓ Mock server started');
   }
 
   const suites = [
@@ -293,8 +297,11 @@ async function run() {
     }
   }
 
-  // Clean up
+  // Clean up stubs and stop the server if we started it
   await clearStubs();
+  if (!alreadyRunning) {
+    await stopServer(false);
+  }
 
   console.log('\n' + '='.repeat(70));
   console.log(`Mock Stubs: ${passed} passed, ${failed} failed`);

--- a/packages/mock-server/tests/run-all-tests.js
+++ b/packages/mock-server/tests/run-all-tests.js
@@ -16,15 +16,16 @@ import { readdirSync } from 'fs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-// Discover all test files in unit/ directory
+// Discover all test files in unit/ and integration/ directories
 const unitDir = join(__dirname, 'unit');
 const unitTestFiles = readdirSync(unitDir)
   .filter(file => file.endsWith('.test.js'))
   .map(file => join('unit', file));
 
-const integrationTestFiles = [
-  join('integration', 'integration.test.js')
-];
+const integrationDir = join(__dirname, 'integration');
+const integrationTestFiles = readdirSync(integrationDir)
+  .filter(file => file.endsWith('.test.js'))
+  .map(file => join('integration', file));
 
 const args = process.argv.slice(2);
 const runUnit = args.includes('--unit') || args.includes('--all') || args.length === 0;

--- a/packages/mock-server/tests/unit/emit-event.test.js
+++ b/packages/mock-server/tests/unit/emit-event.test.js
@@ -55,6 +55,22 @@ test('emitEvent', async (t) => {
     console.log('  ✓ Derives type from domain + object + action');
   });
 
+  await t.test('normalizes hyphenated domain to underscores in event type', () => {
+    clearAll('events');
+    const stored = emitEvent({
+      domain: 'data-exchange',
+      object: 'service-call',
+      action: 'created',
+      resourceId: 'sc-1',
+      source: '/data-exchange',
+      data: null,
+      now: '2024-01-01T00:00:00.000Z',
+    });
+
+    assert.strictEqual(stored.type, 'org.codeforamerica.safety-net-blueprint.data_exchange.service_call.created');
+    console.log('  ✓ Normalizes hyphenated domain/object to underscores');
+  });
+
   await t.test('generates a unique id for each event', () => {
     clearAll('events');
     const e1 = emitEvent({ domain: 'x', object: 'y', action: 'z', resourceId: '1', source: '/x', data: null, now: '2024-01-01T00:00:00.000Z' });

--- a/packages/mock-server/tests/unit/mock-stub-engine.test.js
+++ b/packages/mock-server/tests/unit/mock-stub-engine.test.js
@@ -1,0 +1,250 @@
+/**
+ * Unit tests for mock-stub-engine
+ * Tests registration, ID generation, FIFO matching, field filtering,
+ * removal, and clearing.
+ */
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  registerStub,
+  matchAndPop,
+  listStubs,
+  removeStub,
+  clearStubs
+} from '../../src/mock-stub-engine.js';
+
+const PREFIX = 'org.codeforamerica.safety-net-blueprint.';
+
+function makeStub(on, respond, match) {
+  return match ? { on, match, respond } : { on, respond };
+}
+
+function makeEnvelope(type, data = {}) {
+  return { specversion: '1.0', type, source: '/test', subject: 'sub-1', data };
+}
+
+beforeEach(() => clearStubs());
+
+// =============================================================================
+// registerStub
+// =============================================================================
+
+test('registerStub — assigns human-readable ID from on suffix', () => {
+  const stub = registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed' }
+  ));
+  assert.strictEqual(stub.id, 'service_call.created-1');
+});
+
+test('registerStub — increments counter per suffix', () => {
+  const a = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  const b = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  assert.strictEqual(a.id, 'service_call.created-1');
+  assert.strictEqual(b.id, 'service_call.created-2');
+});
+
+test('registerStub — different suffixes use independent counters', () => {
+  const a = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  const b = registerStub(makeStub('data_exchange.call.completed', { type: 'intake.application.submitted' }));
+  assert.strictEqual(a.id, 'service_call.created-1');
+  assert.strictEqual(b.id, 'call.completed-1');
+});
+
+test('registerStub — accepts full CloudEvents type prefix in on field', () => {
+  const stub = registerStub(makeStub(
+    PREFIX + 'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed' }
+  ));
+  assert.ok(stub.id.startsWith('service_call.created-'));
+});
+
+test('registerStub — throws when on is missing', () => {
+  assert.throws(
+    () => registerStub({ respond: { type: 'x.y.z' } }),
+    /on/
+  );
+});
+
+test('registerStub — throws when respond.type is missing', () => {
+  assert.throws(
+    () => registerStub({ on: 'data_exchange.service_call.created', respond: {} }),
+    /respond/
+  );
+});
+
+// =============================================================================
+// matchAndPop — type matching
+// =============================================================================
+
+test('matchAndPop — matches by short suffix form', () => {
+  registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const stub = matchAndPop(fullType, makeEnvelope(fullType));
+  assert.ok(stub, 'should match');
+  assert.strictEqual(listStubs().length, 0);
+});
+
+test('matchAndPop — matches by full type in on field', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub(makeStub(fullType, { type: 'data_exchange.call.completed' }));
+  const stub = matchAndPop(fullType, makeEnvelope(fullType));
+  assert.ok(stub);
+});
+
+test('matchAndPop — returns null when no stub registered', () => {
+  const result = matchAndPop(PREFIX + 'data_exchange.service_call.created', makeEnvelope(PREFIX + 'data_exchange.service_call.created'));
+  assert.strictEqual(result, null);
+});
+
+test('matchAndPop — returns null when type does not match', () => {
+  registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  const result = matchAndPop(PREFIX + 'intake.application.submitted', makeEnvelope(PREFIX + 'intake.application.submitted'));
+  assert.strictEqual(result, null);
+  assert.strictEqual(listStubs().length, 1);
+});
+
+// =============================================================================
+// matchAndPop — FIFO ordering
+// =============================================================================
+
+test('matchAndPop — pops first matching stub (FIFO)', () => {
+  const a = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }));
+  const b = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } }));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const first = matchAndPop(fullType, makeEnvelope(fullType));
+  assert.strictEqual(first.id, a.id);
+  assert.strictEqual(listStubs().length, 1);
+  assert.strictEqual(listStubs()[0].id, b.id);
+});
+
+test('matchAndPop — second pop returns second stub', () => {
+  registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }));
+  const b = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } }));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  matchAndPop(fullType, makeEnvelope(fullType));
+  const second = matchAndPop(fullType, makeEnvelope(fullType));
+  assert.strictEqual(second.id, b.id);
+  assert.strictEqual(listStubs().length, 0);
+});
+
+// =============================================================================
+// matchAndPop — field match filtering
+// =============================================================================
+
+test('matchAndPop — matches when all match criteria satisfied', () => {
+  registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed' },
+    { 'data.serviceType': 'fdsh_ssa' }
+  ));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const stub = matchAndPop(fullType, makeEnvelope(fullType, { serviceType: 'fdsh_ssa' }));
+  assert.ok(stub);
+});
+
+test('matchAndPop — skips stub when match criteria not satisfied', () => {
+  registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed' },
+    { 'data.serviceType': 'fdsh_ssa' }
+  ));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const stub = matchAndPop(fullType, makeEnvelope(fullType, { serviceType: 'save' }));
+  assert.strictEqual(stub, null);
+  assert.strictEqual(listStubs().length, 1);
+});
+
+test('matchAndPop — skips non-matching stub and returns next matching one', () => {
+  registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } },
+    { 'data.serviceType': 'fdsh_ssa' }
+  ));
+  const b = registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+    // no match filter — matches any
+  ));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const stub = matchAndPop(fullType, makeEnvelope(fullType, { serviceType: 'save' }));
+  assert.strictEqual(stub.id, b.id);
+  assert.strictEqual(listStubs().length, 1);
+});
+
+test('matchAndPop — empty match object matches any event of that type', () => {
+  registerStub(makeStub(
+    'data_exchange.service_call.created',
+    { type: 'data_exchange.call.completed' },
+    {}
+  ));
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  const stub = matchAndPop(fullType, makeEnvelope(fullType, { serviceType: 'save' }));
+  assert.ok(stub);
+});
+
+// =============================================================================
+// listStubs
+// =============================================================================
+
+test('listStubs — returns empty array when no stubs registered', () => {
+  assert.deepStrictEqual(listStubs(), []);
+});
+
+test('listStubs — returns snapshot of all registered stubs', () => {
+  registerStub(makeStub('a.b.c', { type: 'd.e.f' }));
+  registerStub(makeStub('a.b.c', { type: 'd.e.g' }));
+  assert.strictEqual(listStubs().length, 2);
+});
+
+test('listStubs — returns a copy (mutations do not affect registry)', () => {
+  registerStub(makeStub('a.b.c', { type: 'd.e.f' }));
+  const list = listStubs();
+  list.pop();
+  assert.strictEqual(listStubs().length, 1);
+});
+
+// =============================================================================
+// removeStub
+// =============================================================================
+
+test('removeStub — removes a stub by ID and returns true', () => {
+  const stub = registerStub(makeStub('a.b.c', { type: 'd.e.f' }));
+  const result = removeStub(stub.id);
+  assert.strictEqual(result, true);
+  assert.strictEqual(listStubs().length, 0);
+});
+
+test('removeStub — returns false for unknown ID', () => {
+  const result = removeStub('nonexistent-id');
+  assert.strictEqual(result, false);
+});
+
+test('removeStub — removes only the targeted stub', () => {
+  const a = registerStub(makeStub('a.b.c', { type: 'd.e.f' }));
+  const b = registerStub(makeStub('a.b.c', { type: 'd.e.g' }));
+  removeStub(a.id);
+  assert.strictEqual(listStubs().length, 1);
+  assert.strictEqual(listStubs()[0].id, b.id);
+});
+
+// =============================================================================
+// clearStubs
+// =============================================================================
+
+test('clearStubs — removes all stubs', () => {
+  registerStub(makeStub('a.b.c', { type: 'd.e.f' }));
+  registerStub(makeStub('a.b.c', { type: 'd.e.g' }));
+  clearStubs();
+  assert.strictEqual(listStubs().length, 0);
+});
+
+test('clearStubs — resets ID counters', () => {
+  registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  clearStubs();
+  const stub = registerStub(makeStub('data_exchange.service_call.created', { type: 'data_exchange.call.completed' }));
+  assert.strictEqual(stub.id, 'service_call.created-1');
+});
+
+console.log('\n✓ All mock-stub-engine tests passed\n');

--- a/packages/mock-server/tests/unit/platform-action-handlers.test.js
+++ b/packages/mock-server/tests/unit/platform-action-handlers.test.js
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for platform action handlers — fireEvent and applyStub.
+ *
+ * Tests use real dependencies (database, stub engine) rather than mocks so
+ * that the integration between handlers, event emission, and stub matching
+ * is verified end-to-end at the unit level.
+ */
+
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { platformActionRegistry } from '../../src/platform-action-handlers.js';
+import { registerStub, clearStubs, listStubs } from '../../src/mock-stub-engine.js';
+import { clearAll, findAll } from '../../src/database-manager.js';
+
+const PREFIX = 'org.codeforamerica.safety-net-blueprint.';
+
+const fireEvent = platformActionRegistry.get('fireEvent');
+const applyStub = platformActionRegistry.get('applyStub');
+
+function events() {
+  return findAll('events', {}).items;
+}
+
+function makeEnvelope(type, data = {}) {
+  return { specversion: '1.0', type, source: '/test', subject: 'sub-1', data };
+}
+
+beforeEach(() => {
+  clearAll('events');
+  clearStubs();
+});
+
+// =============================================================================
+// fireEvent
+// =============================================================================
+
+test('fireEvent — prepends platform prefix when not present', () => {
+  fireEvent({ type: 'data_exchange.call.completed' }, {}, { context: {} });
+  const [evt] = events();
+  assert.strictEqual(evt.type, PREFIX + 'data_exchange.call.completed');
+});
+
+test('fireEvent — does not double-prepend prefix', () => {
+  fireEvent({ type: PREFIX + 'data_exchange.call.completed' }, {}, { context: {} });
+  const [evt] = events();
+  assert.strictEqual(evt.type, PREFIX + 'data_exchange.call.completed');
+});
+
+test('fireEvent — resolves JSON Logic expression in subject', () => {
+  const ctx = { this: { subject: 'sc-abc' } };
+  fireEvent(
+    { type: 'data_exchange.call.completed', subject: { var: 'this.subject' } },
+    {},
+    { context: ctx }
+  );
+  const [evt] = events();
+  assert.strictEqual(evt.subject, 'sc-abc');
+});
+
+test('fireEvent — resolves JSON Logic expressions in data fields', () => {
+  const ctx = { this: { data: { serviceType: 'fdsh_ssa' } }, result: 'conclusive' };
+  fireEvent(
+    {
+      type: 'data_exchange.call.completed',
+      data: {
+        serviceType: { var: 'this.data.serviceType' },
+        result: { var: 'result' }
+      }
+    },
+    {},
+    { context: ctx }
+  );
+  const [evt] = events();
+  assert.strictEqual(evt.data.serviceType, 'fdsh_ssa');
+  assert.strictEqual(evt.data.result, 'conclusive');
+});
+
+test('fireEvent — passes literal values in data through unchanged', () => {
+  fireEvent(
+    { type: 'x.y.z', data: { result: 'conclusive', count: 3 } },
+    {},
+    { context: {} }
+  );
+  const [evt] = events();
+  assert.strictEqual(evt.data.result, 'conclusive');
+  assert.strictEqual(evt.data.count, 3);
+});
+
+test('fireEvent — sets subject to null when omitted', () => {
+  fireEvent({ type: 'x.y.z' }, {}, { context: {} });
+  const [evt] = events();
+  assert.strictEqual(evt.subject, null);
+});
+
+test('fireEvent — defaults source to /system when omitted', () => {
+  fireEvent({ type: 'x.y.z' }, {}, { context: {} });
+  const [evt] = events();
+  assert.strictEqual(evt.source, '/system');
+});
+
+test('fireEvent — uses provided literal source', () => {
+  fireEvent({ type: 'x.y.z', source: '/data-exchange' }, {}, { context: {} });
+  const [evt] = events();
+  assert.strictEqual(evt.source, '/data-exchange');
+});
+
+test('fireEvent — emits nothing and logs error when type is missing', () => {
+  fireEvent({}, {}, { context: {} });
+  assert.strictEqual(events().length, 0);
+});
+
+// =============================================================================
+// applyStub — stub matched
+// =============================================================================
+
+test('applyStub — fires respond event when stub matches', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: {
+      type: 'data_exchange.call.completed',
+      data: { result: 'conclusive' }
+    }
+  });
+
+  applyStub({}, makeEnvelope(fullType), { context: {} });
+
+  const evts = events();
+  assert.strictEqual(evts.length, 1);
+  assert.strictEqual(evts[0].type, PREFIX + 'data_exchange.call.completed');
+  assert.strictEqual(evts[0].data.result, 'conclusive');
+});
+
+test('applyStub — consumes matched stub (FIFO)', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({ on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } } });
+  registerStub({ on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } } });
+
+  applyStub({}, makeEnvelope(fullType), { context: {} });
+
+  assert.strictEqual(listStubs().length, 1);
+  assert.strictEqual(events()[0].data.result, 'conclusive');
+});
+
+test('applyStub — resolves JSON Logic in respond data fields against event envelope', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: {
+      type: 'data_exchange.call.completed',
+      subject: { var: 'this.subject' },
+      data: { serviceCallId: { var: 'this.subject' } }
+    }
+  });
+
+  const envelope = makeEnvelope(fullType);
+  envelope.subject = 'call-xyz';
+
+  applyStub({}, envelope, { context: { this: envelope } });
+
+  const [evt] = events();
+  assert.strictEqual(evt.subject, 'call-xyz');
+  assert.strictEqual(evt.data.serviceCallId, 'call-xyz');
+});
+
+// =============================================================================
+// applyStub — no stub matched
+// =============================================================================
+
+test('applyStub — fires fallback.fireEvent when no stub matches', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  applyStub(
+    { fallback: { fireEvent: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } } } },
+    makeEnvelope(fullType),
+    { context: {} }
+  );
+
+  const [evt] = events();
+  assert.ok(evt, 'fallback event should fire');
+  assert.strictEqual(evt.type, PREFIX + 'data_exchange.call.completed');
+  assert.strictEqual(evt.data.result, 'conclusive');
+});
+
+test('applyStub — no-op when no stub and no fallback', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  applyStub({}, makeEnvelope(fullType), { context: {} });
+  assert.strictEqual(events().length, 0);
+});
+
+test('applyStub — skips stub lookup and warns when resource has no type', () => {
+  registerStub({ on: 'data_exchange.service_call.created', respond: { type: 'data_exchange.call.completed' } });
+  applyStub({}, {}, { context: {} });
+  assert.strictEqual(listStubs().length, 1); // stub not consumed
+  assert.strictEqual(events().length, 0);
+});
+
+console.log('\n✓ All platform-action-handlers tests passed\n');

--- a/packages/mock-server/tests/unit/platform-action-handlers.test.js
+++ b/packages/mock-server/tests/unit/platform-action-handlers.test.js
@@ -142,25 +142,143 @@ test('applyStub — consumes matched stub (FIFO)', () => {
   assert.strictEqual(events()[0].data.result, 'conclusive');
 });
 
-test('applyStub — resolves JSON Logic in respond data fields against event envelope', () => {
+// Schema used in schema-driven tests — mirrors CallCompletedEvent required fields.
+const callCompletedSchema = {
+  properties: {
+    serviceCallId: { type: 'string' },
+    serviceType: { type: 'string' },
+    requestingResourceId: { type: 'string' },
+    result: { type: 'string' }
+  },
+  required: ['serviceCallId', 'serviceType', 'requestingResourceId', 'result']
+};
+const completedType = PREFIX + 'data_exchange.call.completed';
+const eventSchemas = { [completedType]: callCompletedSchema };
+
+test('applyStub — echoes trigger subject by default', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa', requestingResourceId: 'r-1', id: 'sc-1' });
+  envelope.subject = 'sc-1';
+
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  assert.strictEqual(evt.subject, 'sc-1');
+});
+
+test('applyStub — schema-driven: populates same-named fields from trigger data', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', data: { result: 'inconclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa', requestingResourceId: 'app-1', id: 'sc-1' });
+  envelope.subject = 'sc-1';
+
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  assert.strictEqual(evt.data.serviceType, 'fdsh_ssa');
+  assert.strictEqual(evt.data.requestingResourceId, 'app-1');
+  assert.strictEqual(evt.data.result, 'inconclusive');
+});
+
+test('applyStub — schema-driven: derives serviceCallId from trigger entity name + subject', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa', requestingResourceId: 'r-1', id: 'sc-abc' });
+  envelope.subject = 'sc-abc';
+
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  assert.strictEqual(evt.data.serviceCallId, 'sc-abc');
+});
+
+test('applyStub — schema-driven: only includes schema-defined fields (no extras)', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, {
+    serviceType: 'fdsh_ssa', requestingResourceId: 'r-1', id: 'sc-1',
+    callMode: 'async', status: 'pending', createdAt: '2026-01-01T00:00:00Z'
+  });
+  envelope.subject = 'sc-1';
+
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  const keys = Object.keys(evt.data);
+  assert.ok(!keys.includes('callMode'), 'callMode should not appear in response');
+  assert.ok(!keys.includes('status'), 'status should not appear in response');
+  assert.ok(!keys.includes('createdAt'), 'createdAt should not appear in response');
+  assert.ok(!keys.includes('id'), 'id should not appear in response');
+});
+
+test('applyStub — stub data fields override schema-derived values', () => {
   const fullType = PREFIX + 'data_exchange.service_call.created';
   registerStub({
     on: 'data_exchange.service_call.created',
     respond: {
       type: 'data_exchange.call.completed',
-      subject: { var: 'this.subject' },
-      data: { serviceCallId: { var: 'this.subject' } }
+      data: { result: 'conclusive', serviceType: 'overridden' }
     }
   });
 
-  const envelope = makeEnvelope(fullType);
-  envelope.subject = 'call-xyz';
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa', requestingResourceId: 'r-1', id: 'sc-1' });
+  envelope.subject = 'sc-1';
 
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  assert.strictEqual(evt.data.serviceType, 'overridden');
+  assert.strictEqual(evt.data.result, 'conclusive');
+});
+
+test('applyStub — explicit respond.subject overrides trigger subject', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', subject: 'explicit-subject', data: { result: 'conclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa', requestingResourceId: 'r-1', id: 'sc-1' });
+  envelope.subject = 'trigger-subject';
+
+  applyStub({}, envelope, { context: { this: envelope }, eventSchemas });
+
+  const [evt] = events();
+  assert.strictEqual(evt.subject, 'explicit-subject');
+});
+
+test('applyStub — falls back to stub data only when no schema available', () => {
+  const fullType = PREFIX + 'data_exchange.service_call.created';
+  registerStub({
+    on: 'data_exchange.service_call.created',
+    respond: { type: 'data_exchange.call.completed', data: { result: 'conclusive' } }
+  });
+
+  const envelope = makeEnvelope(fullType, { serviceType: 'fdsh_ssa' });
+
+  // No eventSchemas passed → falls back to stub data
   applyStub({}, envelope, { context: { this: envelope } });
 
   const [evt] = events();
-  assert.strictEqual(evt.subject, 'call-xyz');
-  assert.strictEqual(evt.data.serviceCallId, 'call-xyz');
+  assert.strictEqual(evt.data.result, 'conclusive');
+  assert.ok(!('serviceType' in evt.data), 'no schema → no field derivation');
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds `POST /data-exchange/service-calls` and `GET /data-exchange/service-calls/{id}` for initiating and tracking electronic verification checks against federal data sources (SSA, FDSH, IEVS, SAVE)
- Service calls are automatically enriched at creation with `serviceType`, `callMode`, and `status` from the ExternalService catalog

### Contract-driven mock simulation

The biggest addition in this PR is a stub-based simulation system that makes it straightforward to test verification flows locally and in integration tests without real service connections:

- **Mock simulation rules** (`data-exchange-mock-rules.yaml`) automatically fire `call.completed` events when a service call is created, so the full verification flow works end-to-end out of the box
- **Stub registry** (`POST /mock/stubs`) lets you pre-program specific outcomes before triggering a flow — an inconclusive SSA result, a SAVE failure, etc. — without restarting the server
- **Minimal stub format** — stubs only need to declare what differs. The server reads the `x-events` payload schema from the OpenAPI spec and populates all other required fields automatically by echoing same-named fields from the trigger event. Registering an inconclusive result is a single field: `"data": { "result": "inconclusive" }`
- **`fireEvent` and `applyStub` rule actions** enable rules themselves to emit domain events directly, supporting cross-domain fanout without requiring a state machine transition as intermediary

### Other changes

- Fixes CloudEvents naming consistency: all event type segments use snake_case throughout `intake-rules.yaml`
- Integration tests are now self-contained — `mock-stubs.test.js` starts its own server when none is running

## Notes for reviewer

See issue #272 for validation steps and the minimal stub format in action. The key thing to exercise: register a stub with just `{ "data": { "result": "inconclusive" } }` and watch the response event come back fully populated from the contract schema.

Closes #272