### PR TITLE
mock-server: skip CAST AS REAL for ISO date comparisons

### DIFF
--- a/packages/mock-server/src/query-parser.js
+++ b/packages/mock-server/src/query-parser.js
@@ -284,6 +284,16 @@ export function tokensToSqlConditions(tokens, searchableFields = []) {
   return { whereClauses, params };
 }
 
+// Recognize ISO 8601 date / date-time strings so comparison operators don't
+// silently cast them to REAL. CAST('2026-05-15T16:00:00Z' AS REAL) is 2026.0,
+// which destroys anything finer than year-resolution. SQLite collates ISO
+// strings lexicographically, so plain string comparison is the correct fix
+// (issue #292).
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+function looksLikeIsoDateTime(value) {
+  return typeof value === 'string' && ISO_DATE_RE.test(value);
+}
+
 /**
  * Convert a single token to a SQL condition
  * @param {Object} token - Parsed token
@@ -366,34 +376,34 @@ function tokenToSqlCondition(token, searchableFields) {
 
     case TokenType.GREATER_THAN: {
       const jsonPath = fieldToJsonPath(field);
-      return {
-        clause: `CAST(json_extract(data, '${jsonPath}') AS REAL) > ?`,
-        tokenParams: [value]
-      };
+      const clause = looksLikeIsoDateTime(value)
+        ? `json_extract(data, '${jsonPath}') > ?`
+        : `CAST(json_extract(data, '${jsonPath}') AS REAL) > ?`;
+      return { clause, tokenParams: [value] };
     }
 
     case TokenType.GREATER_THAN_OR_EQUAL: {
       const jsonPath = fieldToJsonPath(field);
-      return {
-        clause: `CAST(json_extract(data, '${jsonPath}') AS REAL) >= ?`,
-        tokenParams: [value]
-      };
+      const clause = looksLikeIsoDateTime(value)
+        ? `json_extract(data, '${jsonPath}') >= ?`
+        : `CAST(json_extract(data, '${jsonPath}') AS REAL) >= ?`;
+      return { clause, tokenParams: [value] };
     }
 
     case TokenType.LESS_THAN: {
       const jsonPath = fieldToJsonPath(field);
-      return {
-        clause: `CAST(json_extract(data, '${jsonPath}') AS REAL) < ?`,
-        tokenParams: [value]
-      };
+      const clause = looksLikeIsoDateTime(value)
+        ? `json_extract(data, '${jsonPath}') < ?`
+        : `CAST(json_extract(data, '${jsonPath}') AS REAL) < ?`;
+      return { clause, tokenParams: [value] };
     }
 
     case TokenType.LESS_THAN_OR_EQUAL: {
       const jsonPath = fieldToJsonPath(field);
-      return {
-        clause: `CAST(json_extract(data, '${jsonPath}') AS REAL) <= ?`,
-        tokenParams: [value]
-      };
+      const clause = looksLikeIsoDateTime(value)
+        ? `json_extract(data, '${jsonPath}') <= ?`
+        : `CAST(json_extract(data, '${jsonPath}') AS REAL) <= ?`;
+      return { clause, tokenParams: [value] };
     }
 
     case TokenType.IN: {

--- a/packages/mock-server/tests/unit/query-parser.test.js
+++ b/packages/mock-server/tests/unit/query-parser.test.js
@@ -355,9 +355,10 @@ function runTests() {
     assertEqual(whereClauses[0], "json_extract(data, '$.created') >= ?");
   });
 
-  test('still uses REAL cast for numeric bounds that look year-ish', () => {
-    // A bare year like "2025" isn't a date — it's an integer. Keep the cast.
-    const tokens = [{ type: TokenType.GREATER_THAN, field: 'year', value: 2025 }];
+  test('still uses REAL cast for bare-year bounds', () => {
+    // The parser emits "2025" as a string. It doesn't match yyyy-mm-dd,
+    // so it stays on the cast path and keeps numeric ordering.
+    const tokens = [{ type: TokenType.GREATER_THAN, field: 'year', value: '2025' }];
     const { whereClauses } = tokensToSqlConditions(tokens, []);
     assertEqual(whereClauses[0], "CAST(json_extract(data, '$.year') AS REAL) > ?");
   });

--- a/packages/mock-server/tests/unit/query-parser.test.js
+++ b/packages/mock-server/tests/unit/query-parser.test.js
@@ -331,6 +331,37 @@ function runTests() {
     assertEqual(params, [1000]);
   });
 
+  test('skips CAST AS REAL for ISO date-time bounds (#292)', () => {
+    // CAST('2026-05-15T16:00:00Z' AS REAL) is 2026.0, which would silently
+    // drop anything finer than year-resolution. SQLite collates strings
+    // lexicographically, so plain string comparison is correct for ISO 8601.
+    const cases = [
+      [TokenType.GREATER_THAN, '>'],
+      [TokenType.GREATER_THAN_OR_EQUAL, '>='],
+      [TokenType.LESS_THAN, '<'],
+      [TokenType.LESS_THAN_OR_EQUAL, '<='],
+    ];
+    for (const [type, op] of cases) {
+      const tokens = [{ type, field: 'startAt', value: '2026-05-15T16:00:00Z' }];
+      const { whereClauses, params } = tokensToSqlConditions(tokens, []);
+      assertEqual(whereClauses[0], `json_extract(data, '$.startAt') ${op} ?`);
+      assertEqual(params, ['2026-05-15T16:00:00Z']);
+    }
+  });
+
+  test('also matches date-only ISO strings', () => {
+    const tokens = [{ type: TokenType.GREATER_THAN_OR_EQUAL, field: 'created', value: '2024-01-01' }];
+    const { whereClauses } = tokensToSqlConditions(tokens, []);
+    assertEqual(whereClauses[0], "json_extract(data, '$.created') >= ?");
+  });
+
+  test('still uses REAL cast for numeric bounds that look year-ish', () => {
+    // A bare year like "2025" isn't a date — it's an integer. Keep the cast.
+    const tokens = [{ type: TokenType.GREATER_THAN, field: 'year', value: 2025 }];
+    const { whereClauses } = tokensToSqlConditions(tokens, []);
+    assertEqual(whereClauses[0], "CAST(json_extract(data, '$.year') AS REAL) > ?");
+  });
+
   test('generates IN clause SQL', () => {
     const tokens = [{ type: TokenType.IN, field: 'status', value: ['a', 'b'] }];
     const { whereClauses, params } = tokensToSqlConditions(tokens, []);


### PR DESCRIPTION
Closes #292

## Summary
- ISO date/date-time strings stored as SQLite text collate correctly with lexicographic comparison — no cast needed
- The `>`, `>=`, `<`, `<=` operators previously emitted `CAST(json_extract(...) AS REAL)`, which truncated ISO dates to year-only (e.g., `2026-05-15` → `2026.0`), silently dropping any filter finer than year resolution
- Added `looksLikeIsoDateTime()` regex check; ISO-shaped bounds skip the REAL cast and use direct string comparison
- Bare year integers and numeric values stay on the REAL cast path — no regression for existing numeric comparisons

## Notes for reviewer
Validation steps are in the issue. The only files changed are `query-parser.js` and its unit test; no schema or API changes.