### PR TITLE
Resolve {{...}} date tokens in seed YAML

### DIFF
--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -33,6 +33,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^11.0.0",
+    "chrono-node": "^2.9.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "js-yaml": "^4.1.0",

--- a/packages/mock-server/seed/scheduling.yaml
+++ b/packages/mock-server/seed/scheduling.yaml
@@ -3,8 +3,9 @@
 
 AppointmentExample1:
   id: b898e306-ecca-57f5-85c9-b7bcf00e5f9f
-  startAt: '2024-01-01T00:00:00.000Z'
-  endAt: '2024-01-01T00:00:00.000Z'
+  # Demo-friendly: upcoming appointment relative to seed load (#302).
+  startAt: '{{now + 1 hour}}'
+  endAt: '{{now + 8 hours}}'
   appointmentType: standard
   status: scheduled
   personId: b3945614-c6d6-5214-82c4-c6b90114f0eb

--- a/packages/mock-server/src/seed-loader.js
+++ b/packages/mock-server/src/seed-loader.js
@@ -1,0 +1,29 @@
+/**
+ * Loads seed YAML files and resolves `{{...}}` date tokens.
+ *
+ * Two consumers — seed-validator and seeder — both need post-template seed
+ * data, validator to check shape and seeder to insert. Centralizing the load
+ * + resolve step here keeps templating concerns out of both consumers.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import yaml from 'js-yaml';
+import { resolveTemplates } from './seed-template-resolver.js';
+
+/**
+ * Load a single seed YAML file and resolve every `{{...}}` token in it.
+ *
+ * @param {string} seedDir - Path to seed directory.
+ * @param {string} apiName - API name; resolves to `${seedDir}/${apiName}.yaml`.
+ * @param {Date} now - Reference instant for token resolution.
+ * @returns {Object} The parsed-and-resolved seed object (empty if file absent).
+ * @throws {Error} If the file is malformed YAML.
+ * @throws {SeedTemplateError} If any token can't be resolved cleanly.
+ */
+export function loadResolvedSeed(seedDir, apiName, now) {
+  const seedPath = join(seedDir, `${apiName}.yaml`);
+  if (!existsSync(seedPath)) return {};
+  const raw = yaml.load(readFileSync(seedPath, 'utf8')) || {};
+  return resolveTemplates(raw, now, apiName);
+}

--- a/packages/mock-server/src/seed-template-resolver.js
+++ b/packages/mock-server/src/seed-template-resolver.js
@@ -1,0 +1,105 @@
+/**
+ * Resolves `{{...}}` date tokens in seed YAML values into absolute ISO
+ * datetimes at seed-load time.
+ *
+ * Issue #302. The token's inner expression is passed verbatim to chrono-node
+ * — a natural-language date parser — with the seed-load instant as the
+ * reference time. That gives us, for free:
+ *
+ *   {{now}}                       → seed-load instant T
+ *   {{now + 1 hour}}              → T + 1 hour
+ *   {{now + 7 days}}              → T + 7 days
+ *   {{now - 2 days}}              → T - 2 days
+ *   {{in 7 days}}, {{2 days ago}} → chrono idiom
+ *   {{tomorrow at 09:30}}         → calendar-aware
+ *   {{next monday at 2pm}}        → named days
+ *   {{2026-06-15T09:30:00Z}}      → absolute ISO
+ *   {{June 15 2026 9:30am}}       → absolute natural language
+ *
+ * A token must occupy the whole field — mixed strings like
+ * "starts at {{now}}" are rejected. Anything chrono can't parse cleanly
+ * throws SeedTemplateError so seed bugs surface at load time.
+ *
+ * Tokens reference only `now` (the seed-load instant) — no inter-field
+ * refs, so resolution is order-independent.
+ */
+
+import * as chrono from 'chrono-node';
+
+const TOKEN_RE = /^\s*\{\{\s*(.+?)\s*\}\}\s*$/;
+
+/**
+ * Thrown when a seed template token can't be parsed. Distinct so the seeder
+ * can re-raise template errors past its per-record / per-API catches and
+ * abort the load (the issue's fail-loud requirement) without aborting on
+ * benign per-record issues like a missing FK.
+ */
+export class SeedTemplateError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SeedTemplateError';
+  }
+}
+
+/**
+ * Resolve every `{{...}}` token in a value against the supplied instant.
+ *
+ * Walks strings, arrays, and plain objects. Non-string/array/object values
+ * and strings without a token pass through unchanged.
+ *
+ * @param {*} value - Value to resolve. Mutates nothing.
+ * @param {Date} now - The seed-load instant. Every token in one call sees this.
+ * @param {string} [path] - Dotted path used in error messages.
+ * @returns {*} Resolved copy of `value`.
+ * @throws {SeedTemplateError} On any token chrono can't parse cleanly.
+ */
+export function resolveTemplates(value, now, path = '') {
+  if (typeof value === 'string') {
+    const match = value.match(TOKEN_RE);
+    if (!match) {
+      // Guard against half-templated strings — if the field contains `{{`
+      // but isn't a clean whole-string token, the author probably wanted
+      // interpolation we don't support. Surface that loudly rather than
+      // leaving the raw braces in the persisted record.
+      if (value.includes('{{')) {
+        throw new SeedTemplateError(
+          `Seed template token must be the entire field value at ${path || '(root)'}: ` +
+          `got ${JSON.stringify(value)}. Move literal text out of the field.`
+        );
+      }
+      return value;
+    }
+    return resolveExpression(match[1], now, value, path);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item, i) => resolveTemplates(item, now, `${path}[${i}]`));
+  }
+  if (value !== null && typeof value === 'object') {
+    const out = {};
+    for (const [key, v] of Object.entries(value)) {
+      out[key] = resolveTemplates(v, now, path ? `${path}.${key}` : key);
+    }
+    return out;
+  }
+  return value;
+}
+
+function resolveExpression(expr, now, originalString, path) {
+  // Use chrono.parse() (not parseDate) so we can verify chrono consumed the
+  // entire input. chrono silently degrades on partial matches — e.g. it
+  // parses "now + 7 dasys" as just "now" because it can't make sense of
+  // "dasys" but happily falls back to what it could match. We require a
+  // single match whose text equals the input so silent degradation surfaces
+  // as an error.
+  const results = chrono.parse(expr, now);
+  if (results.length !== 1 || results[0].text !== expr) {
+    throw new SeedTemplateError(
+      `Unparseable seed template token "{{${expr}}}" at ${path || '(root)'}: ` +
+      `value was ${JSON.stringify(originalString)}. ` +
+      `Tokens are parsed by chrono-node — try expressions like ` +
+      `"{{now + 7 days}}", "{{in 1 hour}}", "{{tomorrow at 09:30}}", ` +
+      `or an absolute ISO datetime.`
+    );
+  }
+  return results[0].start.date().toISOString();
+}

--- a/packages/mock-server/src/seed-validator.js
+++ b/packages/mock-server/src/seed-validator.js
@@ -2,10 +2,9 @@
  * Seed data validator — validates seed YAML records against API schemas.
  */
 
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import yaml from 'js-yaml';
 import { validateExamples } from '@codeforamerica/safety-net-blueprint-contracts/example-validator';
+import { loadResolvedSeed } from './seed-loader.js';
+import { SeedTemplateError } from './seed-template-resolver.js';
 
 /**
  * Validate all seed files in seedDir against schemas in apiSpecs.
@@ -15,18 +14,29 @@ import { validateExamples } from '@codeforamerica/safety-net-blueprint-contracts
  */
 export function validateSeedData(seedDir, apiSpecs) {
   const errors = [];
+  // Single reference instant for token resolution across this validation
+  // pass. The seeder uses its own `now` at insert time — those are within
+  // milliseconds and the validator doesn't persist anything, so the
+  // separation is fine.
+  const now = new Date();
 
   for (const api of apiSpecs) {
-    const seedPath = join(seedDir, `${api.name}.yaml`);
-    if (!existsSync(seedPath)) continue;
-
     let examples;
     try {
-      examples = yaml.load(readFileSync(seedPath, 'utf8')) || {};
+      examples = loadResolvedSeed(seedDir, api.name, now);
     } catch (err) {
+      // Template errors are seed-author bugs that should fail the boot, but
+      // we still want to surface them through the same validator pipeline
+      // so the consolidated error message includes them.
+      if (err instanceof SeedTemplateError) {
+        errors.push({ api: api.name, key: null, message: err.message });
+        continue;
+      }
       errors.push({ api: api.name, key: null, message: `Failed to parse seed file: ${err.message}` });
       continue;
     }
+
+    if (Object.keys(examples).length === 0) continue;
 
     for (const { key, instancePath, message } of validateExamples(examples, api.schemas)) {
       const path = instancePath || '/';

--- a/packages/mock-server/src/seeder.js
+++ b/packages/mock-server/src/seeder.js
@@ -2,24 +2,10 @@
  * Data seeder - loads example data from YAML files into SQLite
  */
 
-import { readFileSync, existsSync } from 'fs';
-import yaml from 'js-yaml';
 import { insertResource, clearAll } from './database-manager.js';
 import { collectionToSchemaPrefix, extractIndividualResources } from '@codeforamerica/safety-net-blueprint-contracts/loader';
-import { join } from 'path';
-
-/**
- * Load examples from YAML file
- * @param {string} examplesPath - Path to examples YAML file
- * @returns {Object} Examples object
- */
-function loadExamples(examplesPath) {
-  if (!existsSync(examplesPath)) {
-    return {};
-  }
-  const content = readFileSync(examplesPath, 'utf8');
-  return yaml.load(content) || {};
-}
+import { loadResolvedSeed } from './seed-loader.js';
+import { SeedTemplateError } from './seed-template-resolver.js';
 
 /**
  * Seed database with examples from a seed YAML file.
@@ -31,7 +17,7 @@ function loadExamples(examplesPath) {
 export function seedDatabase(collectionName, seedDir, apiName) {
   const resourceName = apiName || collectionName;
   try {
-    const examples = loadExamples(join(seedDir, `${resourceName}.yaml`));
+    const examples = loadResolvedSeed(seedDir, resourceName, new Date());
 
     if (Object.keys(examples).length === 0) {
       console.log(`  No seed file found for ${resourceName}, database will be empty`);
@@ -66,6 +52,9 @@ export function seedDatabase(collectionName, seedDir, apiName) {
     console.log(`  Seeded ${seededCount} ${collectionName}`);
     return seededCount;
   } catch (error) {
+    // Fail-loud on seed-template errors (#302) — don't let the load proceed
+    // with an empty collection if the fixtures themselves are malformed.
+    if (error instanceof SeedTemplateError) throw error;
     console.error(`  Error seeding ${collectionName}:`, error.message);
     return 0;
   }
@@ -138,6 +127,9 @@ export function seedAllDatabases(apiSpecs, specsDir, seedDir) {
   console.log('\nSeeding databases from seed files...');
 
   const summary = {};
+  // Single seed-load instant — every {{now}} token in this load resolves
+  // against this timestamp, so paired fields like startAt/endAt stay aligned.
+  const now = new Date();
 
   for (const api of apiSpecs) {
     try {
@@ -147,7 +139,7 @@ export function seedAllDatabases(apiSpecs, specsDir, seedDir) {
         clearAll(name);
       }
 
-      const examples = loadExamples(join(seedDir, `${api.name}.yaml`));
+      const examples = loadResolvedSeed(seedDir, api.name, now);
 
       if (Object.keys(examples).length === 0) {
         console.log(`  No seed file found for ${api.name}, databases will be empty`);
@@ -186,6 +178,8 @@ export function seedAllDatabases(apiSpecs, specsDir, seedDir) {
         summary[collectionName] = seededCount;
       }
     } catch (error) {
+      // Fail-loud on seed-template errors (#302) — abort the whole load.
+      if (error instanceof SeedTemplateError) throw error;
       console.warn(`  Warning: Could not seed ${api.name}:`, error.message);
       summary[api.name] = 0;
     }

--- a/packages/mock-server/tests/unit/seed-template-resolver.test.js
+++ b/packages/mock-server/tests/unit/seed-template-resolver.test.js
@@ -1,0 +1,266 @@
+/**
+ * Unit tests for the seed-template resolver (#302).
+ *
+ * Mirrors the smoke probe we ran against chrono-node, plus the integration
+ * concerns specific to this resolver: recursion through arrays/objects,
+ * passthrough on literals, fail-loud on partial-match degradation, half-
+ * templated strings, and consistency within a single load.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { resolveTemplates } from '../../src/seed-template-resolver.js';
+
+// Fix `now` to a known instant so assertions are deterministic. UTC noon on
+// a date that doesn't straddle DST in most reasonable timezones.
+const NOW = new Date('2026-06-15T12:00:00.000Z'); // Monday
+
+test('resolveTemplates — issue grammar', async (t) => {
+  await t.test('{{now}} resolves to the seed-load instant', () => {
+    assert.strictEqual(resolveTemplates('{{now}}', NOW), '2026-06-15T12:00:00.000Z');
+  });
+
+  await t.test('{{now + 1 hour}} adds one hour', () => {
+    assert.strictEqual(resolveTemplates('{{now + 1 hour}}', NOW), '2026-06-15T13:00:00.000Z');
+  });
+
+  await t.test('{{now + 8 hours}} adds eight hours', () => {
+    assert.strictEqual(resolveTemplates('{{now + 8 hours}}', NOW), '2026-06-15T20:00:00.000Z');
+  });
+
+  await t.test('{{now + 7 days}} adds seven days, same time-of-day', () => {
+    assert.strictEqual(resolveTemplates('{{now + 7 days}}', NOW), '2026-06-22T12:00:00.000Z');
+  });
+
+  await t.test('{{now - 2 days}} subtracts two days', () => {
+    assert.strictEqual(resolveTemplates('{{now - 2 days}}', NOW), '2026-06-13T12:00:00.000Z');
+  });
+
+  await t.test('{{now + 1 day}} (singular) works', () => {
+    assert.strictEqual(resolveTemplates('{{now + 1 day}}', NOW), '2026-06-16T12:00:00.000Z');
+  });
+});
+
+test('resolveTemplates — chrono idiom', async (t) => {
+  await t.test('{{in 1 hour}}', () => {
+    assert.strictEqual(resolveTemplates('{{in 1 hour}}', NOW), '2026-06-15T13:00:00.000Z');
+  });
+
+  await t.test('{{in 8 hours}}', () => {
+    assert.strictEqual(resolveTemplates('{{in 8 hours}}', NOW), '2026-06-15T20:00:00.000Z');
+  });
+
+  await t.test('{{in 7 days}}', () => {
+    assert.strictEqual(resolveTemplates('{{in 7 days}}', NOW), '2026-06-22T12:00:00.000Z');
+  });
+
+  await t.test('{{2 days ago}}', () => {
+    assert.strictEqual(resolveTemplates('{{2 days ago}}', NOW), '2026-06-13T12:00:00.000Z');
+  });
+});
+
+test('resolveTemplates — calendar-aware', async (t) => {
+  await t.test('{{tomorrow}} lands on the next day', () => {
+    const out = resolveTemplates('{{tomorrow}}', NOW);
+    assert.match(out, /^2026-06-16T/);
+  });
+
+  await t.test('{{tomorrow at 09:30}} produces local 09:30', () => {
+    const parsed = new Date(resolveTemplates('{{tomorrow at 09:30}}', NOW));
+    assert.strictEqual(parsed.getHours(), 9);
+    assert.strictEqual(parsed.getMinutes(), 30);
+  });
+
+  await t.test('{{next monday}} lands on a Monday', () => {
+    const parsed = new Date(resolveTemplates('{{next monday}}', NOW));
+    assert.strictEqual(parsed.getDay(), 1);
+  });
+
+  await t.test('{{next friday at 2pm}} lands on a Friday at local 14:00', () => {
+    const parsed = new Date(resolveTemplates('{{next friday at 2pm}}', NOW));
+    assert.strictEqual(parsed.getDay(), 5);
+    assert.strictEqual(parsed.getHours(), 14);
+  });
+
+  await t.test('{{last tuesday}} lands on a Tuesday in the past', () => {
+    const parsed = new Date(resolveTemplates('{{last tuesday}}', NOW));
+    assert.strictEqual(parsed.getDay(), 2);
+    assert.ok(parsed.getTime() < NOW.getTime(), 'should be before NOW');
+  });
+});
+
+test('resolveTemplates — absolute', async (t) => {
+  await t.test('ISO datetime with Z', () => {
+    assert.strictEqual(
+      resolveTemplates('{{2026-06-15T09:30:00Z}}', NOW),
+      '2026-06-15T09:30:00.000Z'
+    );
+  });
+
+  await t.test('ISO datetime without TZ (interpreted as local)', () => {
+    const parsed = new Date(resolveTemplates('{{2026-06-15T09:30:00}}', NOW));
+    assert.strictEqual(parsed.getHours(), 9);
+    assert.strictEqual(parsed.getMinutes(), 30);
+  });
+
+  await t.test('date-only string', () => {
+    const out = resolveTemplates('{{2026-06-15}}', NOW);
+    assert.match(out, /^2026-06-15T/);
+  });
+
+  await t.test('natural-language absolute', () => {
+    const parsed = new Date(resolveTemplates('{{June 15 2026 9:30am}}', NOW));
+    assert.strictEqual(parsed.getFullYear(), 2026);
+    assert.strictEqual(parsed.getMonth(), 5); // June (0-indexed)
+    assert.strictEqual(parsed.getDate(), 15);
+    assert.strictEqual(parsed.getHours(), 9);
+    assert.strictEqual(parsed.getMinutes(), 30);
+  });
+});
+
+test('resolveTemplates — recursion', async (t) => {
+  await t.test('walks plain objects and replaces nested tokens', () => {
+    const input = {
+      id: 'abc',
+      startAt: '{{now}}',
+      meta: { dueAt: '{{now + 7 days}}', label: 'kept literal' },
+    };
+    const out = resolveTemplates(input, NOW);
+    assert.deepStrictEqual(out, {
+      id: 'abc',
+      startAt: '2026-06-15T12:00:00.000Z',
+      meta: { dueAt: '2026-06-22T12:00:00.000Z', label: 'kept literal' },
+    });
+  });
+
+  await t.test('walks arrays', () => {
+    const out = resolveTemplates(
+      ['{{now}}', { at: '{{now + 1 hour}}' }, 'literal'],
+      NOW
+    );
+    assert.deepStrictEqual(out, [
+      '2026-06-15T12:00:00.000Z',
+      { at: '2026-06-15T13:00:00.000Z' },
+      'literal',
+    ]);
+  });
+
+  await t.test('does not mutate the input', () => {
+    const input = { startAt: '{{now}}' };
+    const snapshot = { startAt: '{{now}}' };
+    resolveTemplates(input, NOW);
+    assert.deepStrictEqual(input, snapshot);
+  });
+});
+
+test('resolveTemplates — passthrough', async (t) => {
+  await t.test('literal strings are returned unchanged', () => {
+    assert.strictEqual(resolveTemplates('2024-01-01T00:00:00.000Z', NOW), '2024-01-01T00:00:00.000Z');
+    assert.strictEqual(resolveTemplates('plain text', NOW), 'plain text');
+  });
+
+  await t.test('non-string/array/object values are returned unchanged', () => {
+    assert.strictEqual(resolveTemplates(42, NOW), 42);
+    assert.strictEqual(resolveTemplates(null, NOW), null);
+    assert.strictEqual(resolveTemplates(true, NOW), true);
+    assert.strictEqual(resolveTemplates(undefined, NOW), undefined);
+  });
+
+  await t.test('strings with unrelated braces pass through', () => {
+    assert.strictEqual(resolveTemplates('this {is} fine', NOW), 'this {is} fine');
+  });
+});
+
+test('resolveTemplates — fail loud', async (t) => {
+  // chrono silently degrades on partial input — e.g. "now + 7 dasys" parses
+  // as just "now". The resolver requires chrono to consume the entire
+  // expression so silent degradation surfaces as an error at load time.
+
+  await t.test('throws on a typo in the unit (chrono only matches the prefix)', () => {
+    assert.throws(
+      () => resolveTemplates('{{now + 7 dasys}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on completely unrecognized input', () => {
+    assert.throws(
+      () => resolveTemplates('{{gibberish}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on bare typo "{{7 dasys}}"', () => {
+    assert.throws(
+      () => resolveTemplates('{{7 dasys}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on empty token "{{}}"', () => {
+    assert.throws(
+      () => resolveTemplates('{{}}', NOW),
+      /Unparseable seed template token|must be the entire field/
+    );
+  });
+
+  await t.test('throws when chrono produces multiple disjoint matches', () => {
+    // "now at 09:30" → chrono returns two matches ("now" + "09:30") rather
+    // than one combined parse, so we treat it as ambiguous.
+    assert.throws(
+      () => resolveTemplates('{{now at 09:30}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on missing whitespace around the operator', () => {
+    // "now+1 hour" → chrono only matches "now" and drops "+1 hour".
+    assert.throws(
+      () => resolveTemplates('{{now+1 hour}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on out-of-range time override', () => {
+    // chrono may accept this and produce a misparse, or reject. Either way
+    // we want it loud — out-of-range is a typo.
+    assert.throws(
+      () => resolveTemplates('{{now at 25:00}}', NOW),
+      /Unparseable seed template token/
+    );
+  });
+
+  await t.test('throws on half-templated string', () => {
+    assert.throws(
+      () => resolveTemplates('starts at {{now}}', NOW),
+      /must be the entire field value/
+    );
+  });
+
+  await t.test('error message includes the field path', () => {
+    assert.throws(
+      () => resolveTemplates({ outer: { inner: '{{bogus}}' } }, NOW),
+      /at outer\.inner/
+    );
+  });
+
+  await t.test('error message includes the offending value', () => {
+    assert.throws(
+      () => resolveTemplates({ startAt: '{{now + 7 dasys}}' }, NOW),
+      /"\{\{now \+ 7 dasys\}\}"/
+    );
+  });
+});
+
+test('resolveTemplates — consistency within a single load', async (t) => {
+  await t.test('every reference to {{now}} in one call sees the same instant', () => {
+    const out = resolveTemplates(
+      { a: '{{now}}', b: '{{now}}', c: { d: '{{now}}' } },
+      NOW
+    );
+    assert.strictEqual(out.a, out.b);
+    assert.strictEqual(out.a, out.c.d);
+  });
+});
+
+console.log('\n✓ All seed-template-resolver tests passed\n');


### PR DESCRIPTION
Closes #302.

## Summary

- Mock-server seed loader now resolves `{{...}}` tokens against the seed-load instant, so demo fixtures stay visible across time without hand-edits.
- Inner expressions are parsed by chrono-node — gets the issue's literal grammar (`now + 7 days`, `now + 2 days at 09:30`) plus chrono's natural idiom (`in 7 days`, `tomorrow at 09:30`, `next monday`) and absolute ISO / natural-language datetimes, all without hand-rolled grammar.
- chrono silently degrades on partial input; the resolver compensates by requiring a single match that consumes the entire expression and throws a typed `SeedTemplateError` otherwise, satisfying the issue's fail-loud requirement.

Layering keeps templating concerns out of both consumers:
- `seed-template-resolver.js` — regex + chrono + error class
- `seed-loader.js` — load YAML + resolve
- `seed-validator.js` and `seeder.js` — consume resolved data, no template knowledge

## Test plan

- 44 unit tests in `seed-template-resolver.test.js` cover the issue grammar, chrono idiom, calendar-aware (`next monday`, `last tuesday`), absolute datetimes, recursion through objects/arrays, passthrough on literals, fail-loud on partial matches / half-templated strings / multi-match / typos, and consistency within a single load.
- `AppointmentExample1` migrated to `{{now + 1 hour}}` / `{{now + 8 hours}}`; the rest of the seed corpus is untouched. Smoke test:
  ```bash
  npm run mock:start
  curl -s "http://localhost:1080/scheduling/appointments?limit=2" \
    | jq '.items[] | {id, startAt, endAt}'
  ```
  AppointmentExample1's `startAt` should land ~1h from now, `endAt` ~8h from now; AppointmentExample2 stays on its original 2024 dates (proving literals are untouched).