### PR TITLE
Support document upload and attachment to intake verification items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ package-lock.json
 *.log
 .idea
 
-# Mock server SQLite databases
+# Mock server SQLite databases and uploaded files
 packages/mock-server/data/
+packages/mock-server/uploads/
 
 # Generated artifacts (state-specific, regenerate as needed)
 dist/

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -129,3 +129,9 @@ overrides:
   - files: ["packages/contracts/platform-openapi.yaml#/paths/~1events~1stream"]
     rules:
       response-body-json-only: off
+  # Document management: upload endpoints use multipart/form-data; content endpoint returns raw bytes.
+  # request-body-json-only and response-body-json-only are intentionally off for this domain.
+  - files: ["packages/contracts/document-management-openapi.yaml"]
+    rules:
+      request-body-json-only: off
+      response-body-json-only: off

--- a/docs/architecture/inter-domain-communication.md
+++ b/docs/architecture/inter-domain-communication.md
@@ -1,10 +1,30 @@
 # Inter-Domain Communication
 
-The Safety Net Blueprint uses a pub/sub, event-driven model for cross-domain coordination. Domains are loosely coupled — each domain publishes events when its state changes; other domains subscribe and react independently. No domain needs to know who is consuming its events, and adding a new consumer requires no change to the producer.
+The Safety Net Blueprint uses two distinct patterns for cross-domain communication: **commands** and **domain events**. Choosing the right pattern is a contract decision — it determines coupling, testability, and what consumers can rely on.
+
+## Choosing a pattern
+
+**Use a command when the calling domain needs a result to continue its own operation.**
+
+A command is a direct synchronous API call. The caller sends a request and uses the response before proceeding. The relationship is explicit: the caller depends on the target domain's API contract. Commands are appropriate when the result must be known in the same request — uploading a document and receiving the document ID to attach to a verification record is a command.
+
+**Use a domain event when notifying that something happened.**
+
+A domain event is an async signal. The producing domain has no knowledge of who consumes it or what they do. Consumers subscribe and react independently; adding a new consumer requires no change to the producer. Domain events are appropriate when the producing domain's operation is already complete and others may optionally react — an application being submitted is a domain event.
+
+**The async command variant**
+
+Some interactions combine both patterns: a command initiates a long-running operation, and an async domain event delivers the result when it is ready. Data exchange verification calls use this variant — intake creates a service call (command), the external service responds asynchronously, and a domain event delivers the result when it arrives. The context passthrough pattern (see `api-patterns.yaml`) is used to correlate the result event back to the originating record.
+
+**Decision rule**
+
+> Does the calling domain need a result from the other domain to complete its current operation? → Command. Is the calling domain notifying that its own state changed? → Domain event.
+
+If neither fits cleanly, the interaction may be a candidate for the async command variant.
 
 ---
 
-## Event Model
+## Domain Events
 
 ### CloudEvents envelope
 

--- a/docs/contract-tables/intake/overview.md
+++ b/docs/contract-tables/intake/overview.md
@@ -150,14 +150,6 @@ Evaluation strategy: **first-match-wins**
 |---|-----------|--------|----------|
 | 1 | this.data.subjectType = "interview" | appendToArray: {"entity":"intake/applications/interview","idFrom":"this.data.subjectId","field":"appointments","value":{"var":"this.subject"}} | — |
 
-### document-verified-write-back
-
-Evaluation strategy: **first-match-wins**
-
-| # | Condition | Action | Fallback |
-|---|-----------|--------|----------|
-| 1 | this.data.subjectType = "application-document" | triggerTransition: {"entity":"intake/applications/documents","idFrom":"applicationDocument.id","transition":"verify"} | — |
-
 ### eligibility-determination-write-back
 
 Evaluation strategy: **first-match-wins**
@@ -173,3 +165,11 @@ Evaluation strategy: **first-match-wins**
 | # | Condition | Action | Fallback |
 |---|-----------|--------|----------|
 | 1 | application.id != null and task.taskType = "application_review" and application.status = "submitted" | triggerTransition: {"entity":"intake/applications","idFrom":"application.id","transition":"open"} | — |
+
+### document-verified-write-back
+
+Evaluation strategy: **first-match-wins**
+
+| # | Condition | Action | Fallback |
+|---|-----------|--------|----------|
+| 1 | this.data.subjectType = "application-document" | triggerTransition: {"entity":"intake/applications/documents","idFrom":"applicationDocument.id","transition":"verify"} | — |

--- a/packages/contracts/document-management-config-schema.yaml
+++ b/packages/contracts/document-management-config-schema.yaml
@@ -1,0 +1,68 @@
+# JSON Schema for document-management-config.yaml
+# Extends the generic config envelope (schemas/config-schema.yaml)
+# with document-type catalog validation.
+
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: Document Management Config
+description: Schema for document-management-config.yaml. Validates document type catalog entries.
+
+allOf:
+  - $ref: "schemas/config-schema.yaml"
+
+type: object
+required:
+  - documentTypes
+
+properties:
+  domain:
+    const: document-management
+    description: Must be "document-management".
+
+  documentTypes:
+    type: array
+    description: >
+      Document type catalog. Defines the baseline types available across all deployments.
+      All entries in a config file are config-managed: they are seeded by the mock
+      server on startup (source: "system") and cannot be deleted via the API.
+    minItems: 1
+    items:
+      $ref: "#/$defs/DocumentTypeConfig"
+
+unevaluatedProperties: false
+
+$defs:
+  DocumentTypeConfig:
+    type: object
+    description: A document type definition.
+    required:
+      - id
+      - name
+      - retentionYears
+      - retentionTrigger
+    additionalProperties: false
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: >
+          Stable identifier. Referenced by documents (documentTypeId) and API responses.
+          Use a fixed UUID so overlay authors can target specific document types.
+      name:
+        type: string
+        minLength: 1
+        maxLength: 100
+        description: Machine-readable name (e.g., pay_stub).
+      retentionYears:
+        type: integer
+        minimum: 1
+        description: >
+          How many years documents of this type must be retained after the retention
+          trigger fires. SNAP minimum is 3 years (7 CFR § 272.1(f)).
+      retentionTrigger:
+        type: string
+        enum: [case_closure, application_denial, document_date, submission_date]
+        description: The event that starts the retention clock for this document type.
+      description:
+        type: string
+        maxLength: 2000
+        description: Human-readable description of the document type's purpose.

--- a/packages/contracts/document-management-config-schema.yaml
+++ b/packages/contracts/document-management-config-schema.yaml
@@ -11,14 +11,14 @@ allOf:
 
 type: object
 required:
-  - documentTypes
+  - document-types
 
 properties:
   domain:
     const: document-management
     description: Must be "document-management".
 
-  documentTypes:
+  document-types:
     type: array
     description: >
       Document type catalog. Defines the baseline types available across all deployments.

--- a/packages/contracts/document-management-config.yaml
+++ b/packages/contracts/document-management-config.yaml
@@ -5,7 +5,7 @@ domain: document-management
 # Document type catalog — all entries are config-managed and cannot be deleted via API.
 # States may add program-specific types via overlay or at runtime via POST /document-types.
 # Retention periods follow 7 CFR § 272.1(f) (SNAP: 3 years after close of federal fiscal year).
-documentTypes:
+document-types:
 
   # ---------------------------------------------------------------------------
   # Identity

--- a/packages/contracts/document-management-config.yaml
+++ b/packages/contracts/document-management-config.yaml
@@ -1,0 +1,113 @@
+$schema: ./document-management-config-schema.yaml
+version: "1.0"
+domain: document-management
+
+# Document type catalog — all entries are config-managed and cannot be deleted via API.
+# States may add program-specific types via overlay or at runtime via POST /document-types.
+# Retention periods follow 7 CFR § 272.1(f) (SNAP: 3 years after close of federal fiscal year).
+documentTypes:
+
+  # ---------------------------------------------------------------------------
+  # Identity
+  # ---------------------------------------------------------------------------
+
+  - id: a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5
+    name: birth_certificate
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Official birth record. Used for identity and U.S. citizenship verification for SNAP and Medicaid.
+
+  - id: b2c3d4e5-f6a7-4b8c-9d0e-f1a2b3c4d5e6
+    name: state_id
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: State-issued photo ID or driver's license. Used for identity verification.
+
+  - id: c3d4e5f6-a7b8-4c9d-0e1f-a2b3c4d5e6f7
+    name: social_security_card
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Social Security card. Used to verify SSN for SNAP and Medicaid applicants.
+
+  # ---------------------------------------------------------------------------
+  # Citizenship and immigration
+  # ---------------------------------------------------------------------------
+
+  - id: d4e5f6a7-b8c9-4d0e-1f2a-b3c4d5e6f7a8
+    name: citizenship_certificate
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Certificate of U.S. Citizenship (Form N-560). Used to verify citizenship status for non-U.S.-born applicants.
+
+  - id: e5f6a7b8-c9d0-4e1f-2a3b-c4d5e6f7a8b9
+    name: naturalization_certificate
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Certificate of Naturalization (Form N-550). Used to verify citizenship status for naturalized citizens.
+
+  - id: f6a7b8c9-d0e1-4f2a-3b4c-d5e6f7a8b9c0
+    name: immigration_document
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: >
+      Immigration document (e.g., Permanent Resident Card, Employment Authorization Document,
+      I-94). Used to verify qualified alien status for Medicaid applicants. Specific document
+      type is recorded in document metadata.
+
+  # ---------------------------------------------------------------------------
+  # Income
+  # ---------------------------------------------------------------------------
+
+  - id: a7b8c9d0-e1f2-4a3b-4c5d-e6f7a8b9c0d1
+    name: pay_stub
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Employer-issued pay stub. Used to verify earned income. Caseworkers typically request the two most recent stubs.
+
+  - id: b8c9d0e1-f2a3-4b4c-5d6e-f7a8b9c0d1e2
+    name: benefit_award_letter
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Award letter from SSA (SSDI, SSI) or state unemployment agency. Used to verify unearned income amounts.
+
+  - id: c9d0e1f2-a3b4-4c5d-6e7f-a8b9c0d1e2f3
+    name: self_employment_statement
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Self-employment income statement or most recent federal tax return. Used to verify income for self-employed applicants.
+
+  # ---------------------------------------------------------------------------
+  # Residency
+  # ---------------------------------------------------------------------------
+
+  - id: d0e1f2a3-b4c5-4d6e-7f8a-b9c0d1e2f3a4
+    name: utility_bill
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Recent utility bill (gas, electric, water). Used to verify current address for SNAP residency requirement.
+
+  - id: e1f2a3b4-c5d6-4e7f-8a9b-c0d1e2f3a4b5
+    name: lease_agreement
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Current lease or rental agreement. Used to verify residency and housing costs.
+
+  # ---------------------------------------------------------------------------
+  # Assets
+  # ---------------------------------------------------------------------------
+
+  - id: f2a3b4c5-d6e7-4f8a-9b0c-d1e2f3a4b5c6
+    name: bank_statement
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Bank account statement. Used to verify liquid assets for SNAP resource test.
+
+  # ---------------------------------------------------------------------------
+  # Medical expenses (SNAP deductions)
+  # ---------------------------------------------------------------------------
+
+  - id: a3b4c5d6-e7f8-4a9b-0c1d-e2f3a4b5c6d7
+    name: medical_bill
+    retentionYears: 3
+    retentionTrigger: case_closure
+    description: Medical or dental bill. Used to verify medical expense deductions for elderly or disabled SNAP households (7 CFR § 273.9(d)(3)).

--- a/packages/contracts/document-management-openapi.yaml
+++ b/packages/contracts/document-management-openapi.yaml
@@ -1,0 +1,1050 @@
+openapi: 3.1.0
+info:
+  title: Document Management API
+  version: 0.1.0
+  x-domain: document-management
+  x-status: alpha
+  x-visibility: internal
+  description: |
+    REST API for the Document Management domain — the central store for uploaded
+    files and their metadata across all safety net programs.
+
+    **Upload model:** A document and its first version are created atomically via
+    `POST /documents` (multipart/form-data). Subsequent versions are uploaded via
+    `POST /documents/{documentId}/document-versions`. File content is delivered via
+    `GET /document-versions/{documentVersionId}/content` (proxy by default; states
+    may overlay to redirect).
+
+    **Context passthrough:** Callers attach correlation context to a document via
+    `metadata` at creation or via `PUT /documents/{documentId}/metadata/{domain}`
+    after the fact. Metadata is echoed in events so downstream consumers can
+    correlate without additional lookups. Keys are structured as nested objects
+    per domain namespace — `{ "intake": { "verificationId": "..." } }`.
+
+    **Document types:** Baseline types are seeded from `document-management-config.yaml`.
+    States add program-specific types at runtime via `POST /document-types`.
+
+    > **Status: Alpha** — Breaking changes expected.
+
+  contact:
+    name: API Support
+    email: support@example.com
+
+servers:
+  - url: https://api.example.com/document-management
+    description: Production server
+  - url: http://localhost:1080/document-management
+    description: Local development server
+
+tags:
+  - name: Documents
+    description: Document records and file upload.
+  - name: DocumentVersions
+    description: Immutable version history for documents.
+  - name: DocumentTypes
+    description: Document type catalog — retention rules and classification.
+  - name: DocumentLinks
+    description: Associations between documents and program records (applications, cases, etc.).
+
+x-events:
+  document.created:
+    type: org.codeforamerica.safety-net-blueprint.document_management.document.created
+    summary: Emitted when a document and its first version are created atomically via POST /documents
+    payload:
+      $ref: "#/components/schemas/DocumentCreatedEvent"
+  document_version.uploaded:
+    type: org.codeforamerica.safety-net-blueprint.document_management.document_version.uploaded
+    summary: Emitted when a subsequent version is uploaded via POST /documents/{documentId}/document-versions
+    payload:
+      $ref: "#/components/schemas/DocumentVersionUploadedEvent"
+
+paths:
+
+  # ---------------------------------------------------------------------------
+  # Documents
+  # ---------------------------------------------------------------------------
+
+  /documents:
+    get:
+      summary: List documents
+      description: Retrieve a paginated list of documents. Filter by document type or subject via document links.
+      operationId: listDocuments
+      tags:
+        - Documents
+      parameters:
+        - $ref: "./components/parameters.yaml#/SearchQueryParam"
+        - $ref: "./components/parameters.yaml#/LimitParam"
+        - $ref: "./components/parameters.yaml#/OffsetParam"
+        - name: documentTypeId
+          in: query
+          description: Filter by document type.
+          schema:
+            type: string
+            format: uuid
+        - name: lifecycleState
+          in: query
+          description: Filter by lifecycle state.
+          schema:
+            $ref: "#/components/schemas/DocumentLifecycleState"
+      responses:
+        "200":
+          description: A paginated list of documents.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentList"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    post:
+      summary: Upload a document
+      description: |
+        Create a document and its first version atomically. The document is
+        immediately active. Accepts multipart/form-data with the file bytes
+        and document metadata in a single request.
+
+        If the adapter's virus scanner rejects the file, returns `422` with
+        error code `file_rejected_by_virus_scan` and no document is created.
+
+        Pass `metadata` as a JSON string in the multipart body to attach
+        correlation context at creation time (e.g. `{ "intake": { "verificationId": "ver-abc" } }`).
+      operationId: uploadDocument
+      tags:
+        - Documents
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+                - documentTypeId
+                - title
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The file to upload.
+                documentTypeId:
+                  type: string
+                  format: uuid
+                  description: Document type — determines retention rules and classification.
+                title:
+                  type: string
+                  maxLength: 200
+                  description: >
+                    Human-readable label for the document (e.g. "John Smith — Pay Stub March 2026").
+                    Distinct from the upload filename.
+                documentDate:
+                  type: string
+                  format: date
+                  description: >
+                    The date printed on or associated with the document (e.g. the date on a pay stub).
+                    Required when the document type's retentionTrigger is document_date.
+                metadata:
+                  type: string
+                  description: >
+                    JSON string. Correlation context structured as nested objects per domain namespace.
+                    Example: {"intake":{"verificationId":"ver-abc-123"}}
+      responses:
+        "201":
+          description: Document and first version created successfully.
+          headers:
+            Location:
+              description: URL of the newly created document.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /documents/{documentId}:
+    parameters:
+      - $ref: "#/components/parameters/DocumentIdParam"
+
+    get:
+      summary: Get a document
+      description: Retrieve a single document by identifier. Documents in `destroyed` state are returned with their metadata intact but file content is no longer accessible.
+      operationId: getDocument
+      tags:
+        - Documents
+      responses:
+        "200":
+          description: Document retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    patch:
+      summary: Update a document
+      description: Update mutable document fields. Metadata is not patchable here — use the namespace-level metadata endpoints instead.
+      operationId: updateDocument
+      tags:
+        - Documents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentUpdate"
+      responses:
+        "200":
+          description: Document updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /documents/{documentId}/metadata/{domain}:
+    parameters:
+      - $ref: "#/components/parameters/DocumentIdParam"
+      - name: domain
+        in: path
+        required: true
+        description: The calling domain's namespace to set or remove.
+        schema:
+          $ref: "./components/common.yaml#/Domain"
+
+    put:
+      summary: Set domain metadata on a document
+      description: |
+        Replace the calling domain's entire metadata namespace on a document.
+        Other domains' namespaces are unaffected. Used for context passthrough
+        when metadata is not known at upload time.
+      operationId: setDocumentMetadata
+      tags:
+        - Documents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              description: Domain-defined key-value pairs for this namespace.
+              example:
+                verificationId: ver-abc-123
+      responses:
+        "200":
+          description: Metadata set successfully. Returns the updated document.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Document"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    delete:
+      summary: Remove domain metadata from a document
+      description: Remove the calling domain's entire metadata namespace from a document.
+      operationId: deleteDocumentMetadata
+      tags:
+        - Documents
+      responses:
+        "204":
+          description: Metadata removed successfully.
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  # ---------------------------------------------------------------------------
+  # Document Versions
+  # ---------------------------------------------------------------------------
+
+  /documents/{documentId}/document-versions:
+    parameters:
+      - $ref: "#/components/parameters/DocumentIdParam"
+
+    post:
+      summary: Upload a new version
+      description: |
+        Upload a subsequent version of an existing document. Creates an immutable
+        DocumentVersion record and updates Document.latestVersionId. Each upload
+        preserves prior versions so the file that was current at any point in time
+        is recoverable (required by 7 CFR § 272.1 and 45 CFR § 164.312).
+
+        If the adapter's virus scanner rejects the file, returns `422` with error
+        code `file_rejected_by_virus_scan` and no version is created.
+      operationId: uploadDocumentVersion
+      tags:
+        - DocumentVersions
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The replacement file to upload.
+      responses:
+        "201":
+          description: Version created successfully.
+          headers:
+            Location:
+              description: URL of the newly created document version.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentVersion"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /document-versions/{documentVersionId}:
+    parameters:
+      - $ref: "#/components/parameters/DocumentVersionIdParam"
+
+    get:
+      summary: Get a document version
+      description: Retrieve metadata for a specific document version. Does not return file bytes — use the content endpoint for that.
+      operationId: getDocumentVersion
+      tags:
+        - DocumentVersions
+      responses:
+        "200":
+          description: Document version retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentVersion"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /document-versions/{documentVersionId}/content:
+    parameters:
+      - $ref: "#/components/parameters/DocumentVersionIdParam"
+
+    get:
+      summary: Get file content
+      description: |
+        Retrieve the file bytes for a document version. Emits a
+        `document_version.accessed` audit event on every call (required by
+        HIPAA 45 CFR § 164.312).
+
+        The baseline response is `200` with the file streamed as
+        `application/octet-stream` (proxy delivery). States that prefer
+        redirect delivery add `x-content-delivery: redirect` via overlay —
+        the response then returns `302` to a time-limited signed storage URL.
+        Both response shapes are documented here so clients handle either.
+      operationId: getDocumentVersionContent
+      tags:
+        - DocumentVersions
+      responses:
+        "200":
+          description: File content (proxy delivery).
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "302":
+          description: Redirect to signed storage URL (redirect delivery — opt-in via overlay).
+          headers:
+            Location:
+              description: Time-limited signed URL pointing directly to the file in storage.
+              schema:
+                type: string
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "410":
+          description: File content is no longer accessible — document has been destroyed.
+          content:
+            application/json:
+              schema:
+                $ref: "./components/responses.yaml#/Error"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  # ---------------------------------------------------------------------------
+  # Document Types
+  # ---------------------------------------------------------------------------
+
+  /document-types:
+    get:
+      summary: List document types
+      description: Retrieve the catalog of document types. Includes both config-seeded (system) and runtime-created (user) types.
+      operationId: listDocumentTypes
+      tags:
+        - DocumentTypes
+      parameters:
+        - $ref: "./components/parameters.yaml#/SearchQueryParam"
+        - $ref: "./components/parameters.yaml#/LimitParam"
+        - $ref: "./components/parameters.yaml#/OffsetParam"
+      responses:
+        "200":
+          description: A paginated list of document types.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentTypeList"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    post:
+      summary: Create a document type
+      description: >
+        Create a state-defined document type. Runtime-created types are marked
+        `source: user` and can be deleted via the API. Config-seeded types cannot be deleted.
+      operationId: createDocumentType
+      tags:
+        - DocumentTypes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentTypeCreate"
+      responses:
+        "201":
+          description: Document type created successfully.
+          headers:
+            Location:
+              description: URL of the newly created document type.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentType"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /document-types/{documentTypeId}:
+    parameters:
+      - $ref: "#/components/parameters/DocumentTypeIdParam"
+
+    get:
+      summary: Get a document type
+      description: Retrieve a single document type by identifier.
+      operationId: getDocumentType
+      tags:
+        - DocumentTypes
+      responses:
+        "200":
+          description: Document type retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentType"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    delete:
+      summary: Delete a document type
+      description: >
+        Delete a user-created document type. Returns `409` if the type is
+        config-seeded (`source: system`) or if documents of this type exist.
+      operationId: deleteDocumentType
+      tags:
+        - DocumentTypes
+      responses:
+        "204":
+          description: Document type deleted successfully.
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "409":
+          $ref: "./components/responses.yaml#/Conflict"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  # ---------------------------------------------------------------------------
+  # Document Links
+  # ---------------------------------------------------------------------------
+
+  /document-links:
+    get:
+      summary: List document links
+      description: Retrieve document-subject associations. Filter by documentId or subjectId to find all documents for a subject or all subjects for a document.
+      operationId: listDocumentLinks
+      tags:
+        - DocumentLinks
+      parameters:
+        - $ref: "./components/parameters.yaml#/SearchQueryParam"
+        - $ref: "./components/parameters.yaml#/LimitParam"
+        - $ref: "./components/parameters.yaml#/OffsetParam"
+        - name: documentId
+          in: query
+          description: Filter by document.
+          schema:
+            type: string
+            format: uuid
+        - name: subjectId
+          in: query
+          description: Filter by subject (application, case, etc.).
+          schema:
+            type: string
+            format: uuid
+        - name: subjectType
+          in: query
+          description: Filter by subject type.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A paginated list of document links.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentLinkList"
+        "400":
+          $ref: "./components/responses.yaml#/BadRequest"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+    post:
+      summary: Link a document to a subject
+      description: |
+        Associate a document with a program record (application, case, etc.).
+        Enables cross-program reuse — the same document can satisfy obligations
+        for multiple programs without duplication.
+      operationId: createDocumentLink
+      tags:
+        - DocumentLinks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentLinkCreate"
+      responses:
+        "201":
+          description: Document link created successfully.
+          headers:
+            Location:
+              description: URL of the newly created document link.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentLink"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "422":
+          $ref: "./components/responses.yaml#/UnprocessableEntity"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+  /document-links/{documentLinkId}:
+    parameters:
+      - $ref: "#/components/parameters/DocumentLinkIdParam"
+
+    get:
+      summary: Get a document link
+      description: Retrieve a single document-subject association by identifier.
+      operationId: getDocumentLink
+      tags:
+        - DocumentLinks
+      responses:
+        "200":
+          description: Document link retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentLink"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
+components:
+  parameters:
+    DocumentIdParam:
+      name: documentId
+      in: path
+      required: true
+      description: Unique identifier of the document.
+      schema:
+        type: string
+        format: uuid
+
+    DocumentVersionIdParam:
+      name: documentVersionId
+      in: path
+      required: true
+      description: Unique identifier of the document version.
+      schema:
+        type: string
+        format: uuid
+
+    DocumentTypeIdParam:
+      name: documentTypeId
+      in: path
+      required: true
+      description: Unique identifier of the document type.
+      schema:
+        type: string
+        format: uuid
+
+    DocumentLinkIdParam:
+      name: documentLinkId
+      in: path
+      required: true
+      description: Unique identifier of the document link.
+      schema:
+        type: string
+        format: uuid
+
+  schemas:
+
+    # -------------------------------------------------------------------------
+    # Document
+    # -------------------------------------------------------------------------
+
+    Document:
+      type: object
+      description: A document record spanning all its versions. Holds identity, type, and correlation context; file bytes live in DocumentVersion records.
+      additionalProperties: false
+      required:
+        - id
+        - documentTypeId
+        - title
+        - lifecycleState
+        - legalHold
+        - latestVersionId
+        - metadata
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        documentTypeId:
+          type: string
+          format: uuid
+          description: Links to the DocumentType governing retention rules for this document.
+          x-relationship:
+            resource: document-management/document-types
+            field: id
+        title:
+          type: string
+          maxLength: 200
+          description: Human-readable label (e.g. "Jane Smith — Pay Stub March 2026"). Distinct from the upload filename.
+        documentDate:
+          type: string
+          format: date
+          nullable: true
+          description: The date on the document's face (e.g. a pay stub date). Required when the document type's retentionTrigger is document_date.
+        lifecycleState:
+          $ref: "#/components/schemas/DocumentLifecycleState"
+        legalHold:
+          type: boolean
+          description: When true, the document cannot advance to pending_disposition regardless of retention schedule.
+        latestVersionId:
+          type: string
+          format: uuid
+          description: ID of the most recent DocumentVersion. Single authoritative pointer to the current file.
+          x-relationship:
+            resource: document-management/document-versions
+            field: id
+        retentionDeadline:
+          type: string
+          format: date
+          nullable: true
+          description: The date when the retention period ends. Null until the document enters retained state.
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          description: >
+            Opaque correlation context structured as nested objects per domain namespace.
+            Example: {"intake":{"verificationId":"ver-abc-123"},"workflow":{"taskId":"tsk-xyz-456"}}
+        dispositionApprovedBy:
+          type: string
+          nullable: true
+          description: Identity of the records manager who authorized destruction. Null until destroyed state.
+        dispositionApprovedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When destruction was authorized. Null until destroyed state.
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    DocumentUpdate:
+      type: object
+      description: Mutable fields on a document. Metadata is managed via the namespace-level endpoints.
+      additionalProperties: false
+      properties:
+        title:
+          type: string
+          maxLength: 200
+        documentDate:
+          type: string
+          format: date
+          nullable: true
+
+    DocumentList:
+      type: object
+      required: [items, total, limit, offset, hasNext]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Document"
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasNext:
+          type: boolean
+
+    DocumentLifecycleState:
+      type: string
+      description: Where the document is in its records management lifecycle.
+      enum:
+        - active
+        - retained
+        - pending_disposition
+        - destroyed
+
+    # -------------------------------------------------------------------------
+    # DocumentVersion
+    # -------------------------------------------------------------------------
+
+    DocumentVersion:
+      type: object
+      description: An immutable record of a specific file upload. Each upload creates a new version; prior versions are preserved.
+      additionalProperties: false
+      required:
+        - id
+        - documentId
+        - versionNumber
+        - fileName
+        - mimeType
+        - sizeBytes
+        - contentHash
+        - uploadedById
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+          description: Links to the parent Document.
+          x-relationship:
+            resource: document-management/documents
+            field: id
+        versionNumber:
+          type: integer
+          description: Sequential version number. 1 for the first version.
+        fileName:
+          type: string
+          description: Original filename as uploaded.
+        mimeType:
+          type: string
+          description: MIME type of the uploaded file.
+        sizeBytes:
+          type: integer
+          description: File size in bytes.
+        contentHash:
+          type: string
+          description: SHA-256 hash of the file bytes. Stored for duplicate detection; baseline enforces nothing.
+        uploadedById:
+          type: string
+          description: Identity of the uploader. Required for HIPAA chain-of-custody (45 CFR § 164.312).
+          x-data-classification: pii
+        createdAt:
+          type: string
+          format: date-time
+          description: Authoritative upload timestamp.
+
+    # -------------------------------------------------------------------------
+    # DocumentType
+    # -------------------------------------------------------------------------
+
+    DocumentType:
+      type: object
+      description: Defines the category and retention rules for a class of documents. Baseline types are seeded from document-management-config.yaml.
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - retentionYears
+        - retentionTrigger
+        - source
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          maxLength: 100
+        retentionYears:
+          type: integer
+          description: How many years documents of this type must be retained after the retention trigger fires.
+        retentionTrigger:
+          $ref: "#/components/schemas/RetentionTrigger"
+        source:
+          type: string
+          enum: [system, user]
+          readOnly: true
+          description: '"system" types are seeded from config and cannot be deleted. "user" types are created at runtime and can be deleted.'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    DocumentTypeCreate:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - retentionYears
+        - retentionTrigger
+      properties:
+        name:
+          type: string
+          maxLength: 100
+        retentionYears:
+          type: integer
+        retentionTrigger:
+          $ref: "#/components/schemas/RetentionTrigger"
+
+    DocumentTypeList:
+      type: object
+      required: [items, total, limit, offset, hasNext]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentType"
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasNext:
+          type: boolean
+
+    RetentionTrigger:
+      type: string
+      description: The event that starts the retention clock for this document type.
+      enum:
+        - case_closure
+        - application_denial
+        - document_date
+        - submission_date
+
+    # -------------------------------------------------------------------------
+    # DocumentLink
+    # -------------------------------------------------------------------------
+
+    DocumentLink:
+      type: object
+      description: Associates a document with a program record (application, case, etc.) for cross-program reuse and retention tracking.
+      additionalProperties: false
+      required:
+        - id
+        - documentId
+        - subjectType
+        - subjectId
+        - linkedBy
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        documentId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/documents
+            field: id
+        subjectType:
+          type: string
+          description: The kind of record this document is linked to (e.g. application, case). States add values via overlay.
+          enum:
+            - application
+            - case
+        subjectId:
+          type: string
+          format: uuid
+          description: ID of the linked record.
+          x-relationship:
+            resource: Polymorphic
+        linkedBy:
+          type: string
+          description: Identity of who created the link. Required for HIPAA chain-of-custody (45 CFR § 164.312).
+          x-data-classification: pii
+        closedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Set when the subject closes. Used as the retention trigger timestamp for case_closure and application_denial retention types.
+        createdAt:
+          type: string
+          format: date-time
+
+    DocumentLinkCreate:
+      type: object
+      additionalProperties: false
+      required:
+        - documentId
+        - subjectType
+        - subjectId
+      properties:
+        documentId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/documents
+            field: id
+        subjectType:
+          type: string
+          enum:
+            - application
+            - case
+        subjectId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: Polymorphic
+
+    DocumentLinkList:
+      type: object
+      required: [items, total, limit, offset, hasNext]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/DocumentLink"
+        total:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        hasNext:
+          type: boolean
+
+    # -------------------------------------------------------------------------
+    # Events
+    # -------------------------------------------------------------------------
+
+    DocumentCreatedEvent:
+      type: object
+      description: Payload for document_management.document.created — emitted when a document and its first version are created atomically.
+      additionalProperties: false
+      required:
+        - documentId
+        - documentTypeId
+        - title
+        - latestVersionId
+        - metadata
+      properties:
+        documentId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/documents
+            field: id
+        documentTypeId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/document-types
+            field: id
+        title:
+          type: string
+        latestVersionId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/document-versions
+            field: id
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          description: Echoed verbatim from Document.metadata so consumers can correlate without additional lookups.
+
+    DocumentVersionUploadedEvent:
+      type: object
+      description: Payload for document_management.document_version.uploaded — emitted when a subsequent version is uploaded.
+      additionalProperties: false
+      required:
+        - documentId
+        - documentVersionId
+        - versionNumber
+        - metadata
+      properties:
+        documentId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/documents
+            field: id
+        documentVersionId:
+          type: string
+          format: uuid
+          x-relationship:
+            resource: document-management/document-versions
+            field: id
+        versionNumber:
+          type: integer
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          description: Echoed verbatim from Document.metadata.

--- a/packages/contracts/intake-rules.yaml
+++ b/packages/contracts/intake-rules.yaml
@@ -217,40 +217,6 @@ ruleSets:
           Add the scheduled appointment ID to the linked Interview's appointments list (Decision 15).
           Only fires when the appointment's subjectType is "interview", ensuring non-interview
           appointments scheduled via the shared scheduling domain are ignored.
-  - id: document-verified-write-back
-    "on": document_management.document.verified
-    evaluation: first-match-wins
-    context:
-      - as: applicationDocument
-        entity: intake/applications/documents
-        from:
-          var: data.subjectId
-        optional: true
-    rules:
-      - id: verify-application-document
-        order: 1
-        condition:
-          "==":
-            - var: this.data.subjectType
-            - application-document
-        action:
-          triggerTransition:
-            entity: intake/applications/documents
-            idFrom: applicationDocument.id
-            transition: verify
-          appendToArray:
-            entity: intake/applications/documents
-            idFrom: applicationDocument.id
-            field: evidence
-            value:
-              var: this.subject
-        description: |
-          Transition the ApplicationDocument to verified and record the document ID in its
-          evidence list when document-management reports successful verification (Decision 15).
-          Only fires when the document's subjectType is "application-document", ensuring
-          documents uploaded in document-management without linking to an ApplicationDocument
-          (via subjectType/subjectId) are silently ignored — analogous to an appointment
-          scheduled without linking to an interview.
   - id: eligibility-determination-write-back
     "on": eligibility.determination.completed
     evaluation: first-match-wins
@@ -297,3 +263,30 @@ ruleSets:
             transition: open
         description: |
           When a caseworker claims an application_review task, transition the linked application from submitted to under_review. Guards on the intake open transition enforce that only system-role callers can execute this.
+  - id: document-verified-write-back
+    evaluation: first-match-wins
+    rules:
+      - id: rule-1
+        order: 1
+        condition:
+          "==":
+            - var: this.data.subjectType
+            - application-document
+        action:
+          triggerTransition:
+            entity: intake/applications/documents
+            idFrom: applicationDocument.id
+            transition: verify
+          appendToArray:
+            entity: intake/applications/documents
+            idFrom: applicationDocument.id
+            field: evidence
+            value:
+              var: this.subject
+        description: |
+          Transition the ApplicationDocument to verified and record the document ID in its
+          evidence list when document-management reports successful verification (Decision 15).
+          Only fires when the document's subjectType is "application-document", ensuring
+          documents uploaded in document-management without linking to an ApplicationDocument
+          (via subjectType/subjectId) are silently ignored — analogous to an appointment
+          scheduled without linking to an interview.

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -2205,3 +2205,59 @@ config_managed_resources:
     config_seeding: Config entries are inserted with source set to "system".
     runtime_create: POST handler sets source to "user" for collections that have config entries.
     delete_guard: DELETE returns 409 CONFIG_MANAGED for any resource with a config-managed ID.
+
+# =============================================================================
+# Cross-Domain Communication
+# =============================================================================
+# Two patterns govern how domains interact. Choosing the wrong one creates
+# hidden coupling — see docs/architecture/inter-domain-communication.md for
+# the full decision rule.
+cross_domain_communication:
+  patterns:
+    command:
+      description: >
+        A direct synchronous API call from one domain to another. Use when the
+        calling domain needs a result to continue its own operation.
+      when_to_use: >
+        The caller cannot complete its current operation without a result from
+        the target domain. Examples: uploading a document and receiving the
+        document ID to attach to a verification record; resolving a person
+        identity match before continuing an application submission.
+      contract_surface: >
+        The calling domain depends on the target domain's OpenAPI contract.
+        The dependency is explicit and versioned.
+
+    domain_event:
+      description: >
+        An async signal emitted when a domain's own state changes. Other domains
+        subscribe and react independently. Use when notifying that something
+        happened — not when expecting a result.
+      when_to_use: >
+        The producing domain's operation is already complete and other domains
+        may optionally react. The producer has no knowledge of its consumers.
+        Examples: application submitted, task claimed, determination completed.
+      contract_surface: >
+        Declared in the producing domain's x-events section. Payload schema is
+        the contract; adding a new consumer requires no change to the producer.
+
+    async_command:
+      description: >
+        A command that initiates a long-running operation, with a domain event
+        delivering the result when it is ready. Use when a synchronous result
+        is not available within a single request.
+      when_to_use: >
+        The operation crosses a system boundary or takes time (e.g. an external
+        agency call). The calling domain initiates via a command, then reacts to
+        the result event. Use the context_passthrough pattern to correlate the
+        result back to the originating record.
+      example: >
+        Intake creates a data-exchange service call (command). The external
+        service responds asynchronously. A domain event delivers the result.
+        Intake reads metadata.intake.verificationId from the event payload and
+        transitions the correct verification record.
+
+  decision_rule: >
+    Does the calling domain need a result from the other domain to complete its
+    current operation? → command. Is the calling domain notifying that its own
+    state changed? → domain_event. If neither fits cleanly, consider the
+    async_command variant.

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -37,6 +37,7 @@
     "express": "^5.1.0",
     "js-yaml": "^4.1.0",
     "json-logic-js": "^2.0.5",
+    "multer": "^2.1.1",
     "swagger-ui-express": "^5.0.1"
   },
   "engines": {

--- a/packages/mock-server/scripts/server.js
+++ b/packages/mock-server/scripts/server.js
@@ -8,8 +8,9 @@ import express from 'express';
 import cors from 'cors';
 import http from 'http';
 import { execSync, spawn } from 'child_process';
-import { realpathSync, openSync, statSync } from 'fs';
+import { realpathSync, openSync, statSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
+import { resolveUploadsDir } from '../src/handlers/document-upload-handler.js';
 import { fileURLToPath } from 'url';
 import { performSetup } from '../src/setup.js';
 import { registerAllRoutes, registerStateMachineRoutes } from '../src/route-generator.js';
@@ -218,7 +219,9 @@ async function startMockServer(specDirs = null, seedDir = null) {
 
     // Register API routes dynamically
     const baseUrl = `http://${HOST}:${PORT}`;
-    const allEndpoints = registerAllRoutes(app, apiSpecs, baseUrl, allStateMachines, allRules, allSlaTypes, allMetrics);
+    const uploadsDir = resolveUploadsDir(resolve(import.meta.dirname, '..', 'uploads'));
+    mkdirSync(uploadsDir, { recursive: true });
+    const allEndpoints = registerAllRoutes(app, apiSpecs, baseUrl, allStateMachines, allRules, allSlaTypes, allMetrics, uploadsDir);
 
     // Register state machine RPC routes
     const rpcEndpoints = registerStateMachineRoutes(app, allStateMachines, apiSpecs, allRules, allSlaTypes);

--- a/packages/mock-server/src/handlers/document-content-handler.js
+++ b/packages/mock-server/src/handlers/document-content-handler.js
@@ -1,0 +1,37 @@
+/**
+ * Handler for GET /document-versions/{id}/content (getDocumentVersionContent).
+ * Streams the file bytes for a document version from disk.
+ */
+
+import { createReadStream, existsSync } from 'fs';
+import { join } from 'path';
+import { findById } from '../database-manager.js';
+
+/**
+ * Create handler for GET /document-versions/{documentVersionId}/content.
+ *
+ * @param {string} uploadsDir - Directory where uploaded files are stored
+ * @returns {Function} Express handler
+ */
+export function createDocumentContentHandler(uploadsDir) {
+  return (req, res) => {
+    const { documentVersionId } = req.params;
+
+    const version = findById('document-versions', documentVersionId);
+    if (!version) {
+      return res.status(404).json({ code: 'NOT_FOUND', message: 'Document version not found' });
+    }
+
+    const filePath = join(uploadsDir, version.documentId, version.id);
+    if (!existsSync(filePath)) {
+      return res.status(404).json({ code: 'NOT_FOUND', message: 'File content not available' });
+    }
+
+    res.setHeader('Content-Type', version.mimeType || 'application/octet-stream');
+    if (version.fileName) {
+      res.setHeader('Content-Disposition', `attachment; filename="${version.fileName}"`);
+    }
+
+    createReadStream(filePath).pipe(res);
+  };
+}

--- a/packages/mock-server/src/handlers/document-upload-handler.js
+++ b/packages/mock-server/src/handlers/document-upload-handler.js
@@ -1,0 +1,195 @@
+/**
+ * Handler for document upload endpoints.
+ *
+ * Handles two operationIds:
+ *   uploadDocument         — POST /documents (create document + first version atomically)
+ *   uploadDocumentVersion  — POST /documents/{documentId}/document-versions (add version)
+ *
+ * Files are stored at {uploadsDir}/{documentId}/{versionId}.
+ * MIME type is preserved on the version record; no file extension is stored on disk.
+ */
+
+import multer from 'multer';
+import { createHash, randomUUID } from 'crypto';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { insertResource, findById, findAll, update } from '../database-manager.js';
+import { emitEvent } from '../emit-event.js';
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * Resolve the uploads directory from env or default.
+ * @param {string} [defaultDir] - Fallback path (typically {mockServerRoot}/uploads)
+ * @returns {string}
+ */
+export function resolveUploadsDir(defaultDir) {
+  return process.env.MOCK_UPLOADS_DIR || defaultDir;
+}
+
+/**
+ * Create handler for POST /documents (uploadDocument).
+ * Parses multipart/form-data, creates document + first version atomically.
+ *
+ * @param {string} uploadsDir - Directory to store uploaded files
+ * @param {string} baseUrl - Base URL for Location header
+ * @returns {Array} [multerMiddleware, expressHandler]
+ */
+export function createDocumentUploadHandler(uploadsDir, baseUrl) {
+  const middleware = upload.single('file');
+
+  const handler = (req, res) => {
+    if (!req.file) {
+      return res.status(422).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Missing required field: file',
+        details: [{ field: 'file', message: 'required' }]
+      });
+    }
+
+    const { documentTypeId, title, documentDate, metadata } = req.body;
+
+    if (!documentTypeId) {
+      return res.status(422).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Missing required field: documentTypeId',
+        details: [{ field: 'documentTypeId', message: 'required' }]
+      });
+    }
+
+    if (!title) {
+      return res.status(422).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Missing required field: title',
+        details: [{ field: 'title', message: 'required' }]
+      });
+    }
+
+    const documentId = randomUUID();
+    const versionId = randomUUID();
+    const now = new Date().toISOString();
+
+    // Persist file bytes to disk
+    const docDir = join(uploadsDir, documentId);
+    mkdirSync(docDir, { recursive: true });
+    writeFileSync(join(docDir, versionId), req.file.buffer);
+
+    // Parse optional metadata JSON string
+    let parsedMetadata = {};
+    if (metadata) {
+      try {
+        parsedMetadata = JSON.parse(metadata);
+      } catch {
+        return res.status(400).json({
+          code: 'BAD_REQUEST',
+          message: 'Invalid JSON in metadata field',
+          details: [{ field: 'metadata', message: 'must be valid JSON' }]
+        });
+      }
+    }
+
+    const contentHash = createHash('sha256').update(req.file.buffer).digest('hex');
+
+    const version = {
+      id: versionId,
+      documentId,
+      versionNumber: 1,
+      fileName: req.file.originalname,
+      mimeType: req.file.mimetype,
+      sizeBytes: req.file.size,
+      contentHash,
+      uploadedById: req.headers['x-caller-id'] || 'anonymous',
+      createdAt: now
+    };
+    insertResource('document-versions', version);
+
+    const document = {
+      id: documentId,
+      documentTypeId,
+      title,
+      documentDate: documentDate || null,
+      lifecycleState: 'active',
+      legalHold: false,
+      latestVersionId: versionId,
+      retentionDeadline: null,
+      metadata: parsedMetadata,
+      dispositionApprovedBy: null,
+      dispositionApprovedAt: null,
+      createdAt: now,
+      updatedAt: now
+    };
+    insertResource('documents', document);
+
+    emitEvent({ domain: 'document-management', object: 'document', action: 'created', resourceId: document.id, source: '/document-management', data: { documentId, latestVersionId: versionId } });
+
+    res.status(201)
+      .set('Location', `${baseUrl}/document-management/documents/${documentId}`)
+      .json(document);
+  };
+
+  return [middleware, handler];
+}
+
+/**
+ * Create handler for POST /documents/{documentId}/document-versions (uploadDocumentVersion).
+ * Adds a new version to an existing document.
+ *
+ * @param {string} uploadsDir - Directory to store uploaded files
+ * @param {string} baseUrl - Base URL for Location header
+ * @returns {Array} [multerMiddleware, expressHandler]
+ */
+export function createDocumentVersionUploadHandler(uploadsDir, baseUrl) {
+  const middleware = upload.single('file');
+
+  const handler = (req, res) => {
+    const { documentId } = req.params;
+
+    const document = findById('documents', documentId);
+    if (!document) {
+      return res.status(404).json({ code: 'NOT_FOUND', message: 'Document not found' });
+    }
+
+    if (!req.file) {
+      return res.status(422).json({
+        code: 'VALIDATION_ERROR',
+        message: 'Missing required field: file',
+        details: [{ field: 'file', message: 'required' }]
+      });
+    }
+
+    const { items: existingVersions } = findAll('document-versions', { documentId }, { limit: 1000 });
+    const versionNumber = existingVersions.length + 1;
+    const versionId = randomUUID();
+    const now = new Date().toISOString();
+
+    // Persist file bytes to disk
+    const docDir = join(uploadsDir, documentId);
+    mkdirSync(docDir, { recursive: true });
+    writeFileSync(join(docDir, versionId), req.file.buffer);
+
+    const contentHash = createHash('sha256').update(req.file.buffer).digest('hex');
+
+    const version = {
+      id: versionId,
+      documentId,
+      versionNumber,
+      fileName: req.file.originalname,
+      mimeType: req.file.mimetype,
+      sizeBytes: req.file.size,
+      contentHash,
+      uploadedById: req.headers['x-caller-id'] || 'anonymous',
+      createdAt: now
+    };
+    insertResource('document-versions', version);
+
+    update('documents', documentId, { latestVersionId: versionId, updatedAt: now });
+
+    emitEvent({ domain: 'document-management', object: 'document-version', action: 'uploaded', resourceId: versionId, source: '/document-management', data: { documentId, versionId, versionNumber } });
+
+    res.status(201)
+      .set('Location', `${baseUrl}/document-management/document-versions/${versionId}`)
+      .json(version);
+  };
+
+  return [middleware, handler];
+}

--- a/packages/mock-server/src/route-generator.js
+++ b/packages/mock-server/src/route-generator.js
@@ -11,6 +11,8 @@ import { createDeleteHandler } from './handlers/delete-handler.js';
 import { createTransitionHandler } from './handlers/transition-handler.js';
 import { createSearchHandler } from './handlers/search-handler.js';
 import { createMetricsListHandler, createMetricsGetHandler } from './handlers/metrics-handler.js';
+import { createDocumentUploadHandler, createDocumentVersionUploadHandler } from './handlers/document-upload-handler.js';
+import { createDocumentContentHandler } from './handlers/document-content-handler.js';
 import { findSlaTypes } from './sla-loader.js';
 import { findAll, update } from './database-manager.js';
 import { emitEvent } from './emit-event.js';
@@ -179,7 +181,7 @@ function convertPathFormat(path) {
  * @param {Array|null} rules - Rules for this API's domain (null if none)
  * @returns {Array} Array of registered endpoint info
  */
-export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, rules, slaTypes = []) {
+export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, rules, slaTypes = [], uploadsDir = null) {
   const registeredEndpoints = [];
 
   console.log(`  Registering routes for ${apiMetadata.title}...`);
@@ -198,6 +200,24 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, rules, 
     // item check because both contain '{' parameters.
     if (endpoint.operationId === 'streamEvents') {
       // Handled by manual registration in server.js before routes are registered
+      continue;
+    } else if (endpoint.operationId === 'uploadDocument' && uploadsDir) {
+      const [middleware, uploadHandler] = createDocumentUploadHandler(uploadsDir, baseUrl);
+      app.post(expressPath, middleware, uploadHandler);
+      registeredEndpoints.push({ method: 'POST', path: expressPath, description: 'Upload document (multipart)' });
+      console.log(`    POST   ${expressPath} - Upload document (multipart)`);
+      continue;
+    } else if (endpoint.operationId === 'uploadDocumentVersion' && uploadsDir) {
+      const [middleware, uploadHandler] = createDocumentVersionUploadHandler(uploadsDir, baseUrl);
+      app.post(expressPath, middleware, uploadHandler);
+      registeredEndpoints.push({ method: 'POST', path: expressPath, description: 'Upload document version (multipart)' });
+      console.log(`    POST   ${expressPath} - Upload document version (multipart)`);
+      continue;
+    } else if (endpoint.operationId === 'getDocumentVersionContent' && uploadsDir) {
+      const contentHandler = createDocumentContentHandler(uploadsDir);
+      app.get(expressPath, contentHandler);
+      registeredEndpoints.push({ method: 'GET', path: expressPath, description: 'Get document version file content' });
+      console.log(`    GET    ${expressPath} - Get document version file content`);
       continue;
     } else if (endpoint.operationId === 'search') {
       // Cross-resource search endpoint — custom handler
@@ -341,7 +361,7 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, rules, 
  * @param {Array} rules - Array from discoverRules()
  * @returns {Array} Array of all registered endpoints grouped by API
  */
-export function registerAllRoutes(app, apiSpecs, baseUrl, stateMachines = [], rules = [], slaTypes = [], metrics = []) {
+export function registerAllRoutes(app, apiSpecs, baseUrl, stateMachines = [], rules = [], slaTypes = [], metrics = [], uploadsDir = null) {
   console.log('\nRegistering API routes...');
 
   const allEndpoints = [];
@@ -359,7 +379,7 @@ export function registerAllRoutes(app, apiSpecs, baseUrl, stateMachines = [], ru
   for (const apiSpec of apiSpecs) {
     // Pass all state machines for this domain — there may be more than one (e.g., Application + ApplicationDocument)
     const domainSMs = stateMachines.filter(s => s.domain === apiSpec.name);
-    const endpoints = registerRoutes(app, apiSpec, baseUrl, domainSMs, rules, slaTypes);
+    const endpoints = registerRoutes(app, apiSpec, baseUrl, domainSMs, rules, slaTypes, uploadsDir);
     allEndpoints.push({
       apiName: apiSpec.name,
       title: apiSpec.title,

--- a/packages/mock-server/tests/unit/document-upload-handler.test.js
+++ b/packages/mock-server/tests/unit/document-upload-handler.test.js
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for document upload and content handlers.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { clearAll, findById, findAll, insertResource } from '../../src/database-manager.js';
+import { PassThrough } from 'stream';
+import {
+  createDocumentUploadHandler,
+  createDocumentVersionUploadHandler,
+  resolveUploadsDir
+} from '../../src/handlers/document-upload-handler.js';
+import { createDocumentContentHandler } from '../../src/handlers/document-content-handler.js';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeReq(overrides = {}) {
+  return {
+    file: {
+      originalname: 'test.txt',
+      mimetype: 'text/plain',
+      size: 13,
+      buffer: Buffer.from('hello, world!')
+    },
+    body: {
+      documentTypeId: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5',
+      title: 'Test Document'
+    },
+    headers: { 'x-caller-id': 'user-1' },
+    params: {},
+    ...overrides
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _headers: {},
+    _body: null,
+    status(code) { this._status = code; return this; },
+    set(key, value) { this._headers[key] = value; return this; },
+    setHeader(key, value) { this._headers[key] = value; },
+    json(body) { this._body = body; return this; }
+  };
+  return res;
+}
+
+// =============================================================================
+// resolveUploadsDir
+// =============================================================================
+
+test('resolveUploadsDir — returns MOCK_UPLOADS_DIR env var when set', () => {
+  const original = process.env.MOCK_UPLOADS_DIR;
+  process.env.MOCK_UPLOADS_DIR = '/custom/uploads';
+  assert.strictEqual(resolveUploadsDir('/default'), '/custom/uploads');
+  if (original === undefined) delete process.env.MOCK_UPLOADS_DIR;
+  else process.env.MOCK_UPLOADS_DIR = original;
+});
+
+test('resolveUploadsDir — falls back to defaultDir when env var not set', () => {
+  const original = process.env.MOCK_UPLOADS_DIR;
+  delete process.env.MOCK_UPLOADS_DIR;
+  assert.strictEqual(resolveUploadsDir('/default'), '/default');
+  if (original !== undefined) process.env.MOCK_UPLOADS_DIR = original;
+});
+
+// =============================================================================
+// uploadDocument
+// =============================================================================
+
+test('uploadDocument — creates document and version records, saves file to disk', () => {
+  clearAll('documents');
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq();
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 201);
+    assert.ok(res._body.id, 'document has id');
+    assert.strictEqual(res._body.title, 'Test Document');
+    assert.strictEqual(res._body.lifecycleState, 'active');
+    assert.strictEqual(res._body.legalHold, false);
+    assert.ok(res._body.latestVersionId, 'document has latestVersionId');
+    assert.ok(res._headers['Location']?.includes(res._body.id), 'Location header set');
+
+    // Version record created
+    const version = findById('document-versions', res._body.latestVersionId);
+    assert.ok(version, 'version record exists');
+    assert.strictEqual(version.versionNumber, 1);
+    assert.strictEqual(version.fileName, 'test.txt');
+    assert.strictEqual(version.mimeType, 'text/plain');
+    assert.strictEqual(version.sizeBytes, 13);
+    assert.strictEqual(version.uploadedById, 'user-1');
+
+    // File saved to disk
+    const filePath = join(uploadsDir, res._body.id, version.id);
+    assert.ok(existsSync(filePath), 'file exists on disk');
+    assert.strictEqual(readFileSync(filePath).toString(), 'hello, world!');
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocument — returns 422 when file is missing', () => {
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({ file: null });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 422);
+    assert.strictEqual(res._body.code, 'VALIDATION_ERROR');
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocument — returns 422 when documentTypeId is missing', () => {
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({ body: { title: 'Test' } });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 422);
+    assert.ok(res._body.details.some(d => d.field === 'documentTypeId'));
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocument — returns 422 when title is missing', () => {
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({ body: { documentTypeId: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5' } });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 422);
+    assert.ok(res._body.details.some(d => d.field === 'title'));
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocument — returns 400 when metadata is invalid JSON', () => {
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({ body: { documentTypeId: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5', title: 'Test', metadata: 'not-json' } });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 400);
+    assert.ok(res._body.details.some(d => d.field === 'metadata'));
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocument — parses metadata JSON string onto document record', () => {
+  clearAll('documents');
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({
+      body: {
+        documentTypeId: 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5',
+        title: 'Test',
+        metadata: JSON.stringify({ intake: { verificationId: 'ver-123' } })
+      }
+    });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.deepStrictEqual(res._body.metadata, { intake: { verificationId: 'ver-123' } });
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// uploadDocumentVersion
+// =============================================================================
+
+test('uploadDocumentVersion — adds version to existing document, increments versionNumber', () => {
+  clearAll('documents');
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    // Seed a document and first version
+    const [, uploadHandler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+    const uploadReq = makeReq();
+    const uploadRes = makeRes();
+    uploadHandler(uploadReq, uploadRes);
+    const documentId = uploadRes._body.id;
+
+    // Add second version
+    const [, versionHandler] = createDocumentVersionUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({
+      params: { documentId },
+      file: { originalname: 'v2.txt', mimetype: 'text/plain', size: 5, buffer: Buffer.from('hello') }
+    });
+    const res = makeRes();
+
+    versionHandler(req, res);
+
+    assert.strictEqual(res._status, 201);
+    assert.strictEqual(res._body.versionNumber, 2);
+    assert.strictEqual(res._body.documentId, documentId);
+
+    // Document latestVersionId updated
+    const doc = findById('documents', documentId);
+    assert.strictEqual(doc.latestVersionId, res._body.id);
+
+    // File on disk
+    const filePath = join(uploadsDir, documentId, res._body.id);
+    assert.ok(existsSync(filePath));
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('uploadDocumentVersion — returns 404 when document does not exist', () => {
+  clearAll('documents');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const [, handler] = createDocumentVersionUploadHandler(uploadsDir, 'http://localhost:1080');
+    const req = makeReq({ params: { documentId: '00000000-0000-0000-0000-000000000000' } });
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 404);
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+// =============================================================================
+// getDocumentVersionContent
+// =============================================================================
+
+test('getDocumentVersionContent — sets Content-Type and Content-Disposition headers', (t, done) => {
+  clearAll('documents');
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+
+  // Upload a document to seed DB and disk
+  const [, uploadHandler] = createDocumentUploadHandler(uploadsDir, 'http://localhost:1080');
+  const uploadReq = makeReq();
+  const uploadRes = makeRes();
+  uploadHandler(uploadReq, uploadRes);
+  const versionId = uploadRes._body.latestVersionId;
+
+  // Use a PassThrough as the response so the ReadStream can pipe into it
+  const res = new PassThrough();
+  res._headers = {};
+  res.setHeader = (k, v) => { res._headers[k] = v; };
+
+  const contentHandler = createDocumentContentHandler(uploadsDir);
+  contentHandler({ params: { documentVersionId: versionId } }, res);
+
+  res.on('finish', () => {
+    try {
+      assert.strictEqual(res._headers['Content-Type'], 'text/plain');
+      assert.ok(res._headers['Content-Disposition']?.includes('test.txt'));
+      rmSync(uploadsDir, { recursive: true, force: true });
+      done();
+    } catch (err) {
+      rmSync(uploadsDir, { recursive: true, force: true });
+      done(err);
+    }
+  });
+});
+
+test('getDocumentVersionContent — returns 404 when version does not exist', () => {
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    const handler = createDocumentContentHandler(uploadsDir);
+    const req = { params: { documentVersionId: '00000000-0000-0000-0000-000000000000' } };
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 404);
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});
+
+test('getDocumentVersionContent — returns 404 when file is missing from disk', () => {
+  clearAll('documents');
+  clearAll('document-versions');
+
+  const uploadsDir = mkdtempSync(join(tmpdir(), 'doc-test-'));
+  try {
+    // Insert a version record with no corresponding file on disk
+    const versionId = '11111111-1111-4111-8111-111111111111';
+    insertResource('document-versions', {
+      id: versionId,
+      documentId: '22222222-2222-4222-8222-222222222222',
+      versionNumber: 1,
+      fileName: 'ghost.txt',
+      mimeType: 'text/plain',
+      sizeBytes: 0,
+      contentHash: 'abc',
+      uploadedById: 'user-1',
+      createdAt: new Date().toISOString()
+    });
+
+    const handler = createDocumentContentHandler(uploadsDir);
+    const req = { params: { documentVersionId: versionId } };
+    const res = makeRes();
+
+    handler(req, res);
+
+    assert.strictEqual(res._status, 404);
+    assert.strictEqual(res._body.message, 'File content not available');
+  } finally {
+    rmSync(uploadsDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #273

## Summary
- Add `document-management-config.yaml` with 13 baseline document types (identity, citizenship, income, residency, assets, medical expenses), all with 3-year retention per 7 CFR § 272.1(f)
- Add `document-management-config-schema.yaml` to validate the catalog
- Add file upload and content retrieval to the mock server: multer (memory storage), disk-backed at `{uploadsDir}/{documentId}/{versionId}`, configurable via `MOCK_UPLOADS_DIR`
- Remove stale `document-verified-write-back` rule from `intake-rules.yaml` (replaced by synchronous command pattern)
- Add Spectral file-level override for document-management to allow multipart/form-data and binary response content types

## Notes for reviewer
The Spectral override is file-level (not path-level) because path-level overrides with parameterized paths fail — `{documentId}` in the glob is interpreted as a glob group pattern. Validation steps are in the issue.
