### PR TITLE
Regenerate all explorer outputs

### DIFF
--- a/packages/explorer/adoption-model/src/export-png.js
+++ b/packages/explorer/adoption-model/src/export-png.js
@@ -62,6 +62,11 @@ const SLIDES = [
 ];
 
 async function exportPng() {
+  if (process.env.CI) {
+    console.log('CI environment — skipping PNG export');
+    return;
+  }
+
   let puppeteer;
   try {
     puppeteer = (await import('puppeteer')).default;

--- a/packages/explorer/context-map/src/export-png.js
+++ b/packages/explorer/context-map/src/export-png.js
@@ -14,7 +14,6 @@
  *   domains.png, domain_<id>.png, flow_<domain>_<id>.png
  */
 
-import puppeteer from 'puppeteer';
 import { writeFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -25,6 +24,15 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // imgDir:  where individual PNGs are written (default: dist/)
 const htmlDir = process.argv[2] ? resolve(process.argv[2]) : resolve(__dirname, '..', 'output');
 const imgDir  = process.argv[3] ? resolve(process.argv[3]) : resolve(__dirname, '..', 'dist');
+
+let puppeteer;
+try {
+  puppeteer = (await import('puppeteer')).default;
+} catch {
+  console.warn('puppeteer not installed — skipping PNG export. Run: npm install puppeteer');
+  process.exit(0);
+}
+
 mkdirSync(imgDir, { recursive: true });
 
 const htmlPath = resolve(htmlDir, 'context-map.html');

--- a/packages/explorer/context-map/src/export-png.js
+++ b/packages/explorer/context-map/src/export-png.js
@@ -25,6 +25,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const htmlDir = process.argv[2] ? resolve(process.argv[2]) : resolve(__dirname, '..', 'output');
 const imgDir  = process.argv[3] ? resolve(process.argv[3]) : resolve(__dirname, '..', 'dist');
 
+if (process.env.CI) {
+  console.log('CI environment — skipping PNG export');
+  process.exit(0);
+}
+
 let puppeteer;
 try {
   puppeteer = (await import('puppeteer')).default;

--- a/packages/explorer/data-explorer/output/data-explorer.html
+++ b/packages/explorer/data-explorer/output/data-explorer.html
@@ -1250,13 +1250,14 @@
       <div class="sidebar-domain-header">
         <span class="sidebar-domain-indicator"></span>
         <a href="#domain-intake" class="sidebar-domain-name">Intake</a>
-        <span class="sidebar-domain-count">3</span>
+        <span class="sidebar-domain-count">4</span>
         <span class="sidebar-domain-toggle">▶</span>
       </div>
       <div class="sidebar-domain-entities" style="display: none;">
         <a href="#Application" class="primary">Application</a>
         <a href="#ApplicationMember" class="primary">ApplicationMember</a>
         <a href="#Income" class="primary">Income</a>
+        <a href="#Verification" class="primary">Verification</a>
       </div>
     </div>
     <div class="sidebar-domain" data-domain="eligibility" style="--domain-color: #EF6C75;">
@@ -1535,6 +1536,10 @@ UUIDs upon submission.
     <li><a href="#CaseMember">CaseMember</a> via <code>personId</code></li>
     <li><a href="#Household">Household</a> via <code>members[].personId</code></li>
     <li><a href="#Income">Income</a> via <code>personId</code></li>
+    <li><a href="#ApplicationMemberWritable">ApplicationMemberWritable</a> via <code>personId</code></li>
+    <li><a href="#ApplicationMember">ApplicationMember</a> via <code>personId</code></li>
+    <li><a href="#PersonMatch">PersonMatch</a> via <code>candidates[].personId</code></li>
+    <li><a href="#PersonMatchCandidate">PersonMatchCandidate</a> via <code>personId</code></li>
     <li><a href="#Appointment">Appointment</a> via <code>personId</code></li>
   </ul>
 </div>
@@ -1585,6 +1590,7 @@ UUIDs upon submission.
     <a href="#Application" class="domain-entity-link primary">Application</a>
     <a href="#ApplicationMember" class="domain-entity-link primary">ApplicationMember</a>
     <a href="#Income" class="domain-entity-link primary">Income</a>
+    <a href="#Verification" class="domain-entity-link primary">Verification</a>
   </div>
 </div>
 <section id="Application" class="schema-section primary orca-section" data-domain="intake">
@@ -1640,7 +1646,7 @@ UUIDs upon submission.
       <td class="field-name">status</td>
       <td class="field-type">Dropdown</td>
       <td class="field-required">&#10003;</td>
-      <td class="field-notes">Options: draft, submitted, under review, withdrawn, closed</td>
+      <td class="field-notes">Options: draft, submitted, under review, pending approval, withdrawn, closed</td>
     </tr>
     <tr data-field="isExpedited" class="">
       <td class="field-name">isExpedited</td>
@@ -1687,11 +1693,12 @@ UUIDs upon submission.
   <h5>Referenced By</h5>
   <ul class="rel-list">
     <li><a href="#Determination">Determination</a> via <code>applicationId</code></li>
+    <li><a href="#Decision">Decision</a> via <code>applicationId</code></li>
     <li><a href="#ApplicationExpeditedEvent">ApplicationExpeditedEvent</a> via <code>applicationId</code></li>
     <li><a href="#ApplicationDecisionCompletedEvent">ApplicationDecisionCompletedEvent</a> via <code>applicationId</code></li>
     <li><a href="#ApplicationDeterminationCompletedEvent">ApplicationDeterminationCompletedEvent</a> via <code>applicationId</code></li>
     <li><a href="#ApplicationMember">ApplicationMember</a> via <code>applicationId</code></li>
-    <li><a href="#ApplicationDocument">ApplicationDocument</a> via <code>applicationId</code></li>
+    <li><a href="#Verification">Verification</a> via <code>applicationId</code></li>
     <li><a href="#Interview">Interview</a> via <code>applicationId</code></li>
   </ul>
 </div>
@@ -1742,6 +1749,21 @@ UUIDs upon submission.
       <td class="action-notes">Caseworker signals data collection is complete and the application is ready for determination</td>
     </tr>
     <tr>
+      <td class="action-name">submit-for-approval</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/submit-for-approval</code></td>
+      <td class="action-notes">System routes the application to supervisor review when state-configured approval thresholds are met</td>
+    </tr>
+    <tr>
+      <td class="action-name">approve-determination</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/approve-determination</code></td>
+      <td class="action-notes">Supervisor approves the determination; closes the application and triggers NOA and case creation</td>
+    </tr>
+    <tr>
+      <td class="action-name">reject-determination</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/reject-determination</code></td>
+      <td class="action-notes">Supervisor rejects the determination and returns the application to the caseworker for revision</td>
+    </tr>
+    <tr>
       <td class="action-name">close</td>
       <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/close</code></td>
       <td class="action-notes">Marks a reviewed application as closed after all determinations are complete</td>
@@ -1750,11 +1772,6 @@ UUIDs upon submission.
       <td class="action-name">withdraw</td>
       <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/withdraw</code></td>
       <td class="action-notes">Applicant or caseworker withdraws the application before a decision is made</td>
-    </tr>
-    <tr>
-      <td class="action-name">flag-expedited</td>
-      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/flag-expedited</code></td>
-      <td class="action-notes">Caseworker, supervisor, or system flags the application as qualifying for expedited processing</td>
     </tr>
   </tbody>
 </table>
@@ -1774,8 +1791,12 @@ UUIDs upon submission.
       <td class="action-notes">Emit application.closed — signals intake is complete; triggers case creation</td>
     </tr>
     <tr>
-      <td class="action-name"><code>intake.application.expedited_flagged</code></td>
-      <td class="action-notes">Emit application.expedited_flagged — triggers workflow to escalate to expedited SLA track</td>
+      <td class="action-name"><code>intake.application.determination.approval_needed</code></td>
+      <td class="action-notes">Emit determination.approval_needed — triggers supervisor approval task creation; states configure approval thresholds via rules overlay</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.application.determination.rejected</code></td>
+      <td class="action-notes">Emit determination.rejected — signals the determination was rejected; workflow returns the caseworker task to in_progress via return-to-worker</td>
     </tr>
     <tr>
       <td class="action-name"><code>intake.application.opened</code></td>
@@ -1787,7 +1808,7 @@ UUIDs upon submission.
     </tr>
     <tr>
       <td class="action-name"><code>intake.application.submitted</code></td>
-      <td class="action-notes">Emit application.submitted — starts the regulatory clock; triggers caseworker task creation and confirmation notice</td>
+      <td class="action-notes">Emit application.submitted — starts the regulatory clock; triggers caseworker task creation, confirmation notice, and person matching</td>
     </tr>
     <tr>
       <td class="action-name"><code>intake.application.withdrawn</code></td>
@@ -1805,24 +1826,36 @@ UUIDs upon submission.
   </thead>
   <tbody>
     <tr>
+      <td class="action-name"><code>client_management.person.match_resolved</code></td>
+      <td class="action-notes">Write person match results back to the ApplicationMember when Client Management resolves a match</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>communication.notice.sent</code></td>
+      <td class="action-notes">Append the document request notice to the Verification&#039;s documentRequests when Communication sends a notice</td>
+    </tr>
+    <tr>
       <td class="action-name"><code>data_exchange.call.completed</code></td>
       <td class="action-notes">Update the verification status based on the service call result; create a document fallback if the result is inconclusive</td>
     </tr>
     <tr>
-      <td class="action-name"><code>document_management.version.uploaded</code></td>
+      <td class="action-name"><code>document_management.document_version.uploaded</code></td>
       <td class="action-notes">Satisfy the verification obligation and record the uploaded document as evidence when a document is uploaded</td>
     </tr>
     <tr>
-      <td class="action-name"><code>eligibility.application.all_determined</code></td>
-      <td class="action-notes">Close the application once all program and member combinations have received a determination</td>
+      <td class="action-name"><code>eligibility.application.decision_completed</code></td>
+      <td class="action-notes">Write the eligibility outcome back to the application member record when a per-member program decision is completed</td>
     </tr>
     <tr>
       <td class="action-name"><code>eligibility.application.determination_completed</code></td>
-      <td class="action-notes">Write the eligibility outcome back to the application member record when a program determination is completed</td>
+      <td class="action-notes">Close the application or route to supervisor approval when all program and member combinations have received a determination</td>
     </tr>
     <tr>
       <td class="action-name"><code>eligibility.application.expedited</code></td>
       <td class="action-notes">Flag the application as expedited when eligibility screening confirms the applicant meets expedited processing criteria</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>eligibility.determination.created</code></td>
+      <td class="action-notes">Create one Decision per household member per applied-for program when an eligibility Determination is created for this application</td>
     </tr>
     <tr>
       <td class="action-name"><code>intake.application.submitted</code></td>
@@ -1897,6 +1930,12 @@ UUIDs upon submission.
       <td class="field-required"></td>
       <td class="field-notes">Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid. [Nested]</td>
     </tr>
+    <tr data-field="personId" class="">
+      <td class="field-name">personId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Resolved person record ID. Auto-set on a confirmed match; caseworker can set it manually when selecting from match candidates or correcting a bad link.</td>
+    </tr>
     <tr data-field="id" class="">
       <td class="field-name">id <span class="system-badge">system</span></td>
       <td class="field-type">ID</td>
@@ -1921,6 +1960,18 @@ UUIDs upon submission.
       <td class="field-required">&#10003;</td>
       <td class="field-notes"></td>
     </tr>
+    <tr data-field="personMatch" class="expandable">
+      <td class="field-name">personMatch</td>
+      <td class="field-type">→ <a href="#PersonMatch" class="type-link">PersonMatch</a></td>
+      <td class="field-required"></td>
+      <td class="field-notes">Person matching state for an application member. Populated when client_management.person.match_resolved is received. Null until matching begins. [Nested]</td>
+    </tr>
+    <tr data-field="programDeterminations" class="expandable">
+      <td class="field-name">programDeterminations</td>
+      <td class="field-type">List of → <a href="#ProgramDetermination" class="type-link">ProgramDetermination</a></td>
+      <td class="field-required"></td>
+      <td class="field-notes">Per-program eligibility determination results, populated as decisions arrive from the eligibility domain. [Nested]</td>
+    </tr>
   </tbody>
 </table>
 </div>
@@ -1929,6 +1980,7 @@ UUIDs upon submission.
 <div class="rel-section">
   <h5>Belongs To</h5>
   <ul class="rel-list">
+    <li><a href="#Person">Person</a> via <code>personId</code></li>
     <li><a href="#Application">Application</a> via <code>applicationId</code></li>
   </ul>
 </div>
@@ -2146,6 +2198,200 @@ UUIDs upon submission.
   </div>
 </section>
 
+<section id="Verification" class="schema-section primary orca-section" data-domain="intake">
+  <div class="section-header">
+    <a href="#domain-intake" class="entity-domain-badge" style="--domain-color: #00AD93; --domain-bg: #E2F9F6;">Intake</a>
+    <h2>Verification</h2>
+  </div>
+  <div class="orca-tabs">
+    <button class="orca-tab" data-tab="overview">Overview</button>
+    <button class="orca-tab active" data-tab="attributes">Attributes</button>
+    <button class="orca-tab" data-tab="relationships">Relationships</button>
+    <button class="orca-tab" data-tab="actions">Actions</button>
+    <button class="orca-tab" data-tab="events">Events</button>
+  </div>
+  <div class="orca-panels">
+    <div class="orca-panel" data-tab="overview">
+      <div class="overview-content">
+        <h4>What is Verification?</h4>
+        <p class="description"></p>
+      </div>
+    </div>
+    <div class="orca-panel active" data-tab="attributes">
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="memberId" class="">
+      <td class="field-name">memberId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Member this obligation is for. Null for household-level obligations (e.g., proof of residency).</td>
+    </tr>
+    <tr data-field="category" class="">
+      <td class="field-name">category</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: citizenship, identity, immigration, income, residency</td>
+    </tr>
+    <tr data-field="verificationType" class="">
+      <td class="field-name">verificationType</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: document, electronic</td>
+    </tr>
+    <tr data-field="id" class="">
+      <td class="field-name">id <span class="system-badge">system</span></td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes"></td>
+    </tr>
+    <tr data-field="applicationId" class="">
+      <td class="field-name">applicationId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes"></td>
+    </tr>
+    <tr data-field="status" class="">
+      <td class="field-name">status</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: pending, inconclusive, satisfied, waived, cannot verify</td>
+    </tr>
+    <tr data-field="evidence" class="">
+      <td class="field-name">evidence</td>
+      <td class="field-type">List of Unknown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Electronic and document evidence items accumulated against this obligation.</td>
+    </tr>
+    <tr data-field="documentRequests" class="expandable">
+      <td class="field-name">documentRequests</td>
+      <td class="field-type">List of → <a href="#DocumentRequest" class="type-link">DocumentRequest</a></td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Outbound document request notices sent to the applicant for this obligation. [Nested]</td>
+    </tr>
+    <tr data-field="createdAt" class="">
+      <td class="field-name">createdAt <span class="system-badge">system</span></td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes"></td>
+    </tr>
+    <tr data-field="updatedAt" class="">
+      <td class="field-name">updatedAt <span class="system-badge">system</span></td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes"></td>
+    </tr>
+  </tbody>
+</table>
+</div>
+    </div>
+    <div class="orca-panel" data-tab="relationships">
+<div class="rel-section">
+  <h5>Belongs To</h5>
+  <ul class="rel-list">
+    <li><a href="#Application">Application</a> via <code>applicationId</code></li>
+  </ul>
+</div>
+    </div>
+    <div class="orca-panel" data-tab="actions">
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Action</th>
+      <th>Endpoint</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name">Create</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/verifications</code></td>
+      <td class="action-notes">Required: category</td>
+    </tr>
+    <tr>
+      <td class="action-name">Get</td>
+      <td class="action-endpoint"><span class="action-method method-get">GET</span> <code>/applications/{applicationId}/verifications/{verificationId}</code></td>
+      <td class="action-notes">By ID</td>
+    </tr>
+    <tr>
+      <td class="action-name">Update</td>
+      <td class="action-endpoint"><span class="action-method method-patch">PATCH</span> <code>/applications/{applicationId}/verifications/{verificationId}</code></td>
+      <td class="action-notes">Partial updates</td>
+    </tr>
+    <tr>
+      <td class="action-name">satisfy</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/verifications/{verificationId}/satisfy</code></td>
+      <td class="action-notes">System marks an obligation as satisfied after receiving conclusive service call or document evidence</td>
+    </tr>
+    <tr>
+      <td class="action-name">mark-inconclusive</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/verifications/{verificationId}/mark-inconclusive</code></td>
+      <td class="action-notes">System records that a service call returned inconclusive, triggering document fallback</td>
+    </tr>
+    <tr>
+      <td class="action-name">waive</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/verifications/{verificationId}/waive</code></td>
+      <td class="action-notes">Caseworker grants a waiver for an obligation that cannot be satisfied through normal means</td>
+    </tr>
+    <tr>
+      <td class="action-name">mark-cannot-verify</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/verifications/{verificationId}/mark-cannot-verify</code></td>
+      <td class="action-notes">Caseworker closes an obligation when all available verification methods are exhausted</td>
+    </tr>
+  </tbody>
+</table>
+    </div>
+    <div class="orca-panel" data-tab="events">
+<h5 class="transitions-heading">Publishes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>intake.verification.inconclusive</code></td>
+      <td class="action-notes">Emit verification.inconclusive — triggers document fallback creation via intake rule subscription</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.verification.satisfied</code></td>
+      <td class="action-notes">Emit verification.satisfied — signals the obligation is fulfilled</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.verification.waived</code></td>
+      <td class="action-notes">Emit verification.waived — signals the obligation is resolved without evidence</td>
+    </tr>
+  </tbody>
+</table>
+<h5 class="transitions-heading">Subscribes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>intake.verification.created</code></td>
+      <td class="action-notes">Initiate the appropriate service calls for a newly created electronic verification</td>
+    </tr>
+  </tbody>
+</table>
+    </div>
+  </div>
+</section>
+
 <div id="domain-eligibility" class="domain-header-anchor" style="--domain-color: #EF6C75; --domain-bg: #F9C8CB;">
   <h2 class="domain-header-title"><span class="domain-indicator"></span>Eligibility</h2>
   <p class="domain-description">Program eligibility determination</p>
@@ -2197,6 +2443,18 @@ UUIDs upon submission.
       <td class="field-type">ID</td>
       <td class="field-required">&#10003;</td>
       <td class="field-notes">The determination this decision belongs to.</td>
+    </tr>
+    <tr data-field="applicationId" class="">
+      <td class="field-name">applicationId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">The application this decision belongs to.</td>
+    </tr>
+    <tr data-field="memberId" class="">
+      <td class="field-name">memberId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">The household member this decision covers.</td>
     </tr>
     <tr data-field="program" class="">
       <td class="field-name">program</td>
@@ -2255,6 +2513,7 @@ UUIDs upon submission.
   <h5>Belongs To</h5>
   <ul class="rel-list">
     <li><a href="#Determination">Determination</a> via <code>determinationId</code></li>
+    <li><a href="#Application">Application</a> via <code>applicationId</code></li>
   </ul>
 </div>
 <div class="rel-section">
@@ -2281,24 +2540,57 @@ UUIDs upon submission.
     </tr>
     <tr>
       <td class="action-name">approve</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/decisions/{decisionId}/approve</code></td>
+      <td class="action-notes">System approves a Decision after automatic or caseworker review</td>
     </tr>
     <tr>
       <td class="action-name">deny</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/decisions/{decisionId}/deny</code></td>
+      <td class="action-notes">System denies a Decision based on failing eligibility criteria</td>
     </tr>
     <tr>
       <td class="action-name">mark-ineligible</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/decisions/{decisionId}/mark-ineligible</code></td>
+      <td class="action-notes">System marks a Decision as categorically ineligible</td>
     </tr>
   </tbody>
 </table>
     </div>
     <div class="orca-panel" data-tab="events">
-<p class="no-actions">No events defined for this object.</p>
+<h5 class="transitions-heading">Publishes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>eligibility.decision.eligibility.application.decision_completed</code></td>
+      <td class="action-notes">Emit eligibility.application.decision_completed — Intake records the outcome per member; Determination checks if all Decisions are resolved</td>
+    </tr>
+  </tbody>
+</table>
+<h5 class="transitions-heading">Subscribes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>data_exchange.call.completed</code></td>
+      <td class="action-notes">Run Medicaid ex parte evaluation when all data exchange results for a Decision are in (42 CFR § 435.911)</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>eligibility.decision.created</code></td>
+      <td class="action-notes">Run expedited SNAP screening or initiate Medicaid data exchange when a Decision is created</td>
+    </tr>
+  </tbody>
+</table>
     </div>
   </div>
 </section>
@@ -2415,19 +2707,73 @@ UUIDs upon submission.
     </tr>
     <tr>
       <td class="action-name">flag-expedited</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/flag-expedited</code></td>
+      <td class="action-notes">System flags a Determination as qualifying for expedited SNAP processing</td>
     </tr>
     <tr>
       <td class="action-name">complete</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/complete</code></td>
+      <td class="action-notes">System marks a Determination as complete after all program Decisions are resolved</td>
+    </tr>
+    <tr>
+      <td class="action-name">withdraw</td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/determinations/{determinationId}/withdraw</code></td>
+      <td class="action-notes">System withdraws a Determination when the associated application is withdrawn</td>
     </tr>
   </tbody>
 </table>
     </div>
     <div class="orca-panel" data-tab="events">
-<p class="no-actions">No events defined for this object.</p>
+<h5 class="transitions-heading">Publishes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>eligibility.determination.eligibility.application.determination_completed</code></td>
+      <td class="action-notes">Emit eligibility.application.determination_completed — signals all program Decisions are resolved; Intake subscribes to close the application</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>eligibility.determination.eligibility.application.expedited</code></td>
+      <td class="action-notes">Emit eligibility.application.expedited — Intake stores the flag; Workflow switches the intake task to the expedited SLA track (7 CFR § 273.2(i))</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>eligibility.determination.withdrawn</code></td>
+      <td class="action-notes"></td>
+    </tr>
+  </tbody>
+</table>
+<h5 class="transitions-heading">Subscribes</h5>
+<table class="actions-table">
+  <thead>
+    <tr>
+      <th>Event</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="action-name"><code>eligibility.application.decision_completed</code></td>
+      <td class="action-notes"></td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.application.review_completed</code></td>
+      <td class="action-notes">Run final eligibility determination for all remaining pending Decisions after caseworker review is complete (42 CFR § 435.912)</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.application.submitted</code></td>
+      <td class="action-notes"></td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.application.withdrawn</code></td>
+      <td class="action-notes"></td>
+    </tr>
+  </tbody>
+</table>
     </div>
   </div>
 </section>
@@ -2712,6 +3058,7 @@ years, multiple applications, and multiple programs.
     <li><a href="#DocumentLink">DocumentLink</a> via <code>documentId</code></li>
     <li><a href="#DocumentCreatedEvent">DocumentCreatedEvent</a> via <code>documentId</code></li>
     <li><a href="#DocumentVersionUploadedEvent">DocumentVersionUploadedEvent</a> via <code>documentId</code></li>
+    <li><a href="#VerificationDocumentEvidence">VerificationDocumentEvidence</a> via <code>documentId</code></li>
   </ul>
 </div>
     </div>
@@ -2973,9 +3320,9 @@ years, multiple applications, and multiple programs.
     </tr>
     <tr data-field="priority" class="">
       <td class="field-name">priority</td>
-      <td class="field-type">Dropdown</td>
+      <td class="field-type">Number</td>
       <td class="field-required"></td>
-      <td class="field-notes">Options: expedited, high, normal, low</td>
+      <td class="field-notes">Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first.</td>
     </tr>
     <tr data-field="startedAt" class="">
       <td class="field-name">startedAt</td>
@@ -3099,43 +3446,43 @@ years, multiple applications, and multiple programs.
     </tr>
     <tr>
       <td class="action-name">complete</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/complete</code></td>
+      <td class="action-notes">Marks an in-progress task done with an outcome and optional notes</td>
     </tr>
     <tr>
       <td class="action-name">release</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/release</code></td>
+      <td class="action-notes">Returns an in-progress task to the queue, clearing the assignment</td>
     </tr>
     <tr>
       <td class="action-name">escalate</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/escalate</code></td>
+      <td class="action-notes">Flags an in-progress task for supervisor attention</td>
     </tr>
     <tr>
       <td class="action-name">de-escalate</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/de-escalate</code></td>
+      <td class="action-notes">Returns an escalated task to the pending queue</td>
     </tr>
     <tr>
       <td class="action-name">cancel</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/cancel</code></td>
+      <td class="action-notes">Supervisor cancels a task from any active state</td>
     </tr>
     <tr>
       <td class="action-name">reopen</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/reopen</code></td>
+      <td class="action-notes">Supervisor returns a cancelled task to the pending queue</td>
     </tr>
     <tr>
       <td class="action-name">await-client</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/await-client</code></td>
+      <td class="action-notes">Pauses an in-progress task while waiting for a client response</td>
     </tr>
     <tr>
       <td class="action-name">await-verification</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/await-verification</code></td>
+      <td class="action-notes">Pauses an in-progress task while waiting for a verification result</td>
     </tr>
     <tr>
       <td class="action-name">resume</td>
@@ -3144,13 +3491,13 @@ years, multiple applications, and multiple programs.
     </tr>
     <tr>
       <td class="action-name">system-resume</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/system-resume</code></td>
+      <td class="action-notes">System resumes a verification-blocked task after a timeout or result arrives</td>
     </tr>
     <tr>
       <td class="action-name">system-escalate</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/system-escalate</code></td>
+      <td class="action-notes">System auto-escalates a task when an SLA deadline is approaching or exceeded</td>
     </tr>
     <tr>
       <td class="action-name">system-auto-cancel</td>
@@ -3164,23 +3511,23 @@ years, multiple applications, and multiple programs.
     </tr>
     <tr>
       <td class="action-name">approve</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/approve</code></td>
+      <td class="action-notes">Supervisor approves a submitted task and records the final outcome</td>
     </tr>
     <tr>
       <td class="action-name">return-to-worker</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/return-to-worker</code></td>
+      <td class="action-notes">Supervisor sends a review-pending task back to the worker with feedback</td>
     </tr>
     <tr>
       <td class="action-name">assign</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/assign</code></td>
+      <td class="action-notes">Supervisor reassigns a task to a specific caseworker or moves it to a different queue</td>
     </tr>
     <tr>
       <td class="action-name">set-priority</td>
-      <td class="action-endpoint"></td>
-      <td class="action-notes"></td>
+      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/tasks/{taskId}/set-priority</code></td>
+      <td class="action-notes">Supervisor manually overrides the task priority</td>
     </tr>
   </tbody>
 </table>
@@ -3275,8 +3622,24 @@ years, multiple applications, and multiple programs.
   </thead>
   <tbody>
     <tr>
+      <td class="action-name"><code>eligibility.application.expedited</code></td>
+      <td class="action-notes">Flag the intake review task as expedited and switch it to the 7-day SLA when SNAP expedited criteria are confirmed (7 CFR § 273.2(i))</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.application.closed</code></td>
+      <td class="action-notes">Complete open tasks for the application when intake closes; handles direct close, supervisor-approved close, and auto-determination paths</td>
+    </tr>
+    <tr>
       <td class="action-name"><code>intake.application.submitted</code></td>
       <td class="action-notes">Create an application review task when a new application is submitted</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.determination.approval_needed</code></td>
+      <td class="action-notes">Move the caseworker&#039;s review task to pending_review and create a supervisor approval task when a determination requires sign-off</td>
+    </tr>
+    <tr>
+      <td class="action-name"><code>intake.determination.rejected</code></td>
+      <td class="action-notes">Return the caseworker&#039;s review task to in_progress and complete the supervisor approval task when a determination is rejected</td>
     </tr>
     <tr>
       <td class="action-name"><code>workflow.client_timeout</code></td>
@@ -3748,131 +4111,6 @@ use when calling back with a result.
   <p class="domain-description">Benefit issuance, EBT & recoupment</p>
   <p class="domain-coming-soon">Coming soon - this domain is part of the architecture but not yet implemented.</p>
 </div>
-<section id="ApplicationDocument" class="schema-section primary orca-section" data-domain="unclassified">
-  <div class="section-header">
-    <h2>ApplicationDocument</h2>
-  </div>
-  <div class="orca-tabs">
-    <button class="orca-tab" data-tab="overview">Overview</button>
-    <button class="orca-tab active" data-tab="attributes">Attributes</button>
-    <button class="orca-tab" data-tab="relationships">Relationships</button>
-    <button class="orca-tab" data-tab="actions">Actions</button>
-    <button class="orca-tab" data-tab="events">Events</button>
-  </div>
-  <div class="orca-panels">
-    <div class="orca-panel" data-tab="overview">
-      <div class="overview-content">
-        <h4>What is ApplicationDocument?</h4>
-        <p class="description"></p>
-      </div>
-    </div>
-    <div class="orca-panel active" data-tab="attributes">
-<div class="attributes-content" data-state-content="base">
-<table class="property-table">
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Type</th>
-      <th>Req</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr data-field="memberId" class="">
-      <td class="field-name">memberId</td>
-      <td class="field-type">ID</td>
-      <td class="field-required"></td>
-      <td class="field-notes">Member this document is required for. Null for household-level requirements (e.g., proof of residency).</td>
-    </tr>
-    <tr data-field="category" class="">
-      <td class="field-name">category</td>
-      <td class="field-type">Dropdown</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes">Options: income, identity, residency, citizenship</td>
-    </tr>
-    <tr data-field="id" class="">
-      <td class="field-name">id <span class="system-badge">system</span></td>
-      <td class="field-type">ID</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes"></td>
-    </tr>
-    <tr data-field="applicationId" class="">
-      <td class="field-name">applicationId</td>
-      <td class="field-type">ID</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes"></td>
-    </tr>
-    <tr data-field="status" class="">
-      <td class="field-name">status</td>
-      <td class="field-type">Dropdown</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes">Options: requested, verified</td>
-    </tr>
-    <tr data-field="createdAt" class="">
-      <td class="field-name">createdAt <span class="system-badge">system</span></td>
-      <td class="field-type">Date & Time</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes"></td>
-    </tr>
-    <tr data-field="updatedAt" class="">
-      <td class="field-name">updatedAt <span class="system-badge">system</span></td>
-      <td class="field-type">Date & Time</td>
-      <td class="field-required">&#10003;</td>
-      <td class="field-notes"></td>
-    </tr>
-    <tr data-field="evidence" class="">
-      <td class="field-name">evidence</td>
-      <td class="field-type">List of ID</td>
-      <td class="field-required"></td>
-      <td class="field-notes">IDs of documents in document-management that satisfy this checklist item. Populated by the document-verified-write-back rule when a verified document carries subjectType &quot;application-document&quot; and subjectId matching this record.
-</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-    </div>
-    <div class="orca-panel" data-tab="relationships">
-<div class="rel-section">
-  <h5>Belongs To</h5>
-  <ul class="rel-list">
-    <li><a href="#Application">Application</a> via <code>applicationId</code></li>
-  </ul>
-</div>
-    </div>
-    <div class="orca-panel" data-tab="actions">
-<table class="actions-table">
-  <thead>
-    <tr>
-      <th>Action</th>
-      <th>Endpoint</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td class="action-name">Create</td>
-      <td class="action-endpoint"><span class="action-method method-post">POST</span> <code>/applications/{applicationId}/documents</code></td>
-      <td class="action-notes">Required: category</td>
-    </tr>
-    <tr>
-      <td class="action-name">Get</td>
-      <td class="action-endpoint"><span class="action-method method-get">GET</span> <code>/applications/{applicationId}/documents/{documentId}</code></td>
-      <td class="action-notes">By ID</td>
-    </tr>
-    <tr>
-      <td class="action-name">Update</td>
-      <td class="action-endpoint"><span class="action-method method-patch">PATCH</span> <code>/applications/{applicationId}/documents/{documentId}</code></td>
-      <td class="action-notes">Partial updates</td>
-    </tr>
-  </tbody>
-</table>
-    </div>
-    <div class="orca-panel" data-tab="events">
-<p class="no-actions">No events defined for this object.</p>
-    </div>
-  </div>
-</section>
-
 <section id="DocumentLink" class="schema-section primary orca-section" data-domain="unclassified">
   <div class="section-header">
     <h2>DocumentLink</h2>
@@ -4324,7 +4562,7 @@ use when calling back with a result.
     <tr data-field="data" class="expandable">
       <td class="field-name">data</td>
       <td class="field-type">→ Data</td>
-      <td class="field-required">&#10003;</td>
+      <td class="field-required"></td>
       <td class="field-notes">Event payload. Schema is defined per event type in each domain&#039;s x-events section. [Nested]</td>
     </tr>
   </tbody>
@@ -5302,7 +5540,7 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
       <td class="field-name">status</td>
       <td class="field-type">Dropdown</td>
       <td class="field-required">&#10003;</td>
-      <td class="field-notes">Options: draft, submitted, under review, withdrawn, closed</td>
+      <td class="field-notes">Options: draft, submitted, under review, pending approval, withdrawn, closed</td>
     </tr>
     <tr data-field="isExpedited" class="">
       <td class="field-name">isExpedited</td>
@@ -5378,6 +5616,12 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
       <td class="field-type">ID</td>
       <td class="field-required">&#10003;</td>
       <td class="field-notes"></td>
+    </tr>
+    <tr data-field="memberId" class="">
+      <td class="field-name">memberId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">The household member this decision covers.</td>
     </tr>
     <tr data-field="program" class="">
       <td class="field-name">program</td>
@@ -5462,39 +5706,6 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
 </div>
 </section>
 
-<section id="ApplicationDocumentWritable" class="schema-section" data-domain="unclassified">
-  <div class="section-header simple">
-    <h2>ApplicationDocumentWritable</h2>
-  </div>
-  <p class="description">Client-writable fields for an application document requirement.</p>
-<div class="attributes-content" data-state-content="base">
-<table class="property-table">
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Type</th>
-      <th>Req</th>
-      <th>Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr data-field="memberId" class="">
-      <td class="field-name">memberId</td>
-      <td class="field-type">ID</td>
-      <td class="field-required"></td>
-      <td class="field-notes">Member this document is required for. Null for household-level requirements (e.g., proof of residency).</td>
-    </tr>
-    <tr data-field="category" class="">
-      <td class="field-name">category</td>
-      <td class="field-type">Dropdown</td>
-      <td class="field-required"></td>
-      <td class="field-notes">Options: income, identity, residency, citizenship</td>
-    </tr>
-  </tbody>
-</table>
-</div>
-</section>
-
 <section id="ApplicationExpeditedEvent" class="schema-section" data-domain="unclassified">
   <div class="section-header simple">
     <h2>ApplicationExpeditedEvent</h2>
@@ -5528,11 +5739,11 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
 </div>
 </section>
 
-<section id="ApplicationExpeditedFlaggedEvent" class="schema-section" data-domain="unclassified">
+<section id="ApplicationMemberProgramDetermination" class="schema-section" data-domain="unclassified">
   <div class="section-header simple">
-    <h2>ApplicationExpeditedFlaggedEvent</h2>
+    <h2>ApplicationMemberProgramDetermination</h2>
   </div>
-  <p class="description">Payload for application.expedited_flagged — triggers escalation to expedited SLA track.</p>
+  <p class="description">A single program eligibility determination result for a household member.</p>
 <div class="attributes-content" data-state-content="base">
 <table class="property-table">
   <thead>
@@ -5544,11 +5755,23 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
     </tr>
   </thead>
   <tbody>
-    <tr data-field="flaggedAt" class="">
-      <td class="field-name">flaggedAt</td>
-      <td class="field-type">Date & Time</td>
+    <tr data-field="program" class="">
+      <td class="field-name">program</td>
+      <td class="field-type">Text</td>
       <td class="field-required">&#10003;</td>
-      <td class="field-notes">When the expedited flag was set.</td>
+      <td class="field-notes">Program identifier (e.g., snap, medicaid, tanf).</td>
+    </tr>
+    <tr data-field="outcome" class="">
+      <td class="field-name">outcome</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: approved, denied</td>
+    </tr>
+    <tr data-field="determinedAt" class="">
+      <td class="field-name">determinedAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required"></td>
+      <td class="field-notes">When the determination was recorded.</td>
     </tr>
   </tbody>
 </table>
@@ -5594,6 +5817,12 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
       <td class="field-type">→ <a href="#ImmigrationInfo" class="type-link">ImmigrationInfo</a></td>
       <td class="field-required"></td>
       <td class="field-notes">Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid. [Nested]</td>
+    </tr>
+    <tr data-field="personId" class="">
+      <td class="field-name">personId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Resolved person record ID. Auto-set on a confirmed match; caseworker can set it manually when selecting from match candidates or correcting a bad link.</td>
     </tr>
   </tbody>
 </table>
@@ -5694,11 +5923,11 @@ Format varies by IdP (e.g., &quot;auth0|507f1f77bcf86cd799439011&quot;).
       <td class="field-required"></td>
       <td class="field-notes">Options: online, in person, phone, mail</td>
     </tr>
-    <tr data-field="isExpedited" class="">
-      <td class="field-name">isExpedited</td>
-      <td class="field-type">boolean,null</td>
+    <tr data-field="memberIds" class="">
+      <td class="field-name">memberIds</td>
+      <td class="field-type">List of ID</td>
       <td class="field-required"></td>
-      <td class="field-notes">Whether expedited screening has already determined the application qualifies. Null if not yet screened.</td>
+      <td class="field-notes">IDs of all household members at submission time. Client Management fetches each member record to determine which are applying for benefits and should be matched against person records.</td>
     </tr>
   </tbody>
 </table>
@@ -7153,6 +7382,56 @@ income data via the IEVS interface.
 </div>
 </section>
 
+<section id="NoticeSentEvent" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>NoticeSentEvent</h2>
+  </div>
+  <p class="description">Payload for the communication.notice.sent event. Emitted when Communication
+sends a notice to a client. The metadata field carries domain-keyed correlation
+context from the triggering event so consumers can correlate the notice back
+to their records without additional lookups.
+</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="noticeId" class="">
+      <td class="field-name">noticeId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">ID of the notice that was sent.</td>
+    </tr>
+    <tr data-field="type" class="">
+      <td class="field-name">type</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: document request citizenship verification, document request identity verification, document request immigration verification, document request income verification, document request residency verification</td>
+    </tr>
+    <tr data-field="sentAt" class="">
+      <td class="field-name">sentAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">When the notice was sent.</td>
+    </tr>
+    <tr data-field="metadata" class="expandable">
+      <td class="field-name">metadata</td>
+      <td class="field-type">→ Metadata</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Domain-keyed correlation context. Keys are domain names; values are arbitrary objects defined by the triggering domain. Treated as opaque by Communication — echoed back verbatim from the triggering event. Example: {&quot;intake&quot;: {&quot;verificationId&quot;: &quot;uuid-of-the-verification&quot;}}
+ [Nested]</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
 <section id="PerHouseholdProgramRequest" class="schema-section" data-domain="unclassified">
   <div class="section-header simple">
     <h2>PerHouseholdProgramRequest</h2>
@@ -7292,6 +7571,72 @@ income data via the IEVS interface.
       <td class="field-type">Email</td>
       <td class="field-required"></td>
       <td class="field-notes">Email address of the person.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="PersonMatch" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>PersonMatch</h2>
+  </div>
+  <p class="description">Person matching state for an application member. Populated when client_management.person.match_resolved is received. Null until matching begins.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="matchStatus" class="">
+      <td class="field-name">matchStatus</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: confirmed, review required, no match</td>
+    </tr>
+    <tr data-field="candidates" class="expandable">
+      <td class="field-name">candidates</td>
+      <td class="field-type">List of → <a href="#Candidate" class="type-link">Candidate</a></td>
+      <td class="field-required"></td>
+      <td class="field-notes">Match candidates. Populated for review_required; empty otherwise. [Nested]</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="PersonMatchCandidate" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>PersonMatchCandidate</h2>
+  </div>
+  <p class="description">A candidate person record returned by the person matching process.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="personId" class="">
+      <td class="field-name">personId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">The candidate person record ID.</td>
+    </tr>
+    <tr data-field="confidenceScore" class="">
+      <td class="field-name">confidenceScore</td>
+      <td class="field-type">Number</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Match confidence score from 0 (no confidence) to 1 (certain).</td>
     </tr>
   </tbody>
 </table>
@@ -7759,9 +8104,9 @@ records for income verification. Interface varies by state.
     </tr>
     <tr data-field="priority" class="">
       <td class="field-name">priority</td>
-      <td class="field-type">Dropdown</td>
+      <td class="field-type">Number</td>
       <td class="field-required"></td>
-      <td class="field-notes">Options: expedited, high, normal, low</td>
+      <td class="field-notes">Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first.</td>
     </tr>
     <tr data-field="startedAt" class="">
       <td class="field-name">startedAt</td>
@@ -7907,9 +8252,9 @@ removed.
   <tbody>
     <tr data-field="priority" class="">
       <td class="field-name">priority</td>
-      <td class="field-type">Text</td>
+      <td class="field-type">Number</td>
       <td class="field-required">&#10003;</td>
-      <td class="field-notes">The new priority value.</td>
+      <td class="field-notes">The new priority value (1=expedited, 2=high, 3=normal, 4=low).</td>
     </tr>
     <tr data-field="reason" class="">
       <td class="field-name">reason</td>
@@ -8189,9 +8534,9 @@ full resource.
     </tr>
     <tr data-field="priority" class="">
       <td class="field-name">priority</td>
-      <td class="field-type">Dropdown</td>
+      <td class="field-type">Number</td>
       <td class="field-required"></td>
-      <td class="field-notes">Options: expedited, high, normal, low</td>
+      <td class="field-notes">Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first.</td>
     </tr>
     <tr data-field="startedAt" class="">
       <td class="field-name">startedAt</td>
@@ -8339,6 +8684,168 @@ Example fields: timezone, dateFormat, itemsPerPage, language, theme, etc.
 </div>
 </section>
 
+<section id="VerificationDocumentEvidence" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>VerificationDocumentEvidence</h2>
+  </div>
+  <p class="description">A document submitted as evidence against a verification obligation.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="type" class="">
+      <td class="field-name">type</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: document</td>
+    </tr>
+    <tr data-field="documentId" class="">
+      <td class="field-name">documentId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">ID of the verified document in the document-management domain.</td>
+    </tr>
+    <tr data-field="receivedAt" class="">
+      <td class="field-name">receivedAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">When the document was received.</td>
+    </tr>
+    <tr data-field="reviewedAt" class="">
+      <td class="field-name">reviewedAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required"></td>
+      <td class="field-notes">When a caseworker reviewed the document.</td>
+    </tr>
+    <tr data-field="reviewedBy" class="">
+      <td class="field-name">reviewedBy</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">ID of the caseworker who reviewed the document.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="VerificationDocumentRequest" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>VerificationDocumentRequest</h2>
+  </div>
+  <p class="description">An outbound notice requesting documents from an applicant for a verification obligation.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="noticeId" class="">
+      <td class="field-name">noticeId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">ID of the notice in the communication domain.</td>
+    </tr>
+    <tr data-field="type" class="">
+      <td class="field-name">type</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: document request citizenship verification, document request identity verification, document request immigration verification, document request income verification, document request residency verification</td>
+    </tr>
+    <tr data-field="sentAt" class="">
+      <td class="field-name">sentAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">When the notice was sent.</td>
+    </tr>
+    <tr data-field="dueAt" class="">
+      <td class="field-name">dueAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Deadline by which the applicant must respond.</td>
+    </tr>
+    <tr data-field="channel" class="">
+      <td class="field-name">channel</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: email, in person, mail, portal</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="VerificationElectronicEvidence" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>VerificationElectronicEvidence</h2>
+  </div>
+  <p class="description">An electronic service check result recorded as evidence against a verification obligation.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="type" class="">
+      <td class="field-name">type</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: electronic</td>
+    </tr>
+    <tr data-field="source" class="">
+      <td class="field-name">source</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: fdsh fti, fdsh ssa, fdsh vlp, save, ssa ievs</td>
+    </tr>
+    <tr data-field="result" class="">
+      <td class="field-name">result</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: conclusive, inconclusive</td>
+    </tr>
+    <tr data-field="serviceCallId" class="">
+      <td class="field-name">serviceCallId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">ID of the data-exchange service call that produced this result.</td>
+    </tr>
+    <tr data-field="receivedAt" class="">
+      <td class="field-name">receivedAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">When the result was received.</td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="VerificationEvidenceItem" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>VerificationEvidenceItem</h2>
+  </div>
+  <p class="description">An electronic or document evidence item accumulated against a verification obligation.</p>
+<div class="attributes-content" data-state-content="base">
+</div>
+</section>
+
 <section id="VerificationSource" class="schema-section" data-domain="unclassified">
   <div class="section-header simple">
     <h2>VerificationSource</h2>
@@ -8401,6 +8908,45 @@ Example fields: timezone, dateFormat, itemsPerPage, language, theme, etc.
       <td class="field-required"></td>
       <td class="field-notes">Identifier of the intake domain member this verification applies to. Passed through from intake for correlation — the adapter does not resolve this identifier.
 </td>
+    </tr>
+  </tbody>
+</table>
+</div>
+</section>
+
+<section id="VerificationWritable" class="schema-section" data-domain="unclassified">
+  <div class="section-header simple">
+    <h2>VerificationWritable</h2>
+  </div>
+  <p class="description">Client-writable fields for a verification obligation record.</p>
+<div class="attributes-content" data-state-content="base">
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="memberId" class="">
+      <td class="field-name">memberId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Member this obligation is for. Null for household-level obligations (e.g., proof of residency).</td>
+    </tr>
+    <tr data-field="category" class="">
+      <td class="field-name">category</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: citizenship, identity, immigration, income, residency</td>
+    </tr>
+    <tr data-field="verificationType" class="">
+      <td class="field-name">verificationType</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: document, electronic</td>
     </tr>
   </tbody>
 </table>
@@ -8838,6 +9384,161 @@ Example fields: timezone, dateFormat, itemsPerPage, language, theme, etc.
       <td class="field-type">Text</td>
       <td class="field-required"></td>
       <td class="field-notes">ISO 3166-1 alpha-2 country code of the country that issued the immigration document.</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section id="PersonMatch" class="schema-section inline-object" data-domain="intake">
+  <div class="section-header simple">
+    <a href="#domain-intake" class="entity-domain-badge" style="--domain-color: #00AD93; --domain-bg: #E2F9F6;">Intake</a>
+    <span class="inline-object-badge">Nested in <a href="#ApplicationMember">ApplicationMember</a></span>
+    <h2>PersonMatch</h2>
+  </div>
+  <p class="description">Person matching state for an application member. Populated when client_management.person.match_resolved is received. Null until matching begins.</p>
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="matchStatus" class="">
+      <td class="field-name">matchStatus</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: confirmed, review required, no match</td>
+    </tr>
+    <tr data-field="candidates" class="expandable">
+      <td class="field-name">candidates</td>
+      <td class="field-type">List of → <a href="#Candidate" class="type-link">Candidate</a></td>
+      <td class="field-required"></td>
+      <td class="field-notes">Match candidates. Populated for review_required; empty otherwise. [Nested]</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section id="ProgramDetermination" class="schema-section inline-object" data-domain="intake">
+  <div class="section-header simple">
+    <a href="#domain-intake" class="entity-domain-badge" style="--domain-color: #00AD93; --domain-bg: #E2F9F6;">Intake</a>
+    <span class="inline-object-badge">Nested in <a href="#ApplicationMember">ApplicationMember</a></span>
+    <h2>ProgramDetermination</h2>
+  </div>
+  <p class="description">A single program eligibility determination result for a household member.</p>
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="program" class="">
+      <td class="field-name">program</td>
+      <td class="field-type">Text</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Program identifier (e.g., snap, medicaid, tanf).</td>
+    </tr>
+    <tr data-field="outcome" class="">
+      <td class="field-name">outcome</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: approved, denied</td>
+    </tr>
+    <tr data-field="determinedAt" class="">
+      <td class="field-name">determinedAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required"></td>
+      <td class="field-notes">When the determination was recorded.</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section id="Candidate" class="schema-section inline-object" data-domain="unclassified">
+  <div class="section-header simple">
+    <span class="inline-object-badge">Nested in <a href="#PersonMatch">PersonMatch</a></span>
+    <h2>Candidate</h2>
+  </div>
+  <p class="description">A candidate person record returned by the person matching process.</p>
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="personId" class="">
+      <td class="field-name">personId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">The candidate person record ID.</td>
+    </tr>
+    <tr data-field="confidenceScore" class="">
+      <td class="field-name">confidenceScore</td>
+      <td class="field-type">Number</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Match confidence score from 0 (no confidence) to 1 (certain).</td>
+    </tr>
+  </tbody>
+</table>
+</section>
+
+<section id="DocumentRequest" class="schema-section inline-object" data-domain="intake">
+  <div class="section-header simple">
+    <a href="#domain-intake" class="entity-domain-badge" style="--domain-color: #00AD93; --domain-bg: #E2F9F6;">Intake</a>
+    <span class="inline-object-badge">Nested in <a href="#Verification">Verification</a></span>
+    <h2>DocumentRequest</h2>
+  </div>
+  <p class="description">An outbound notice requesting documents from an applicant for a verification obligation.</p>
+<table class="property-table">
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Req</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr data-field="noticeId" class="">
+      <td class="field-name">noticeId</td>
+      <td class="field-type">ID</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">ID of the notice in the communication domain.</td>
+    </tr>
+    <tr data-field="type" class="">
+      <td class="field-name">type</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">Options: document request citizenship verification, document request identity verification, document request immigration verification, document request income verification, document request residency verification</td>
+    </tr>
+    <tr data-field="sentAt" class="">
+      <td class="field-name">sentAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required">&#10003;</td>
+      <td class="field-notes">When the notice was sent.</td>
+    </tr>
+    <tr data-field="dueAt" class="">
+      <td class="field-name">dueAt</td>
+      <td class="field-type">Date & Time</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Deadline by which the applicant must respond.</td>
+    </tr>
+    <tr data-field="channel" class="">
+      <td class="field-name">channel</td>
+      <td class="field-type">Dropdown</td>
+      <td class="field-required"></td>
+      <td class="field-notes">Options: email, in person, mail, portal</td>
     </tr>
   </tbody>
 </table>
@@ -9686,7 +10387,7 @@ Examples: applications:read, persons:update, users:create
     });
 
     // Search index
-    const searchIndex = [{"field":"id","schema":"Case","type":"ID","domain":"Case Management","description":"Unique identifier (server-generated)."},{"field":"status","schema":"Case","type":"Dropdown","domain":"Case Management","description":"Current status of the case."},{"field":"effectiveStartDate","schema":"Case","type":"Date","domain":"Case Management","description":"Date when coverage or the case relationship begins."},{"field":"effectiveEndDate","schema":"Case","type":"Date","domain":"Case Management","description":"Date when the case was closed. Null while active."},{"field":"primaryApplicantId","schema":"Case","type":"ID","domain":"Case Management","description":"Reference to the Person record for the primary applicant."},{"field":"members","schema":"Case","type":"List of → Member","domain":"Case Management","description":"Household members associated with this case."},{"field":"assignedToId","schema":"Case","type":"ID","domain":"Case Management","description":"Reference to the User record for the assigned case worker."},{"field":"createdAt","schema":"Case","type":"Date & Time","domain":"Case Management","description":"Timestamp when the case was created."},{"field":"updatedAt","schema":"Case","type":"Date & Time","domain":"Case Management","description":"Timestamp when the case was last updated."},{"field":"personId","schema":"CaseMember","type":"ID","domain":"Other","description":"Reference to the Person record."},{"field":"relationship","schema":"CaseMember","type":"Text","domain":"Other","description":"Relationship to the primary applicant."},{"field":"id","schema":"ExternalService","type":"ID","domain":"Data Exchange","description":"Stable identifier. Referenced by ExternalServiceCall submissions."},{"field":"name","schema":"ExternalService","type":"Text","domain":"Data Exchange","description":"Human-readable name (e.g., \"SSA Composite via FDSH\")."},{"field":"serviceType","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"defaultCallMode","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"Default call mode for submissions against this service. Can be overridden per call."},{"field":"programs","schema":"ExternalService","type":"Multi-select","domain":"Data Exchange","description":"Programs that use this service."},{"field":"source","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"\"system\" entries are defined in data-exchange-config.yaml and cannot be deleted via the API. \"user\" entries are added by states at runtime."},{"field":"createdAt","schema":"ExternalService","type":"Date & Time","domain":"Data Exchange","description":""},{"field":"updatedAt","schema":"ExternalService","type":"Date & Time","domain":"Data Exchange","description":""},{"field":"id","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"Unique identifier."},{"field":"serviceId","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"ID of the ExternalService catalog entry being called."},{"field":"serviceType","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"ID of the resource that triggered the call (e.g., an ApplicationMember ID). Combined with `serviceId`, forms the idempotency key."},{"field":"requestingResourceType","schema":"ExternalServiceCall","type":"Text","domain":"Data Exchange","description":"Resource type of the requesting resource, copied from the ExternalService catalog entry at submission time. Together with `requestingResourceId`, tells adapters where to fetch sensitive input fields."},{"field":"callMode","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"Whether this call is synchronous or asynchronous."},{"field":"status","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"Lifecycle state of an external service call."},{"field":"data","schema":"ExternalServiceCall","type":"→ Data","domain":"Data Exchange","description":"Optional per-call non-PII context (e.g., which FDSH sub-components to request). Polymorphic on `serviceType`."},{"field":"metadata","schema":"ExternalServiceCall","type":"→ Metadata","domain":"Data Exchange","description":"Namespace-keyed metadata attached by calling domains for context passthrough. Keys are domain names; values are arbitrary objects."},{"field":"createdAt","schema":"ExternalServiceCall","type":"Date & Time","domain":"Data Exchange","description":"When the call was submitted."},{"field":"updatedAt","schema":"ExternalServiceCall","type":"Date & Time","domain":"Data Exchange","description":"When the call status last changed."},{"field":"serviceCallId","schema":"CallCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallCompletedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"result","schema":"CallCompletedEvent","type":"Dropdown","domain":"Other","description":"High-level outcome of the service call."},{"field":"metadata","schema":"CallCompletedEvent","type":"→ Metadata","domain":"Other","description":"Domain-keyed metadata echoed back from the service call record. Enables calling domains to resume without querying the service call."},{"field":"serviceResult","schema":"CallCompletedEvent","type":"→ ServiceResult","domain":"Other","description":"Service-type-specific result payload. Polymorphic on `serviceType`."},{"field":"serviceCallId","schema":"CallFailedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallFailedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallFailedEvent","type":"ID","domain":"Other","description":""},{"field":"failureReason","schema":"CallFailedEvent","type":"Dropdown","domain":"Other","description":"Classification of the failure to help calling domains decide whether to retry, escalate, or proceed without the data."},{"field":"metadata","schema":"CallFailedEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"serviceCallId","schema":"CallSubmittedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallSubmittedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallSubmittedEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"CallSubmittedEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"serviceCallId","schema":"CallTimedOutEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallTimedOutEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallTimedOutEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"CallTimedOutEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"id","schema":"Document","type":"ID","domain":"Document Management","description":""},{"field":"documentTypeId","schema":"Document","type":"ID","domain":"Document Management","description":"Links to the DocumentType governing retention rules for this document."},{"field":"title","schema":"Document","type":"Text","domain":"Document Management","description":"Human-readable label (e.g. \"Jane Smith — Pay Stub March 2026\"). Distinct from the upload filename."},{"field":"documentDate","schema":"Document","type":"Date","domain":"Document Management","description":"The date on the document's face (e.g. a pay stub date). Required when the document type's retentionTrigger is document_date."},{"field":"lifecycleState","schema":"Document","type":"Dropdown","domain":"Document Management","description":"Where the document is in its records management lifecycle."},{"field":"legalHold","schema":"Document","type":"Yes/No","domain":"Document Management","description":"When true, the document cannot advance to pending_disposition regardless of retention schedule."},{"field":"latestVersionId","schema":"Document","type":"ID","domain":"Document Management","description":"ID of the most recent DocumentVersion. Single authoritative pointer to the current file."},{"field":"retentionDeadline","schema":"Document","type":"Date","domain":"Document Management","description":"The date when the retention period ends. Null until the document enters retained state."},{"field":"metadata","schema":"Document","type":"→ Metadata","domain":"Document Management","description":"Opaque correlation context structured as nested objects per domain namespace. Example: {\"intake\":{\"verificationId\":\"ver-abc-123\"},\"workflow\":{\"taskId\":\"tsk-xyz-456\"}}\n"},{"field":"dispositionApprovedBy","schema":"Document","type":"Text","domain":"Document Management","description":"Identity of the records manager who authorized destruction. Null until destroyed state."},{"field":"dispositionApprovedAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":"When destruction was authorized. Null until destroyed state."},{"field":"createdAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":""},{"field":"updatedAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":""},{"field":"id","schema":"DocumentVersion","type":"ID","domain":"Other","description":""},{"field":"documentId","schema":"DocumentVersion","type":"ID","domain":"Other","description":"Links to the parent Document."},{"field":"versionNumber","schema":"DocumentVersion","type":"Number","domain":"Other","description":"Sequential version number. 1 for the first version."},{"field":"fileName","schema":"DocumentVersion","type":"Text","domain":"Other","description":"Original filename as uploaded."},{"field":"mimeType","schema":"DocumentVersion","type":"Text","domain":"Other","description":"MIME type of the uploaded file."},{"field":"sizeBytes","schema":"DocumentVersion","type":"Number","domain":"Other","description":"File size in bytes."},{"field":"contentHash","schema":"DocumentVersion","type":"Text","domain":"Other","description":"SHA-256 hash of the file bytes. Stored for duplicate detection; baseline enforces nothing."},{"field":"uploadedById","schema":"DocumentVersion","type":"Text","domain":"Other","description":"Identity of the uploader. Required for HIPAA chain-of-custody (45 CFR § 164.312)."},{"field":"createdAt","schema":"DocumentVersion","type":"Date & Time","domain":"Other","description":"Authoritative upload timestamp."},{"field":"id","schema":"DocumentType","type":"ID","domain":"Other","description":""},{"field":"name","schema":"DocumentType","type":"Text","domain":"Other","description":""},{"field":"retentionYears","schema":"DocumentType","type":"Number","domain":"Other","description":"How many years documents of this type must be retained after the retention trigger fires."},{"field":"retentionTrigger","schema":"DocumentType","type":"Dropdown","domain":"Other","description":"The event that starts the retention clock for this document type."},{"field":"source","schema":"DocumentType","type":"Dropdown","domain":"Other","description":"\"system\" types are seeded from config and cannot be deleted. \"user\" types are created at runtime and can be deleted."},{"field":"createdAt","schema":"DocumentType","type":"Date & Time","domain":"Other","description":""},{"field":"updatedAt","schema":"DocumentType","type":"Date & Time","domain":"Other","description":""},{"field":"id","schema":"DocumentLink","type":"ID","domain":"Other","description":""},{"field":"documentId","schema":"DocumentLink","type":"ID","domain":"Other","description":""},{"field":"subjectType","schema":"DocumentLink","type":"Dropdown","domain":"Other","description":"The kind of record this document is linked to (e.g. application, case). States add values via overlay."},{"field":"subjectId","schema":"DocumentLink","type":"ID","domain":"Other","description":"ID of the linked record."},{"field":"linkedBy","schema":"DocumentLink","type":"Text","domain":"Other","description":"Identity of who created the link. Required for HIPAA chain-of-custody (45 CFR § 164.312)."},{"field":"closedAt","schema":"DocumentLink","type":"Date & Time","domain":"Other","description":"Set when the subject closes. Used as the retention trigger timestamp for case_closure and application_denial retention types."},{"field":"createdAt","schema":"DocumentLink","type":"Date & Time","domain":"Other","description":""},{"field":"documentId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"documentTypeId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"title","schema":"DocumentCreatedEvent","type":"Text","domain":"Other","description":""},{"field":"latestVersionId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"DocumentCreatedEvent","type":"→ Metadata","domain":"Other","description":"Echoed verbatim from Document.metadata so consumers can correlate without additional lookups."},{"field":"documentId","schema":"DocumentVersionUploadedEvent","type":"ID","domain":"Other","description":""},{"field":"documentVersionId","schema":"DocumentVersionUploadedEvent","type":"ID","domain":"Other","description":""},{"field":"versionNumber","schema":"DocumentVersionUploadedEvent","type":"Number","domain":"Other","description":""},{"field":"metadata","schema":"DocumentVersionUploadedEvent","type":"→ Metadata","domain":"Other","description":"Echoed verbatim from Document.metadata."},{"field":"dateOfBirth","schema":"MemberContext","type":"Date","domain":"Other","description":"Member's date of birth. Used in age-based program eligibility criteria."},{"field":"relationshipToHead","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's relationship to the head of household."},{"field":"citizenshipStatus","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's citizenship status. Affects eligibility for SNAP (non-citizens face a 5-year bar in most cases, 8 U.S.C. § 1612) and Medicaid (42 CFR § 435.406).\n"},{"field":"immigrationStatus","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's immigration status. Required for non-citizens to determine qualified alien status under 8 U.S.C. § 1641. Verified electronically via FDSH VLP or SAVE (42 CFR § 435.956(c)).\n"},{"field":"isDisabled","schema":"MemberContext","type":"Yes/No","domain":"Other","description":"Whether the member has a disability. Affects SNAP deductions for medical expenses (7 CFR § 273.9(d)(3)) and may affect Medicaid eligibility pathways.\n"},{"field":"programs","schema":"MemberContext","type":"Multi-select","domain":"Other","description":"Programs this member is applying for."},{"field":"income","schema":"MemberContext","type":"List of → Income","domain":"Other","description":"Income records for this member."},{"field":"expenses","schema":"MemberContext","type":"List of → Expense","domain":"Other","description":"Expense records for this member."},{"field":"assets","schema":"MemberContext","type":"List of → Asset","domain":"Other","description":"Asset records for this member."},{"field":"serviceType","schema":"ElectronicCheckResult","type":"Dropdown","domain":"Other","description":"The data exchange service that performed the check."},{"field":"result","schema":"ElectronicCheckResult","type":"Dropdown","domain":"Other","description":"High-level outcome of the service call."},{"field":"receivedAt","schema":"ElectronicCheckResult","type":"Date & Time","domain":"Other","description":"When the result was received."},{"field":"serviceResult","schema":"ElectronicCheckResult","type":"→ ServiceResult","domain":"Other","description":"Service-type-specific result payload. Shape varies by serviceType — see data-exchange-adapter-openapi.yaml for the schema per service type.\n"},{"field":"category","schema":"VerificationSummary","type":"Text","domain":"Other","description":"The type of verification (e.g., income, identity, residency)."},{"field":"status","schema":"VerificationSummary","type":"Dropdown","domain":"Other","description":"Current status of the verification obligation."},{"field":"memberId","schema":"VerificationSummary","type":"ID","domain":"Other","description":"Identifier of the intake domain member this verification applies to. Passed through from intake for correlation — the adapter does not resolve this identifier.\n"},{"field":"metadata","schema":"PerMemberProgramRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"PerMemberProgramRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"PerMemberProgramRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"metadata","schema":"PerHouseholdProgramRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"PerHouseholdProgramRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"members","schema":"PerHouseholdProgramRequest","type":"List of → Member","domain":"Other","description":"All members in the household benefit unit."},{"field":"household","schema":"PerHouseholdProgramRequest","type":"→ Household","domain":"Other","description":"Household-level data used in benefit calculation."},{"field":"metadata","schema":"ProgramDecision","type":"→ Metadata","domain":"Other","description":"Echoed back unchanged from the request. The blueprint uses this to map the response to its internal records without exposing resource identities to the adapter.\n"},{"field":"program","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"The program this decision applies to."},{"field":"status","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"The eligibility outcome."},{"field":"path","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"How the decision was reached."},{"field":"denialReasonCode","schema":"ProgramDecision","type":"Text","domain":"Other","description":"Machine-readable reason code when status is denied or ineligible."},{"field":"metadata","schema":"ExpeditedScreeningRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"household","schema":"ExpeditedScreeningRequest","type":"→ Household","domain":"Other","description":"Household-level data used in SNAP expedited screening criteria."},{"field":"metadata","schema":"ExpeditedScreeningResponse","type":"→ Metadata","domain":"Other","description":"Echoed back unchanged from the request. The blueprint uses this to map the response to its internal records without exposing resource identities to the adapter.\n"},{"field":"expedited","schema":"ExpeditedScreeningResponse","type":"Yes/No","domain":"Other","description":"Whether the application qualifies for expedited SNAP processing."},{"field":"metadata","schema":"MedicaidExParteRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"MedicaidExParteRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"MedicaidExParteRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"electronicChecks","schema":"MedicaidExParteRequest","type":"List of → ElectronicCheck","domain":"Other","description":"Results from FDSH FTI, FDSH Medicare/VCI, and other Medicaid data exchange calls for this applicant.\n"},{"field":"metadata","schema":"IndividualDeterminationRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"IndividualDeterminationRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"IndividualDeterminationRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"verificationSummary","schema":"IndividualDeterminationRequest","type":"List of → VerificationSummary","domain":"Other","description":"Status of verification obligations relevant to this applicant and program."},{"field":"metadata","schema":"HouseholdDeterminationRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"HouseholdDeterminationRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"members","schema":"HouseholdDeterminationRequest","type":"List of → Member","domain":"Other","description":"All members in the household benefit unit."},{"field":"household","schema":"HouseholdDeterminationRequest","type":"→ Household","domain":"Other","description":"Household-level data used in benefit calculation."},{"field":"verificationSummary","schema":"HouseholdDeterminationRequest","type":"List of → VerificationSummary","domain":"Other","description":"Status of verification obligations relevant to this household and program."},{"field":"id","schema":"Determination","type":"ID","domain":"Eligibility","description":"Unique identifier for the determination."},{"field":"applicationId","schema":"Determination","type":"ID","domain":"Eligibility","description":"The application this determination belongs to."},{"field":"status","schema":"Determination","type":"Dropdown","domain":"Eligibility","description":"Lifecycle status of the determination. `pending` — created at submission, awaiting processing. `in_progress` — at least one Decision has been resolved. `completed` — all Decisions have reached a terminal state. `withdrawn` — the application was withdrawn before determination completed.\n"},{"field":"expeditedFlagged","schema":"Determination","type":"Yes/No","domain":"Eligibility","description":"Whether the application was flagged for expedited SNAP processing (7 CFR § 273.2(i)). Set at submission based on the rules engine expedited screening call.\n"},{"field":"createdAt","schema":"Determination","type":"Date & Time","domain":"Eligibility","description":"When the determination record was created."},{"field":"updatedAt","schema":"Determination","type":"Date & Time","domain":"Eligibility","description":"When the determination record was last updated."},{"field":"id","schema":"Decision","type":"ID","domain":"Eligibility","description":"Unique identifier for the decision."},{"field":"determinationId","schema":"Decision","type":"ID","domain":"Eligibility","description":"The determination this decision belongs to."},{"field":"program","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"Public assistance program available through integrated online benefits applications. Values use the federal program name; state-specific names (e.g., \"medical_assistance\" for Medicaid) are overlay concerns. States may extend this list via overlay.\n"},{"field":"status","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"Outcome status of a single program eligibility decision. `pending` — not yet evaluated, or deferred to caseworker review by the rules engine. `approved` — member meets program requirements. `denied` — member does not meet requirements based on provided information. `ineligible` — member cannot qualify for this program (e.g., citizenship bar, age limit).\n"},{"field":"path","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"How the decision was reached. `auto` — resolved by the rules engine without caseworker intervention (e.g., Medicaid ex parte). `manual` — resolved by a caseworker after review.\n"},{"field":"decidedAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision reached a terminal state."},{"field":"denialReasonCode","schema":"Decision","type":"Text","domain":"Eligibility","description":"Machine-readable reason code when status is denied or ineligible."},{"field":"electronicChecks","schema":"Decision","type":"List of → ElectronicCheck","domain":"Eligibility","description":"Summary of electronic checks that informed this decision."},{"field":"createdAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision record was created."},{"field":"updatedAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision record was last updated."},{"field":"serviceType","schema":"ElectronicCheckSummary","type":"Text","domain":"Other","description":"The data exchange service that performed the check."},{"field":"result","schema":"ElectronicCheckSummary","type":"Text","domain":"Other","description":"The outcome of the check (e.g., conclusive, inconclusive)."},{"field":"checkedAt","schema":"ElectronicCheckSummary","type":"Date & Time","domain":"Other","description":"When the check result was received."},{"field":"applicationId","schema":"ApplicationExpeditedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationExpeditedEvent","type":"ID","domain":"Other","description":""},{"field":"applicationId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"decisionId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"program","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"Public assistance program available through integrated online benefits applications. Values use the federal program name; state-specific names (e.g., \"medical_assistance\" for Medicaid) are overlay concerns. States may extend this list via overlay.\n"},{"field":"status","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"Outcome status of a single program eligibility decision. `pending` — not yet evaluated, or deferred to caseworker review by the rules engine. `approved` — member meets program requirements. `denied` — member does not meet requirements based on provided information. `ineligible` — member cannot qualify for this program (e.g., citizenship bar, age limit).\n"},{"field":"path","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"How the decision was reached. `auto` — resolved by the rules engine without caseworker intervention (e.g., Medicaid ex parte). `manual` — resolved by a caseworker after review.\n"},{"field":"applicationId","schema":"ApplicationDeterminationCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationDeterminationCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"id","schema":"Household","type":"ID","domain":"Other","description":"Unique identifier for the household."},{"field":"homeAddress","schema":"Household","type":"→ HomeAddress","domain":"Other","description":"Home address of the household."},{"field":"mailingAddress","schema":"Household","type":"→ MailingAddress","domain":"Other","description":"Mailing address if different from home address."},{"field":"phoneNumber","schema":"Household","type":"Phone","domain":"Other","description":"Primary phone number for the household."},{"field":"members","schema":"Household","type":"List of → Member","domain":"Other","description":"List of household members with their relationship to the head of household."},{"field":"createdAt","schema":"Household","type":"Date & Time","domain":"Other","description":"Timestamp when the household record was created."},{"field":"updatedAt","schema":"Household","type":"Date & Time","domain":"Other","description":"Timestamp when the household record was last updated."},{"field":"id","schema":"Income","type":"ID","domain":"Intake","description":"Unique identifier for the income."},{"field":"personId","schema":"Income","type":"ID","domain":"Intake","description":"Foreign key reference to the person who has this income."},{"field":"employerId","schema":"Income","type":"ID","domain":"Intake","description":"Optional foreign key reference to the employer, third-party or self related to this income."},{"field":"type","schema":"Income","type":"Dropdown","domain":"Intake","description":"The type of income this item represents."},{"field":"unearnedType","schema":"Income","type":"Dropdown","domain":"Intake","description":"Types of unearned income."},{"field":"incomeBasis","schema":"Income","type":"Dropdown","domain":"Intake","description":"Whether the income is net or gross."},{"field":"amount","schema":"Income","type":"Number","domain":"Intake","description":"The amount of income this item represents."},{"field":"frequency","schema":"Income","type":"Dropdown","domain":"Intake","description":"The frequency with which the income is received."},{"field":"reportedOn","schema":"Income","type":"Date","domain":"Intake","description":"The date the income was reported on."},{"field":"source","schema":"Income","type":"Dropdown","domain":"Intake","description":"The source of the income."},{"field":"startDate","schema":"Income","type":"Date","domain":"Intake","description":"When did the applicant first receive this income?"},{"field":"endDate","schema":"Income","type":"Date","domain":"Intake","description":"Does applicant expect this income to end soon or has it already ended?"},{"field":"isVerified","schema":"Income","type":"Yes/No","domain":"Intake","description":"Whether the income has been verified."},{"field":"verifiedDate","schema":"Income","type":"Date","domain":"Intake","description":"The date the income was verified."},{"field":"verifiedBy","schema":"Income","type":"ID","domain":"Intake","description":"The county worker who verified the income."},{"field":"verificationSourceIds","schema":"Income","type":"List of ID","domain":"Intake","description":"Array of verification sources related to this income."},{"field":"id","schema":"VerificationSource","type":"ID","domain":"Other","description":"Unique identifier for the verification source."},{"field":"programs","schema":"ApplicationWritable","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"ApplicationWritable","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"programs","schema":"Application","type":"Multi-select","domain":"Intake","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"Application","type":"Dropdown","domain":"Intake","description":"How the application was filed."},{"field":"id","schema":"Application","type":"ID","domain":"Intake","description":"Unique identifier for the application."},{"field":"status","schema":"Application","type":"Dropdown","domain":"Intake","description":"Current lifecycle status of the application."},{"field":"isExpedited","schema":"Application","type":["boolean","null"],"domain":"Intake","description":"Whether the application qualifies for expedited processing (e.g., SNAP 7-day track). Set during caseworker expedited screening after submission. Null until screening is complete."},{"field":"submittedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application was formally submitted. Null until submitted."},{"field":"withdrawnAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application was withdrawn. Null unless withdrawn."},{"field":"closedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the intake phase closed. Null until closed."},{"field":"createdAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application record was created."},{"field":"updatedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application record was last modified."},{"field":"roles","schema":"ApplicationMemberWritable","type":"Multi-select","domain":"Other","description":"Roles this person plays in the application."},{"field":"programsApplyingFor","schema":"ApplicationMemberWritable","type":"Multi-select","domain":"Other","description":"Programs this member is applying for. Subset of the application's programs."},{"field":"citizenshipStatus","schema":"ApplicationMemberWritable","type":"Dropdown","domain":"Other","description":"Citizenship or immigration status for this member."},{"field":"immigrationInfo","schema":"ApplicationMemberWritable","type":"→ ImmigrationInfo","domain":"Other","description":"Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid."},{"field":"roles","schema":"ApplicationMember","type":"Multi-select","domain":"Intake","description":"Roles this person plays in the application."},{"field":"programsApplyingFor","schema":"ApplicationMember","type":"Multi-select","domain":"Intake","description":"Programs this member is applying for. Subset of the application's programs."},{"field":"citizenshipStatus","schema":"ApplicationMember","type":"Dropdown","domain":"Intake","description":"Citizenship or immigration status for this member."},{"field":"immigrationInfo","schema":"ApplicationMember","type":"→ ImmigrationInfo","domain":"Intake","description":"Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid."},{"field":"id","schema":"ApplicationMember","type":"ID","domain":"Intake","description":""},{"field":"applicationId","schema":"ApplicationMember","type":"ID","domain":"Intake","description":""},{"field":"createdAt","schema":"ApplicationMember","type":"Date & Time","domain":"Intake","description":""},{"field":"updatedAt","schema":"ApplicationMember","type":"Date & Time","domain":"Intake","description":""},{"field":"memberId","schema":"ApplicationDocumentWritable","type":"ID","domain":"Other","description":"Member this document is required for. Null for household-level requirements (e.g., proof of residency)."},{"field":"category","schema":"ApplicationDocumentWritable","type":"Dropdown","domain":"Other","description":"Type of documentation required."},{"field":"memberId","schema":"ApplicationDocument","type":"ID","domain":"Other","description":"Member this document is required for. Null for household-level requirements (e.g., proof of residency)."},{"field":"category","schema":"ApplicationDocument","type":"Dropdown","domain":"Other","description":"Type of documentation required."},{"field":"id","schema":"ApplicationDocument","type":"ID","domain":"Other","description":""},{"field":"applicationId","schema":"ApplicationDocument","type":"ID","domain":"Other","description":""},{"field":"status","schema":"ApplicationDocument","type":"Dropdown","domain":"Other","description":"Current verification status of the document requirement."},{"field":"createdAt","schema":"ApplicationDocument","type":"Date & Time","domain":"Other","description":""},{"field":"updatedAt","schema":"ApplicationDocument","type":"Date & Time","domain":"Other","description":""},{"field":"evidence","schema":"ApplicationDocument","type":"List of ID","domain":"Other","description":"IDs of documents in document-management that satisfy this checklist item. Populated by the document-verified-write-back rule when a verified document carries subjectType \"application-document\" and subjectId matching this record.\n"},{"field":"waiverGranted","schema":"InterviewWritable","type":["boolean","null"],"domain":"Other","description":"Whether the interview requirement has been waived for this applicant."},{"field":"waiverReason","schema":"InterviewWritable","type":"Text","domain":"Other","description":"Reason the interview was waived. Required when waiverGranted is true."},{"field":"completedAt","schema":"InterviewWritable","type":"Date & Time","domain":"Other","description":"When the caseworker attested the interview obligation was satisfied. Null until completed."},{"field":"waiverGranted","schema":"Interview","type":["boolean","null"],"domain":"Other","description":"Whether the interview requirement has been waived for this applicant."},{"field":"waiverReason","schema":"Interview","type":"Text","domain":"Other","description":"Reason the interview was waived. Required when waiverGranted is true."},{"field":"completedAt","schema":"Interview","type":"Date & Time","domain":"Other","description":"When the caseworker attested the interview obligation was satisfied. Null until completed."},{"field":"id","schema":"Interview","type":"ID","domain":"Other","description":""},{"field":"applicationId","schema":"Interview","type":"ID","domain":"Other","description":""},{"field":"appointments","schema":"Interview","type":"List of ID","domain":"Other","description":"Appointment IDs from the scheduling domain accumulated for this interview obligation. Populated by the rules engine when scheduling.appointment.scheduled fires."},{"field":"createdAt","schema":"Interview","type":"Date & Time","domain":"Other","description":""},{"field":"updatedAt","schema":"Interview","type":"Date & Time","domain":"Other","description":""},{"field":"reviewCompletedAt","schema":"ApplicationReviewCompletedEvent","type":"Date & Time","domain":"Other","description":"When the caseworker signaled review was complete."},{"field":"closedAt","schema":"ApplicationClosedEvent","type":"Date & Time","domain":"Other","description":"When the intake phase closed."},{"field":"programs","schema":"ApplicationCreatedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"ApplicationCreatedEvent","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"id","schema":"ApplicationCreatedEvent","type":"ID","domain":"Other","description":"Unique identifier for the application."},{"field":"status","schema":"ApplicationCreatedEvent","type":"Dropdown","domain":"Other","description":"Current lifecycle status of the application."},{"field":"isExpedited","schema":"ApplicationCreatedEvent","type":["boolean","null"],"domain":"Other","description":"Whether the application qualifies for expedited processing (e.g., SNAP 7-day track). Set during caseworker expedited screening after submission. Null until screening is complete."},{"field":"submittedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application was formally submitted. Null until submitted."},{"field":"withdrawnAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application was withdrawn. Null unless withdrawn."},{"field":"closedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the intake phase closed. Null until closed."},{"field":"createdAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application record was created."},{"field":"updatedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application record was last modified."},{"field":"id","schema":"ApplicationDeletedEvent","type":"ID","domain":"Other","description":"Identifier of the deleted application."},{"field":"flaggedAt","schema":"ApplicationExpeditedFlaggedEvent","type":"Date & Time","domain":"Other","description":"When the expedited flag was set."},{"field":"openedAt","schema":"ApplicationOpenedEvent","type":"Date & Time","domain":"Other","description":"When the application moved to under_review."},{"field":"programs","schema":"ApplicationOpenedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. Included so downstream systems can fan out per-program work after intake screening (see Decision 15)."},{"field":"submittedAt","schema":"ApplicationSubmittedEvent","type":"Date & Time","domain":"Other","description":"When the application was formally submitted."},{"field":"programs","schema":"ApplicationSubmittedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. Consumers route per program type — not all programs generate caseworker tasks at submission."},{"field":"channel","schema":"ApplicationSubmittedEvent","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"isExpedited","schema":"ApplicationSubmittedEvent","type":["boolean","null"],"domain":"Other","description":"Whether expedited screening has already determined the application qualifies. Null if not yet screened."},{"field":"withdrawnAt","schema":"ApplicationWithdrawnEvent","type":"Date & Time","domain":"Other","description":"When the application was withdrawn."},{"field":"reason","schema":"ApplicationWithdrawnEvent","type":"Text","domain":"Other","description":"Why the application was withdrawn."},{"field":"name","schema":"Person","type":"→ Name","domain":"Client Management","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"Person","type":"Date","domain":"Client Management","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"Person","type":"SSN","domain":"Client Management","description":"Social Security Number for identity verification."},{"field":"address","schema":"Person","type":"→ Address","domain":"Client Management","description":"Address of the person."},{"field":"phoneNumber","schema":"Person","type":"Phone","domain":"Client Management","description":"Phone number for the person."},{"field":"email","schema":"Person","type":"Email","domain":"Client Management","description":"Email address of the person."},{"field":"id","schema":"Person","type":"ID","domain":"Client Management","description":"Unique identifier for the person. When creating an application, clients may\nprovide a temporary ID for linking related records (e.g., linking an absent\nparent to a child). The server replaces client-provided IDs with server-generated\nUUIDs upon submission.\n"},{"field":"demographicInfo","schema":"Person","type":"→ DemographicInfo","domain":"Client Management","description":"Demographic information including sex, marital status, and race."},{"field":"citizenshipInfo","schema":"Person","type":"→ CitizenshipInfo","domain":"Client Management","description":"Citizenship and immigration status information."},{"field":"contactInfo","schema":"Person","type":"→ ContactInfo","domain":"Client Management","description":"Contact information and communication preferences."},{"field":"employmentInfo","schema":"Person","type":"→ EmploymentInfo","domain":"Client Management","description":"Employment and self-employment information."},{"field":"educationInfo","schema":"Person","type":"→ EducationInfo","domain":"Client Management","description":"Student enrollment information for this person."},{"field":"militaryInfo","schema":"Person","type":"→ MilitaryInfo","domain":"Client Management","description":"Military and veteran status information."},{"field":"tribalInfo","schema":"Person","type":"→ TribalInfo","domain":"Client Management","description":"American Indian or Alaska Native tribal information for this person."},{"field":"consentToShareInformation","schema":"Person","type":"Yes/No","domain":"Client Management","description":"Consent to share information with partner agencies."},{"field":"createdAt","schema":"Person","type":"Date & Time","domain":"Client Management","description":"Timestamp when the person record was created."},{"field":"updatedAt","schema":"Person","type":"Date & Time","domain":"Client Management","description":"Timestamp when the person record was last updated."},{"field":"status","schema":"CitizenshipInfo","type":"Dropdown","domain":"Other","description":"Citizenship or immigration status relevant to benefits eligibility."},{"field":"certificateNumber","schema":"CitizenshipInfo","type":"Text","domain":"Other","description":"Certificate number if naturalized or derived citizen."},{"field":"immigrationInfo","schema":"CitizenshipInfo","type":"→ ImmigrationInfo","domain":"Other","description":"Immigration information for this person (if non-citizen)."},{"field":"otherPhoneNumber","schema":"ContactInfo","type":"Phone","domain":"Other","description":"Alternative phone number."},{"field":"mailingAddress","schema":"ContactInfo","type":"→ MailingAddress","domain":"Other","description":"Mailing address if different from residential address."},{"field":"isHomeless","schema":"ContactInfo","type":"Yes/No","domain":"Other","description":"Whether the person is currently homeless."},{"field":"preferredNoticeMethod","schema":"ContactInfo","type":"Dropdown","domain":"Other","description":"Preferred method for receiving official notices."},{"field":"languagePreference","schema":"ContactInfo","type":"→ LanguagePreference","domain":"Other","description":"Language preferences for communications."},{"field":"preferredContactMethod","schema":"ContactInfo","type":"Dropdown","domain":"Other","description":"Preferred method of contact."},{"field":"sex","schema":"DemographicInfo","type":"Dropdown","domain":"Other","description":"Biological sex of the person."},{"field":"maritalStatus","schema":"DemographicInfo","type":"Dropdown","domain":"Other","description":"Current marital status."},{"field":"isHispanicOrLatino","schema":"DemographicInfo","type":"Yes/No","domain":"Other","description":"Whether the person identifies as Hispanic or Latino."},{"field":"race","schema":"DemographicInfo","type":"Multi-select","domain":"Other","description":"Race identification (can select multiple)."},{"field":"lastGradeCompleted","schema":"EducationInfo","type":"Text","domain":"Other","description":"Last grade level completed."},{"field":"isCurrentlyEnrolled","schema":"EducationInfo","type":"Yes/No","domain":"Other","description":"Whether this person is currently enrolled in school."},{"field":"schoolName","schema":"EducationInfo","type":"Text","domain":"Other","description":"Name of the school or educational institution (if currently enrolled)."},{"field":"startDate","schema":"EducationInfo","type":"Date","domain":"Other","description":"Date enrollment started (if currently enrolled)."},{"field":"isFullTimeStudent","schema":"EducationInfo","type":"Yes/No","domain":"Other","description":"Whether the person is a full-time student (if currently enrolled)."},{"field":"expectedGraduationDate","schema":"EducationInfo","type":"Date","domain":"Other","description":"Expected graduation date (if currently enrolled)."},{"field":"jobs","schema":"EmploymentInfo","type":"List of → Job","domain":"Other","description":"Employment records for this person."},{"field":"status","schema":"ImmigrationInfo","type":"Dropdown","domain":"Other","description":"Immigration status category per 8 U.S.C. § 1641 (PRWORA qualified alien categories). Drives eligibility determination and benefit waiting-period rules.\n"},{"field":"documentType","schema":"ImmigrationInfo","type":"Dropdown","domain":"Other","description":"Type of immigration document presented. Determines which fields FDSH VLP requires to initiate a verification check.\n"},{"field":"documentNumber","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"Document number used to verify immigration status via FDSH VLP or USCIS SAVE."},{"field":"alienOrI94Number","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"Alien registration number or I-94 admission number."},{"field":"documentExpirationDate","schema":"ImmigrationInfo","type":"Date","domain":"Other","description":"Expiration date of the immigration document."},{"field":"countryOfIssuance","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"ISO 3166-1 alpha-2 country code of the country that issued the immigration document."},{"field":"hasSponsor","schema":"ImmigrationInfo","type":"Yes/No","domain":"Other","description":"Whether this non-citizen has a financial sponsor."},{"field":"sponsor","schema":"ImmigrationInfo","type":"→ Sponsor","domain":"Other","description":"Sponsor information for this non-citizen."},{"field":"employer","schema":"Job","type":"→ Employer","domain":"Other","description":"Employer information."},{"field":"startDate","schema":"Job","type":"Date","domain":"Other","description":"Date employment started."},{"field":"endDate","schema":"Job","type":"Date","domain":"Other","description":"Date employment ended (omit if current job)."},{"field":"isMilitaryServiceMember","schema":"MilitaryInfo","type":"Yes/No","domain":"Other","description":"Whether this person is a military service member."},{"field":"veteranStatus","schema":"MilitaryInfo","type":"Yes/No","domain":"Other","description":"Indicates whether the person has served in the armed forces."},{"field":"name","schema":"PersonIdentity","type":"→ Name","domain":"Other","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"PersonIdentity","type":"Date","domain":"Other","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"PersonIdentity","type":"SSN","domain":"Other","description":"Social Security Number for identity verification."},{"field":"address","schema":"PersonIdentity","type":"→ Address","domain":"Other","description":"Address of the person."},{"field":"phoneNumber","schema":"PersonIdentity","type":"Phone","domain":"Other","description":"Phone number for the person."},{"field":"email","schema":"PersonIdentity","type":"Email","domain":"Other","description":"Email address of the person."},{"field":"name","schema":"Sponsor","type":"→ Name","domain":"Other","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"Sponsor","type":"Date","domain":"Other","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"Sponsor","type":"SSN","domain":"Other","description":"Social Security Number for identity verification."},{"field":"address","schema":"Sponsor","type":"→ Address","domain":"Other","description":"Address of the person."},{"field":"phoneNumber","schema":"Sponsor","type":"Phone","domain":"Other","description":"Phone number for the person."},{"field":"email","schema":"Sponsor","type":"Email","domain":"Other","description":"Email address of the person."},{"field":"spouse","schema":"Sponsor","type":"→ Spouse","domain":"Other","description":"Basic identity and contact information for a person."},{"field":"totalPeopleInHousehold","schema":"Sponsor","type":"Number","domain":"Other","description":"Total number of people in the sponsor's household."},{"field":"tribeName","schema":"TribalInfo","type":"Text","domain":"Other","description":""},{"field":"tribeState","schema":"TribalInfo","type":"Text","domain":"Other","description":""},{"field":"hasReceivedServiceFromIndianHealthService","schema":"TribalInfo","type":"Yes/No","domain":"Other","description":""},{"field":"isEligibleForIndianHealthService","schema":"TribalInfo","type":"Yes/No","domain":"Other","description":""},{"field":"specversion","schema":"DomainEvent","type":"Dropdown","domain":"Other","description":"CloudEvents specification version."},{"field":"id","schema":"DomainEvent","type":"ID","domain":"Other","description":"Unique event identifier."},{"field":"type","schema":"DomainEvent","type":"Text","domain":"Other","description":"Fully qualified CloudEvents event type following the convention `org.codeforamerica.safety-net-blueprint.{domain}.{entity}.{verb}`.\n"},{"field":"source","schema":"DomainEvent","type":"Text","domain":"Other","description":"Domain base path that produced the event (e.g., `/intake`, `/workflow`)."},{"field":"subject","schema":"DomainEvent","type":"ID","domain":"Other","description":"Entity ID the event pertains to."},{"field":"time","schema":"DomainEvent","type":"Date & Time","domain":"Other","description":"When the event occurred."},{"field":"datacontenttype","schema":"DomainEvent","type":"Dropdown","domain":"Other","description":"Media type of the event payload."},{"field":"traceparent","schema":"DomainEvent","type":["string","null"],"domain":"Other","description":"W3C Trace Context header (optional). Propagated from the triggering request or event. The trace ID component is stable across the full causal chain.\n"},{"field":"data","schema":"DomainEvent","type":"→ Data","domain":"Other","description":"Event payload. Schema is defined per event type in each domain's x-events section."},{"field":"id","schema":"SearchResult","type":"ID","domain":"Other","description":"Unique identifier of the matched resource."},{"field":"type","schema":"SearchResult","type":"Dropdown","domain":"Other","description":"The type of resource matched by the search."},{"field":"title","schema":"SearchResult","type":"Text","domain":"Other","description":"Display title for the result (e.g., person name, case number)."},{"field":"url","schema":"SearchResult","type":"URL","domain":"Other","description":"Canonical API URL of the matched resource."},{"field":"score","schema":"SearchResult","type":"Number","domain":"Other","description":"Relevance score between 0 and 1. Higher is more relevant."},{"field":"attributes","schema":"SearchResult","type":"List of → Attribute","domain":"Other","description":"Typed key-value pairs describing the result (e.g., status, date of birth, case number)."},{"field":"createdAt","schema":"SearchResult","type":"Date & Time","domain":"Other","description":"When the matched resource was created."},{"field":"updatedAt","schema":"SearchResult","type":"Date & Time","domain":"Other","description":"When the matched resource was last updated."},{"field":"type","schema":"SearchFacet","type":"Dropdown","domain":"Other","description":"The type of resource matched by the search."},{"field":"count","schema":"SearchFacet","type":"Number","domain":"Other","description":"Number of matching results for this type."},{"field":"field","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Machine-readable field key (e.g., \"dob\", \"status\", \"caseNumber\")."},{"field":"label","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Human-readable display label (e.g., \"Date of Birth\", \"Status\", \"Case Number\")."},{"field":"value","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Display value, pre-formatted as a string regardless of type."},{"field":"type","schema":"SearchResultAttribute","type":"Dropdown","domain":"Other","description":"Value type hint for client rendering:\n- `string` — plain text (default)\n- `date` — date value (client may reformat)\n- `currency` — monetary amount (client may reformat)\n"},{"field":"id","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Unique identifier (server-generated)."},{"field":"startAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"When the appointment begins."},{"field":"endAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"When the appointment ends."},{"field":"appointmentType","schema":"Appointment","type":"Text","domain":"Scheduling","description":"Type of appointment (e.g., interview, recertification, orientation). Free-text, not enum — states define their own types."},{"field":"status","schema":"Appointment","type":"Dropdown","domain":"Scheduling","description":"Current status of the appointment."},{"field":"personId","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Reference to the Person record (the subject of the appointment)."},{"field":"assignedToId","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Reference to the User record (staff member conducting the appointment)."},{"field":"notes","schema":"Appointment","type":"Text","domain":"Scheduling","description":"Free-text notes about the appointment."},{"field":"createdAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"Timestamp when the appointment was created."},{"field":"updatedAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"Timestamp when the appointment was last updated."},{"field":"userId","schema":"User","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"User","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"ui","schema":"User","type":"→ Ui","domain":"Other","description":"Computed UI permissions and display data for frontend feature toggling.\nBackend computes these from role and permissions to provide\na UI-friendly interface for showing/hiding features.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: name, availableModules, canApproveApplications, etc.\n"},{"field":"preferences","schema":"User","type":"→ Preferences","domain":"Other","description":"User preferences for the application.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: timezone, dateFormat, itemsPerPage, language, theme, etc.\n"},{"field":"id","schema":"User","type":"ID","domain":"Other","description":"Unique identifier for the user (same as userId in JWT claims)."},{"field":"idpSubject","schema":"User","type":"Text","domain":"Other","description":"Subject identifier from the Identity Provider. Immutable after creation.\nFormat varies by IdP (e.g., \"auth0|507f1f77bcf86cd799439011\").\n"},{"field":"email","schema":"User","type":"Email","domain":"Other","description":"User's email address (from IdP or manually set)."},{"field":"status","schema":"User","type":"Dropdown","domain":"Other","description":"User account status."},{"field":"createdAt","schema":"User","type":"Date & Time","domain":"Other","description":"Timestamp when the user was created."},{"field":"updatedAt","schema":"User","type":"Date & Time","domain":"Other","description":"Timestamp when the user was last updated."},{"field":"userId","schema":"FrontendAuthContext","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"FrontendAuthContext","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"ui","schema":"FrontendAuthContext","type":"→ Ui","domain":"Other","description":"Computed UI permissions and display data for frontend feature toggling.\nBackend computes these from role and permissions to provide\na UI-friendly interface for showing/hiding features.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: name, availableModules, canApproveApplications, etc.\n"},{"field":"preferences","schema":"FrontendAuthContext","type":"→ Preferences","domain":"Other","description":"User preferences for the application.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: timezone, dateFormat, itemsPerPage, language, theme, etc.\n"},{"field":"userId","schema":"TokenClaims","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"TokenClaims","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"id","schema":"Queue","type":"ID","domain":"Workflow","description":"Unique identifier for the queue."},{"field":"name","schema":"Queue","type":"Text","domain":"Workflow","description":"Machine-readable name for the queue (e.g., snap-intake)."},{"field":"description","schema":"Queue","type":"Text","domain":"Workflow","description":"Human-readable description of the queue's purpose."},{"field":"source","schema":"Queue","type":"Dropdown","domain":"Workflow","description":"Origin of the queue. \"system\" queues are defined in workflow-config.yaml and cannot be deleted via the API. \"user\" queues are created at runtime via POST /queues and can be deleted. Consumers may use this field to disable destructive actions for system queues without first attempting the operation.\n"},{"field":"createdAt","schema":"Queue","type":"Date & Time","domain":"Workflow","description":"Timestamp when the queue was created."},{"field":"updatedAt","schema":"Queue","type":"Date & Time","domain":"Workflow","description":"Timestamp when the queue was last updated."},{"field":"name","schema":"TaskWritable","type":"Text","domain":"Other","description":"Human-readable label for the task."},{"field":"description","schema":"TaskWritable","type":"Text","domain":"Other","description":"Detailed information about the task."},{"field":"status","schema":"TaskWritable","type":"Text","domain":"Other","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"TaskWritable","type":"Text","domain":"Other","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"TaskWritable","type":"Dropdown","domain":"Other","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"TaskWritable","type":"Dropdown","domain":"Other","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"TaskWritable","type":"Yes/No","domain":"Other","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"TaskWritable","type":"Dropdown","domain":"Other","description":"Task processing priority."},{"field":"startedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When work finished."},{"field":"escalatedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task was escalated."},{"field":"cancelledAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task was cancelled."},{"field":"blockedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"TaskWritable","type":"Text","domain":"Other","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"TaskWritable","type":"Text","domain":"Other","description":"Optional notes recorded when the task was completed."},{"field":"name","schema":"Task","type":"Text","domain":"Workflow","description":"Human-readable label for the task."},{"field":"description","schema":"Task","type":"Text","domain":"Workflow","description":"Detailed information about the task."},{"field":"status","schema":"Task","type":"Text","domain":"Workflow","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"Task","type":"Text","domain":"Workflow","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"Task","type":"Dropdown","domain":"Workflow","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"Task","type":"Dropdown","domain":"Workflow","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"Task","type":"Yes/No","domain":"Workflow","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"Task","type":"Dropdown","domain":"Workflow","description":"Task processing priority."},{"field":"startedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When work finished."},{"field":"escalatedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task was escalated."},{"field":"cancelledAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task was cancelled."},{"field":"blockedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"Task","type":"Text","domain":"Workflow","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"Task","type":"Text","domain":"Workflow","description":"Optional notes recorded when the task was completed."},{"field":"id","schema":"Task","type":"ID","domain":"Workflow","description":"Unique identifier for the task."},{"field":"slaInfo","schema":"Task","type":"List of → SlaInfo","domain":"Workflow","description":"Engine-managed SLA tracking entries. Populated on create and updated on every transition. Read-only — use slaInfo on TaskCreate to specify which SLA types to track.\n"},{"field":"createdAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"Timestamp when the task was created."},{"field":"updatedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"Timestamp when the task was last updated."},{"field":"id","schema":"Metric","type":"Text","domain":"Other","description":"Unique metric identifier, from the domain's *-metrics.yaml."},{"field":"name","schema":"Metric","type":"Text","domain":"Other","description":"Human-readable metric name."},{"field":"aggregate","schema":"Metric","type":"Dropdown","domain":"Other","description":"Aggregation function used to compute the value."},{"field":"value","schema":"Metric","type":"Number","domain":"Other","description":"Computed scalar value. count: total matching records. ratio: 0–1. duration: median seconds between paired events. null when groupBy is specified.\n"},{"field":"breakdown","schema":"Metric","type":"→ Breakdown","domain":"Other","description":"Map of group value to computed metric value. Present when groupBy is specified; null otherwise.\n"},{"field":"targets","schema":"Metric","type":"List of → Target","domain":"Other","description":"Thresholds and goals from the metric definition."},{"field":"computedAt","schema":"Metric","type":"Date & Time","domain":"Other","description":"Timestamp when the value was computed."},{"field":"stat","schema":"MetricTarget","type":"Text","domain":"Other","description":"Statistic type (e.g., p50, ratio, trend)."},{"field":"operator","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Comparison operator for evaluating the target."},{"field":"amount","schema":"MetricTarget","type":"Number","domain":"Other","description":"Machine-readable threshold value."},{"field":"unit","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Unit for the amount field."},{"field":"label","schema":"MetricTarget","type":"Text","domain":"Other","description":"Human-readable target label (e.g., \"4h\", \"10%\")."},{"field":"direction","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Desired trend direction (for trend-type targets)."},{"field":"name","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Human-readable label for the task."},{"field":"description","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Detailed information about the task."},{"field":"status","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"TaskCreatedEvent","type":"Dropdown","domain":"Other","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"TaskCreatedEvent","type":"Dropdown","domain":"Other","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"TaskCreatedEvent","type":"Yes/No","domain":"Other","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"TaskCreatedEvent","type":"Dropdown","domain":"Other","description":"Task processing priority."},{"field":"startedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When work finished."},{"field":"escalatedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task was escalated."},{"field":"cancelledAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task was cancelled."},{"field":"blockedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Optional notes recorded when the task was completed."},{"field":"id","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Unique identifier for the task."},{"field":"slaInfo","schema":"TaskCreatedEvent","type":"List of → SlaInfo","domain":"Other","description":"Engine-managed SLA tracking entries. Populated on create and updated on every transition. Read-only — use slaInfo on TaskCreate to specify which SLA types to track.\n"},{"field":"createdAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"Timestamp when the task was created."},{"field":"updatedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"Timestamp when the task was last updated."},{"field":"assignedToId","schema":"TaskAssignedEvent","type":"ID","domain":"Other","description":"Caseworker the task was assigned to, if any."},{"field":"queueId","schema":"TaskAssignedEvent","type":"ID","domain":"Other","description":"Queue the task was assigned to, if any."},{"field":"assignedToId","schema":"TaskClaimedEvent","type":"ID","domain":"Other","description":"ID of the caseworker who claimed the task."},{"field":"reason","schema":"TaskReleasedEvent","type":"Text","domain":"Other","description":"Why the task was released."},{"field":"outcome","schema":"TaskCompletedEvent","type":"Text","domain":"Other","description":"The outcome recorded at completion."},{"field":"reason","schema":"TaskCancelledEvent","type":"Text","domain":"Other","description":"Why the task was cancelled."},{"field":"reason","schema":"TaskReopenedEvent","type":"Text","domain":"Other","description":"Why the task was reopened."},{"field":"reason","schema":"TaskEscalatedEvent","type":"Text","domain":"Other","description":"Why the task was escalated."},{"field":"source","schema":"TaskSystemResumedEvent","type":"Text","domain":"Other","description":"System that triggered the automated resumption."},{"field":"result","schema":"TaskSystemResumedEvent","type":"Text","domain":"Other","description":"Result of the verification or external check."},{"field":"outcome","schema":"TaskApprovedEvent","type":"Text","domain":"Other","description":"The outcome recorded at approval."},{"field":"reason","schema":"TaskReturnedToWorkerEvent","type":"Text","domain":"Other","description":"Why the task was returned for revision."},{"field":"priority","schema":"TaskPriorityChangedEvent","type":"Text","domain":"Other","description":"The new priority value."},{"field":"reason","schema":"TaskPriorityChangedEvent","type":"Text","domain":"Other","description":"Why the priority was changed."},{"field":"reason","schema":"TaskSlaBreachedEvent","type":"Dropdown","domain":"Other","description":"The SLA breach reason."},{"field":"changes","schema":"TaskUpdatedEvent","type":"List of → Change","domain":"Other","description":"List of fields that changed, with before and after values."}];
+    const searchIndex = [{"field":"id","schema":"Case","type":"ID","domain":"Case Management","description":"Unique identifier (server-generated)."},{"field":"status","schema":"Case","type":"Dropdown","domain":"Case Management","description":"Current status of the case."},{"field":"effectiveStartDate","schema":"Case","type":"Date","domain":"Case Management","description":"Date when coverage or the case relationship begins."},{"field":"effectiveEndDate","schema":"Case","type":"Date","domain":"Case Management","description":"Date when the case was closed. Null while active."},{"field":"primaryApplicantId","schema":"Case","type":"ID","domain":"Case Management","description":"Reference to the Person record for the primary applicant."},{"field":"members","schema":"Case","type":"List of → Member","domain":"Case Management","description":"Household members associated with this case."},{"field":"assignedToId","schema":"Case","type":"ID","domain":"Case Management","description":"Reference to the User record for the assigned case worker."},{"field":"createdAt","schema":"Case","type":"Date & Time","domain":"Case Management","description":"Timestamp when the case was created."},{"field":"updatedAt","schema":"Case","type":"Date & Time","domain":"Case Management","description":"Timestamp when the case was last updated."},{"field":"personId","schema":"CaseMember","type":"ID","domain":"Other","description":"Reference to the Person record."},{"field":"relationship","schema":"CaseMember","type":"Text","domain":"Other","description":"Relationship to the primary applicant."},{"field":"noticeId","schema":"NoticeSentEvent","type":"ID","domain":"Other","description":"ID of the notice that was sent."},{"field":"type","schema":"NoticeSentEvent","type":"Dropdown","domain":"Other","description":"Template identifier for the notice. Determines which template Communication used to generate the notice content. States may overlay the enum to add program-specific notice types.\n"},{"field":"sentAt","schema":"NoticeSentEvent","type":"Date & Time","domain":"Other","description":"When the notice was sent."},{"field":"metadata","schema":"NoticeSentEvent","type":"→ Metadata","domain":"Other","description":"Domain-keyed correlation context. Keys are domain names; values are arbitrary objects defined by the triggering domain. Treated as opaque by Communication — echoed back verbatim from the triggering event. Example: {\"intake\": {\"verificationId\": \"uuid-of-the-verification\"}}\n"},{"field":"id","schema":"ExternalService","type":"ID","domain":"Data Exchange","description":"Stable identifier. Referenced by ExternalServiceCall submissions."},{"field":"name","schema":"ExternalService","type":"Text","domain":"Data Exchange","description":"Human-readable name (e.g., \"SSA Composite via FDSH\")."},{"field":"serviceType","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"defaultCallMode","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"Default call mode for submissions against this service. Can be overridden per call."},{"field":"programs","schema":"ExternalService","type":"Multi-select","domain":"Data Exchange","description":"Programs that use this service."},{"field":"source","schema":"ExternalService","type":"Dropdown","domain":"Data Exchange","description":"\"system\" entries are defined in data-exchange-config.yaml and cannot be deleted via the API. \"user\" entries are added by states at runtime."},{"field":"createdAt","schema":"ExternalService","type":"Date & Time","domain":"Data Exchange","description":""},{"field":"updatedAt","schema":"ExternalService","type":"Date & Time","domain":"Data Exchange","description":""},{"field":"id","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"Unique identifier."},{"field":"serviceId","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"ID of the ExternalService catalog entry being called."},{"field":"serviceType","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"ExternalServiceCall","type":"ID","domain":"Data Exchange","description":"ID of the resource that triggered the call (e.g., an ApplicationMember ID). Combined with `serviceId`, forms the idempotency key."},{"field":"requestingResourceType","schema":"ExternalServiceCall","type":"Text","domain":"Data Exchange","description":"Resource type of the requesting resource, copied from the ExternalService catalog entry at submission time. Together with `requestingResourceId`, tells adapters where to fetch sensitive input fields."},{"field":"callMode","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"Whether this call is synchronous or asynchronous."},{"field":"status","schema":"ExternalServiceCall","type":"Dropdown","domain":"Data Exchange","description":"Lifecycle state of an external service call."},{"field":"data","schema":"ExternalServiceCall","type":"→ Data","domain":"Data Exchange","description":"Optional per-call non-PII context (e.g., which FDSH sub-components to request). Polymorphic on `serviceType`."},{"field":"metadata","schema":"ExternalServiceCall","type":"→ Metadata","domain":"Data Exchange","description":"Namespace-keyed metadata attached by calling domains for context passthrough. Keys are domain names; values are arbitrary objects."},{"field":"createdAt","schema":"ExternalServiceCall","type":"Date & Time","domain":"Data Exchange","description":"When the call was submitted."},{"field":"updatedAt","schema":"ExternalServiceCall","type":"Date & Time","domain":"Data Exchange","description":"When the call status last changed."},{"field":"serviceCallId","schema":"CallCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallCompletedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"result","schema":"CallCompletedEvent","type":"Dropdown","domain":"Other","description":"High-level outcome of the service call."},{"field":"metadata","schema":"CallCompletedEvent","type":"→ Metadata","domain":"Other","description":"Domain-keyed metadata echoed back from the service call record. Enables calling domains to resume without querying the service call."},{"field":"serviceResult","schema":"CallCompletedEvent","type":"→ ServiceResult","domain":"Other","description":"Service-type-specific result payload. Polymorphic on `serviceType`."},{"field":"serviceCallId","schema":"CallFailedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallFailedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallFailedEvent","type":"ID","domain":"Other","description":""},{"field":"failureReason","schema":"CallFailedEvent","type":"Dropdown","domain":"Other","description":"Classification of the failure to help calling domains decide whether to retry, escalate, or proceed without the data."},{"field":"metadata","schema":"CallFailedEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"serviceCallId","schema":"CallSubmittedEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallSubmittedEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallSubmittedEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"CallSubmittedEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"serviceCallId","schema":"CallTimedOutEvent","type":"ID","domain":"Other","description":""},{"field":"serviceType","schema":"CallTimedOutEvent","type":"Dropdown","domain":"Other","description":"The specific federal service interface being called. Each type has a distinct adapter interface, input schema, and result schema.\nFDSH services are prefixed fdsh_ — they route through the CMS Federal Data Services Hub. IEVS sources are separate systems with distinct interfaces. See the Data Exchange architecture doc for the full reference.\n"},{"field":"requestingResourceId","schema":"CallTimedOutEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"CallTimedOutEvent","type":"→ Metadata","domain":"Other","description":""},{"field":"id","schema":"Document","type":"ID","domain":"Document Management","description":""},{"field":"documentTypeId","schema":"Document","type":"ID","domain":"Document Management","description":"Links to the DocumentType governing retention rules for this document."},{"field":"title","schema":"Document","type":"Text","domain":"Document Management","description":"Human-readable label (e.g. \"Jane Smith — Pay Stub March 2026\"). Distinct from the upload filename."},{"field":"documentDate","schema":"Document","type":"Date","domain":"Document Management","description":"The date on the document's face (e.g. a pay stub date). Required when the document type's retentionTrigger is document_date."},{"field":"lifecycleState","schema":"Document","type":"Dropdown","domain":"Document Management","description":"Where the document is in its records management lifecycle."},{"field":"legalHold","schema":"Document","type":"Yes/No","domain":"Document Management","description":"When true, the document cannot advance to pending_disposition regardless of retention schedule."},{"field":"latestVersionId","schema":"Document","type":"ID","domain":"Document Management","description":"ID of the most recent DocumentVersion. Single authoritative pointer to the current file."},{"field":"retentionDeadline","schema":"Document","type":"Date","domain":"Document Management","description":"The date when the retention period ends. Null until the document enters retained state."},{"field":"metadata","schema":"Document","type":"→ Metadata","domain":"Document Management","description":"Opaque correlation context structured as nested objects per domain namespace. Example: {\"intake\":{\"verificationId\":\"ver-abc-123\"},\"workflow\":{\"taskId\":\"tsk-xyz-456\"}}\n"},{"field":"dispositionApprovedBy","schema":"Document","type":"Text","domain":"Document Management","description":"Identity of the records manager who authorized destruction. Null until destroyed state."},{"field":"dispositionApprovedAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":"When destruction was authorized. Null until destroyed state."},{"field":"createdAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":""},{"field":"updatedAt","schema":"Document","type":"Date & Time","domain":"Document Management","description":""},{"field":"id","schema":"DocumentVersion","type":"ID","domain":"Other","description":""},{"field":"documentId","schema":"DocumentVersion","type":"ID","domain":"Other","description":"Links to the parent Document."},{"field":"versionNumber","schema":"DocumentVersion","type":"Number","domain":"Other","description":"Sequential version number. 1 for the first version."},{"field":"fileName","schema":"DocumentVersion","type":"Text","domain":"Other","description":"Original filename as uploaded."},{"field":"mimeType","schema":"DocumentVersion","type":"Text","domain":"Other","description":"MIME type of the uploaded file."},{"field":"sizeBytes","schema":"DocumentVersion","type":"Number","domain":"Other","description":"File size in bytes."},{"field":"contentHash","schema":"DocumentVersion","type":"Text","domain":"Other","description":"SHA-256 hash of the file bytes. Stored for duplicate detection; baseline enforces nothing."},{"field":"uploadedById","schema":"DocumentVersion","type":"Text","domain":"Other","description":"Identity of the uploader. Required for HIPAA chain-of-custody (45 CFR § 164.312)."},{"field":"createdAt","schema":"DocumentVersion","type":"Date & Time","domain":"Other","description":"Authoritative upload timestamp."},{"field":"id","schema":"DocumentType","type":"ID","domain":"Other","description":""},{"field":"name","schema":"DocumentType","type":"Text","domain":"Other","description":""},{"field":"retentionYears","schema":"DocumentType","type":"Number","domain":"Other","description":"How many years documents of this type must be retained after the retention trigger fires."},{"field":"retentionTrigger","schema":"DocumentType","type":"Dropdown","domain":"Other","description":"The event that starts the retention clock for this document type."},{"field":"source","schema":"DocumentType","type":"Dropdown","domain":"Other","description":"\"system\" types are seeded from config and cannot be deleted. \"user\" types are created at runtime and can be deleted."},{"field":"createdAt","schema":"DocumentType","type":"Date & Time","domain":"Other","description":""},{"field":"updatedAt","schema":"DocumentType","type":"Date & Time","domain":"Other","description":""},{"field":"id","schema":"DocumentLink","type":"ID","domain":"Other","description":""},{"field":"documentId","schema":"DocumentLink","type":"ID","domain":"Other","description":""},{"field":"subjectType","schema":"DocumentLink","type":"Dropdown","domain":"Other","description":"The kind of record this document is linked to (e.g. application, case). States add values via overlay."},{"field":"subjectId","schema":"DocumentLink","type":"ID","domain":"Other","description":"ID of the linked record."},{"field":"linkedBy","schema":"DocumentLink","type":"Text","domain":"Other","description":"Identity of who created the link. Required for HIPAA chain-of-custody (45 CFR § 164.312)."},{"field":"closedAt","schema":"DocumentLink","type":"Date & Time","domain":"Other","description":"Set when the subject closes. Used as the retention trigger timestamp for case_closure and application_denial retention types."},{"field":"createdAt","schema":"DocumentLink","type":"Date & Time","domain":"Other","description":""},{"field":"documentId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"documentTypeId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"title","schema":"DocumentCreatedEvent","type":"Text","domain":"Other","description":""},{"field":"latestVersionId","schema":"DocumentCreatedEvent","type":"ID","domain":"Other","description":""},{"field":"metadata","schema":"DocumentCreatedEvent","type":"→ Metadata","domain":"Other","description":"Echoed verbatim from Document.metadata so consumers can correlate without additional lookups."},{"field":"documentId","schema":"DocumentVersionUploadedEvent","type":"ID","domain":"Other","description":""},{"field":"documentVersionId","schema":"DocumentVersionUploadedEvent","type":"ID","domain":"Other","description":""},{"field":"versionNumber","schema":"DocumentVersionUploadedEvent","type":"Number","domain":"Other","description":""},{"field":"metadata","schema":"DocumentVersionUploadedEvent","type":"→ Metadata","domain":"Other","description":"Echoed verbatim from Document.metadata."},{"field":"dateOfBirth","schema":"MemberContext","type":"Date","domain":"Other","description":"Member's date of birth. Used in age-based program eligibility criteria."},{"field":"relationshipToHead","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's relationship to the head of household."},{"field":"citizenshipStatus","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's citizenship status. Affects eligibility for SNAP (non-citizens face a 5-year bar in most cases, 8 U.S.C. § 1612) and Medicaid (42 CFR § 435.406).\n"},{"field":"immigrationStatus","schema":"MemberContext","type":"Dropdown","domain":"Other","description":"The member's immigration status. Required for non-citizens to determine qualified alien status under 8 U.S.C. § 1641. Verified electronically via FDSH VLP or SAVE (42 CFR § 435.956(c)).\n"},{"field":"isDisabled","schema":"MemberContext","type":"Yes/No","domain":"Other","description":"Whether the member has a disability. Affects SNAP deductions for medical expenses (7 CFR § 273.9(d)(3)) and may affect Medicaid eligibility pathways.\n"},{"field":"programs","schema":"MemberContext","type":"Multi-select","domain":"Other","description":"Programs this member is applying for."},{"field":"income","schema":"MemberContext","type":"List of → Income","domain":"Other","description":"Income records for this member."},{"field":"expenses","schema":"MemberContext","type":"List of → Expense","domain":"Other","description":"Expense records for this member."},{"field":"assets","schema":"MemberContext","type":"List of → Asset","domain":"Other","description":"Asset records for this member."},{"field":"serviceType","schema":"ElectronicCheckResult","type":"Dropdown","domain":"Other","description":"The data exchange service that performed the check."},{"field":"result","schema":"ElectronicCheckResult","type":"Dropdown","domain":"Other","description":"High-level outcome of the service call."},{"field":"receivedAt","schema":"ElectronicCheckResult","type":"Date & Time","domain":"Other","description":"When the result was received."},{"field":"serviceResult","schema":"ElectronicCheckResult","type":"→ ServiceResult","domain":"Other","description":"Service-type-specific result payload. Shape varies by serviceType — see data-exchange-adapter-openapi.yaml for the schema per service type.\n"},{"field":"category","schema":"VerificationSummary","type":"Text","domain":"Other","description":"The type of verification (e.g., income, identity, residency)."},{"field":"status","schema":"VerificationSummary","type":"Dropdown","domain":"Other","description":"Current status of the verification obligation."},{"field":"memberId","schema":"VerificationSummary","type":"ID","domain":"Other","description":"Identifier of the intake domain member this verification applies to. Passed through from intake for correlation — the adapter does not resolve this identifier.\n"},{"field":"metadata","schema":"PerMemberProgramRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"PerMemberProgramRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"PerMemberProgramRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"metadata","schema":"PerHouseholdProgramRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"PerHouseholdProgramRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"members","schema":"PerHouseholdProgramRequest","type":"List of → Member","domain":"Other","description":"All members in the household benefit unit."},{"field":"household","schema":"PerHouseholdProgramRequest","type":"→ Household","domain":"Other","description":"Household-level data used in benefit calculation."},{"field":"metadata","schema":"ProgramDecision","type":"→ Metadata","domain":"Other","description":"Echoed back unchanged from the request. The blueprint uses this to map the response to its internal records without exposing resource identities to the adapter.\n"},{"field":"program","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"The program this decision applies to."},{"field":"status","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"The eligibility outcome."},{"field":"path","schema":"ProgramDecision","type":"Dropdown","domain":"Other","description":"How the decision was reached."},{"field":"denialReasonCode","schema":"ProgramDecision","type":"Text","domain":"Other","description":"Machine-readable reason code when status is denied or ineligible."},{"field":"metadata","schema":"ExpeditedScreeningRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"household","schema":"ExpeditedScreeningRequest","type":"→ Household","domain":"Other","description":"Household-level data used in SNAP expedited screening criteria."},{"field":"metadata","schema":"ExpeditedScreeningResponse","type":"→ Metadata","domain":"Other","description":"Echoed back unchanged from the request. The blueprint uses this to map the response to its internal records without exposing resource identities to the adapter.\n"},{"field":"expedited","schema":"ExpeditedScreeningResponse","type":"Yes/No","domain":"Other","description":"Whether the application qualifies for expedited SNAP processing."},{"field":"metadata","schema":"MedicaidExParteRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"MedicaidExParteRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"MedicaidExParteRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"electronicChecks","schema":"MedicaidExParteRequest","type":"List of → ElectronicCheck","domain":"Other","description":"Results from FDSH FTI, FDSH Medicare/VCI, and other Medicaid data exchange calls for this applicant.\n"},{"field":"metadata","schema":"IndividualDeterminationRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"IndividualDeterminationRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"member","schema":"IndividualDeterminationRequest","type":"→ Member","domain":"Other","description":"The applicant being evaluated."},{"field":"verificationSummary","schema":"IndividualDeterminationRequest","type":"List of → VerificationSummary","domain":"Other","description":"Status of verification obligations relevant to this applicant and program."},{"field":"metadata","schema":"HouseholdDeterminationRequest","type":"→ Metadata","domain":"Other","description":"Opaque correlation context set by the blueprint. Echo back unchanged in the response. The adapter must not inspect or modify this field.\n"},{"field":"program","schema":"HouseholdDeterminationRequest","type":"Dropdown","domain":"Other","description":"The program being evaluated."},{"field":"members","schema":"HouseholdDeterminationRequest","type":"List of → Member","domain":"Other","description":"All members in the household benefit unit."},{"field":"household","schema":"HouseholdDeterminationRequest","type":"→ Household","domain":"Other","description":"Household-level data used in benefit calculation."},{"field":"verificationSummary","schema":"HouseholdDeterminationRequest","type":"List of → VerificationSummary","domain":"Other","description":"Status of verification obligations relevant to this household and program."},{"field":"id","schema":"Determination","type":"ID","domain":"Eligibility","description":"Unique identifier for the determination."},{"field":"applicationId","schema":"Determination","type":"ID","domain":"Eligibility","description":"The application this determination belongs to."},{"field":"status","schema":"Determination","type":"Dropdown","domain":"Eligibility","description":"Lifecycle status of the determination. `pending` — created at submission, awaiting processing. `in_progress` — at least one Decision has been resolved. `completed` — all Decisions have reached a terminal state. `withdrawn` — the application was withdrawn before determination completed.\n"},{"field":"expeditedFlagged","schema":"Determination","type":"Yes/No","domain":"Eligibility","description":"Whether the application was flagged for expedited SNAP processing (7 CFR § 273.2(i)). Set at submission based on the rules engine expedited screening call.\n"},{"field":"createdAt","schema":"Determination","type":"Date & Time","domain":"Eligibility","description":"When the determination record was created."},{"field":"updatedAt","schema":"Determination","type":"Date & Time","domain":"Eligibility","description":"When the determination record was last updated."},{"field":"id","schema":"Decision","type":"ID","domain":"Eligibility","description":"Unique identifier for the decision."},{"field":"determinationId","schema":"Decision","type":"ID","domain":"Eligibility","description":"The determination this decision belongs to."},{"field":"applicationId","schema":"Decision","type":"ID","domain":"Eligibility","description":"The application this decision belongs to."},{"field":"memberId","schema":"Decision","type":"ID","domain":"Eligibility","description":"The household member this decision covers."},{"field":"program","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"Public assistance program available through integrated online benefits applications. Values use the federal program name; state-specific names (e.g., \"medical_assistance\" for Medicaid) are overlay concerns. States may extend this list via overlay.\n"},{"field":"status","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"Outcome status of a single program eligibility decision. `pending` — not yet evaluated, or deferred to caseworker review by the rules engine. `approved` — member meets program requirements. `denied` — member does not meet requirements based on provided information. `ineligible` — member cannot qualify for this program (e.g., citizenship bar, age limit).\n"},{"field":"path","schema":"Decision","type":"Dropdown","domain":"Eligibility","description":"How the decision was reached. `auto` — resolved by the rules engine without caseworker intervention (e.g., Medicaid ex parte). `manual` — resolved by a caseworker after review.\n"},{"field":"decidedAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision reached a terminal state."},{"field":"denialReasonCode","schema":"Decision","type":"Text","domain":"Eligibility","description":"Machine-readable reason code when status is denied or ineligible."},{"field":"electronicChecks","schema":"Decision","type":"List of → ElectronicCheck","domain":"Eligibility","description":"Summary of electronic checks that informed this decision."},{"field":"createdAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision record was created."},{"field":"updatedAt","schema":"Decision","type":"Date & Time","domain":"Eligibility","description":"When the decision record was last updated."},{"field":"serviceType","schema":"ElectronicCheckSummary","type":"Text","domain":"Other","description":"The data exchange service that performed the check."},{"field":"result","schema":"ElectronicCheckSummary","type":"Text","domain":"Other","description":"The outcome of the check (e.g., conclusive, inconclusive)."},{"field":"checkedAt","schema":"ElectronicCheckSummary","type":"Date & Time","domain":"Other","description":"When the check result was received."},{"field":"applicationId","schema":"ApplicationExpeditedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationExpeditedEvent","type":"ID","domain":"Other","description":""},{"field":"applicationId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"decisionId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"memberId","schema":"ApplicationDecisionCompletedEvent","type":"ID","domain":"Other","description":"The household member this decision covers."},{"field":"program","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"Public assistance program available through integrated online benefits applications. Values use the federal program name; state-specific names (e.g., \"medical_assistance\" for Medicaid) are overlay concerns. States may extend this list via overlay.\n"},{"field":"status","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"Outcome status of a single program eligibility decision. `pending` — not yet evaluated, or deferred to caseworker review by the rules engine. `approved` — member meets program requirements. `denied` — member does not meet requirements based on provided information. `ineligible` — member cannot qualify for this program (e.g., citizenship bar, age limit).\n"},{"field":"path","schema":"ApplicationDecisionCompletedEvent","type":"Dropdown","domain":"Other","description":"How the decision was reached. `auto` — resolved by the rules engine without caseworker intervention (e.g., Medicaid ex parte). `manual` — resolved by a caseworker after review.\n"},{"field":"applicationId","schema":"ApplicationDeterminationCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"determinationId","schema":"ApplicationDeterminationCompletedEvent","type":"ID","domain":"Other","description":""},{"field":"id","schema":"Household","type":"ID","domain":"Other","description":"Unique identifier for the household."},{"field":"homeAddress","schema":"Household","type":"→ HomeAddress","domain":"Other","description":"Home address of the household."},{"field":"mailingAddress","schema":"Household","type":"→ MailingAddress","domain":"Other","description":"Mailing address if different from home address."},{"field":"phoneNumber","schema":"Household","type":"Phone","domain":"Other","description":"Primary phone number for the household."},{"field":"members","schema":"Household","type":"List of → Member","domain":"Other","description":"List of household members with their relationship to the head of household."},{"field":"createdAt","schema":"Household","type":"Date & Time","domain":"Other","description":"Timestamp when the household record was created."},{"field":"updatedAt","schema":"Household","type":"Date & Time","domain":"Other","description":"Timestamp when the household record was last updated."},{"field":"id","schema":"Income","type":"ID","domain":"Intake","description":"Unique identifier for the income."},{"field":"personId","schema":"Income","type":"ID","domain":"Intake","description":"Foreign key reference to the person who has this income."},{"field":"employerId","schema":"Income","type":"ID","domain":"Intake","description":"Optional foreign key reference to the employer, third-party or self related to this income."},{"field":"type","schema":"Income","type":"Dropdown","domain":"Intake","description":"The type of income this item represents."},{"field":"unearnedType","schema":"Income","type":"Dropdown","domain":"Intake","description":"Types of unearned income."},{"field":"incomeBasis","schema":"Income","type":"Dropdown","domain":"Intake","description":"Whether the income is net or gross."},{"field":"amount","schema":"Income","type":"Number","domain":"Intake","description":"The amount of income this item represents."},{"field":"frequency","schema":"Income","type":"Dropdown","domain":"Intake","description":"The frequency with which the income is received."},{"field":"reportedOn","schema":"Income","type":"Date","domain":"Intake","description":"The date the income was reported on."},{"field":"source","schema":"Income","type":"Dropdown","domain":"Intake","description":"The source of the income."},{"field":"startDate","schema":"Income","type":"Date","domain":"Intake","description":"When did the applicant first receive this income?"},{"field":"endDate","schema":"Income","type":"Date","domain":"Intake","description":"Does applicant expect this income to end soon or has it already ended?"},{"field":"isVerified","schema":"Income","type":"Yes/No","domain":"Intake","description":"Whether the income has been verified."},{"field":"verifiedDate","schema":"Income","type":"Date","domain":"Intake","description":"The date the income was verified."},{"field":"verifiedBy","schema":"Income","type":"ID","domain":"Intake","description":"The county worker who verified the income."},{"field":"verificationSourceIds","schema":"Income","type":"List of ID","domain":"Intake","description":"Array of verification sources related to this income."},{"field":"id","schema":"VerificationSource","type":"ID","domain":"Other","description":"Unique identifier for the verification source."},{"field":"programs","schema":"ApplicationWritable","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"ApplicationWritable","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"programs","schema":"Application","type":"Multi-select","domain":"Intake","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"Application","type":"Dropdown","domain":"Intake","description":"How the application was filed."},{"field":"id","schema":"Application","type":"ID","domain":"Intake","description":"Unique identifier for the application."},{"field":"status","schema":"Application","type":"Dropdown","domain":"Intake","description":"Current lifecycle status of the application."},{"field":"isExpedited","schema":"Application","type":["boolean","null"],"domain":"Intake","description":"Whether the application qualifies for expedited processing (e.g., SNAP 7-day track). Set during caseworker expedited screening after submission. Null until screening is complete."},{"field":"submittedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application was formally submitted. Null until submitted."},{"field":"withdrawnAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application was withdrawn. Null unless withdrawn."},{"field":"closedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the intake phase closed. Null until closed."},{"field":"createdAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application record was created."},{"field":"updatedAt","schema":"Application","type":"Date & Time","domain":"Intake","description":"When the application record was last modified."},{"field":"roles","schema":"ApplicationMemberWritable","type":"Multi-select","domain":"Other","description":"Roles this person plays in the application."},{"field":"programsApplyingFor","schema":"ApplicationMemberWritable","type":"Multi-select","domain":"Other","description":"Programs this member is applying for. Subset of the application's programs."},{"field":"citizenshipStatus","schema":"ApplicationMemberWritable","type":"Dropdown","domain":"Other","description":"Citizenship or immigration status for this member."},{"field":"immigrationInfo","schema":"ApplicationMemberWritable","type":"→ ImmigrationInfo","domain":"Other","description":"Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid."},{"field":"personId","schema":"ApplicationMemberWritable","type":"ID","domain":"Other","description":"Resolved person record ID. Auto-set on a confirmed match; caseworker can set it manually when selecting from match candidates or correcting a bad link."},{"field":"roles","schema":"ApplicationMember","type":"Multi-select","domain":"Intake","description":"Roles this person plays in the application."},{"field":"programsApplyingFor","schema":"ApplicationMember","type":"Multi-select","domain":"Intake","description":"Programs this member is applying for. Subset of the application's programs."},{"field":"citizenshipStatus","schema":"ApplicationMember","type":"Dropdown","domain":"Intake","description":"Citizenship or immigration status for this member."},{"field":"immigrationInfo","schema":"ApplicationMember","type":"→ ImmigrationInfo","domain":"Intake","description":"Immigration document details. Required when citizenshipStatus is not citizen and the member is applying for Medicaid."},{"field":"personId","schema":"ApplicationMember","type":"ID","domain":"Intake","description":"Resolved person record ID. Auto-set on a confirmed match; caseworker can set it manually when selecting from match candidates or correcting a bad link."},{"field":"id","schema":"ApplicationMember","type":"ID","domain":"Intake","description":""},{"field":"applicationId","schema":"ApplicationMember","type":"ID","domain":"Intake","description":""},{"field":"createdAt","schema":"ApplicationMember","type":"Date & Time","domain":"Intake","description":""},{"field":"updatedAt","schema":"ApplicationMember","type":"Date & Time","domain":"Intake","description":""},{"field":"personMatch","schema":"ApplicationMember","type":"→ PersonMatch","domain":"Intake","description":"Person matching state for an application member. Populated when client_management.person.match_resolved is received. Null until matching begins."},{"field":"programDeterminations","schema":"ApplicationMember","type":"List of → ProgramDetermination","domain":"Intake","description":"Per-program eligibility determination results, populated as decisions arrive from the eligibility domain."},{"field":"matchStatus","schema":"PersonMatch","type":"Dropdown","domain":"Other","description":""},{"field":"candidates","schema":"PersonMatch","type":"List of → Candidate","domain":"Other","description":"Match candidates. Populated for review_required; empty otherwise."},{"field":"personId","schema":"PersonMatchCandidate","type":"ID","domain":"Other","description":"The candidate person record ID."},{"field":"confidenceScore","schema":"PersonMatchCandidate","type":"Number","domain":"Other","description":"Match confidence score from 0 (no confidence) to 1 (certain)."},{"field":"program","schema":"ApplicationMemberProgramDetermination","type":"Text","domain":"Other","description":"Program identifier (e.g., snap, medicaid, tanf)."},{"field":"outcome","schema":"ApplicationMemberProgramDetermination","type":"Dropdown","domain":"Other","description":"Determination outcome for this member/program combination."},{"field":"determinedAt","schema":"ApplicationMemberProgramDetermination","type":"Date & Time","domain":"Other","description":"When the determination was recorded."},{"field":"memberId","schema":"VerificationWritable","type":"ID","domain":"Other","description":"Member this obligation is for. Null for household-level obligations (e.g., proof of residency)."},{"field":"category","schema":"VerificationWritable","type":"Dropdown","domain":"Other","description":"Verification obligation category."},{"field":"verificationType","schema":"VerificationWritable","type":"Dropdown","domain":"Other","description":"How this verification obligation is to be fulfilled."},{"field":"memberId","schema":"Verification","type":"ID","domain":"Intake","description":"Member this obligation is for. Null for household-level obligations (e.g., proof of residency)."},{"field":"category","schema":"Verification","type":"Dropdown","domain":"Intake","description":"Verification obligation category."},{"field":"verificationType","schema":"Verification","type":"Dropdown","domain":"Intake","description":"How this verification obligation is to be fulfilled."},{"field":"id","schema":"Verification","type":"ID","domain":"Intake","description":""},{"field":"applicationId","schema":"Verification","type":"ID","domain":"Intake","description":""},{"field":"status","schema":"Verification","type":"Dropdown","domain":"Intake","description":"Current status of the verification obligation."},{"field":"evidence","schema":"Verification","type":"List of Unknown","domain":"Intake","description":"Electronic and document evidence items accumulated against this obligation."},{"field":"documentRequests","schema":"Verification","type":"List of → DocumentRequest","domain":"Intake","description":"Outbound document request notices sent to the applicant for this obligation."},{"field":"createdAt","schema":"Verification","type":"Date & Time","domain":"Intake","description":""},{"field":"updatedAt","schema":"Verification","type":"Date & Time","domain":"Intake","description":""},{"field":"waiverGranted","schema":"InterviewWritable","type":["boolean","null"],"domain":"Other","description":"Whether the interview requirement has been waived for this applicant."},{"field":"waiverReason","schema":"InterviewWritable","type":"Text","domain":"Other","description":"Reason the interview was waived. Required when waiverGranted is true."},{"field":"completedAt","schema":"InterviewWritable","type":"Date & Time","domain":"Other","description":"When the caseworker attested the interview obligation was satisfied. Null until completed."},{"field":"waiverGranted","schema":"Interview","type":["boolean","null"],"domain":"Other","description":"Whether the interview requirement has been waived for this applicant."},{"field":"waiverReason","schema":"Interview","type":"Text","domain":"Other","description":"Reason the interview was waived. Required when waiverGranted is true."},{"field":"completedAt","schema":"Interview","type":"Date & Time","domain":"Other","description":"When the caseworker attested the interview obligation was satisfied. Null until completed."},{"field":"id","schema":"Interview","type":"ID","domain":"Other","description":""},{"field":"applicationId","schema":"Interview","type":"ID","domain":"Other","description":""},{"field":"appointments","schema":"Interview","type":"List of ID","domain":"Other","description":"Appointment IDs from the scheduling domain accumulated for this interview obligation. Populated by the rules engine when scheduling.appointment.scheduled fires."},{"field":"createdAt","schema":"Interview","type":"Date & Time","domain":"Other","description":""},{"field":"updatedAt","schema":"Interview","type":"Date & Time","domain":"Other","description":""},{"field":"closedAt","schema":"ApplicationClosedEvent","type":"Date & Time","domain":"Other","description":"When the intake phase closed."},{"field":"programs","schema":"ApplicationCreatedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. At least one required at submission."},{"field":"channel","schema":"ApplicationCreatedEvent","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"id","schema":"ApplicationCreatedEvent","type":"ID","domain":"Other","description":"Unique identifier for the application."},{"field":"status","schema":"ApplicationCreatedEvent","type":"Dropdown","domain":"Other","description":"Current lifecycle status of the application."},{"field":"isExpedited","schema":"ApplicationCreatedEvent","type":["boolean","null"],"domain":"Other","description":"Whether the application qualifies for expedited processing (e.g., SNAP 7-day track). Set during caseworker expedited screening after submission. Null until screening is complete."},{"field":"submittedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application was formally submitted. Null until submitted."},{"field":"withdrawnAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application was withdrawn. Null unless withdrawn."},{"field":"closedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the intake phase closed. Null until closed."},{"field":"createdAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application record was created."},{"field":"updatedAt","schema":"ApplicationCreatedEvent","type":"Date & Time","domain":"Other","description":"When the application record was last modified."},{"field":"id","schema":"ApplicationDeletedEvent","type":"ID","domain":"Other","description":"Identifier of the deleted application."},{"field":"openedAt","schema":"ApplicationOpenedEvent","type":"Date & Time","domain":"Other","description":"When the application moved to under_review."},{"field":"programs","schema":"ApplicationOpenedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. Included so downstream systems can fan out per-program work after intake screening (see Decision 15)."},{"field":"reviewCompletedAt","schema":"ApplicationReviewCompletedEvent","type":"Date & Time","domain":"Other","description":"When the caseworker signaled review was complete."},{"field":"submittedAt","schema":"ApplicationSubmittedEvent","type":"Date & Time","domain":"Other","description":"When the application was formally submitted."},{"field":"programs","schema":"ApplicationSubmittedEvent","type":"Multi-select","domain":"Other","description":"Programs the household is applying for. Consumers route per program type — not all programs generate caseworker tasks at submission."},{"field":"channel","schema":"ApplicationSubmittedEvent","type":"Dropdown","domain":"Other","description":"How the application was filed."},{"field":"memberIds","schema":"ApplicationSubmittedEvent","type":"List of ID","domain":"Other","description":"IDs of all household members at submission time. Client Management fetches each member record to determine which are applying for benefits and should be matched against person records."},{"field":"withdrawnAt","schema":"ApplicationWithdrawnEvent","type":"Date & Time","domain":"Other","description":"When the application was withdrawn."},{"field":"reason","schema":"ApplicationWithdrawnEvent","type":"Text","domain":"Other","description":"Why the application was withdrawn."},{"field":"type","schema":"VerificationDocumentEvidence","type":"Dropdown","domain":"Other","description":""},{"field":"documentId","schema":"VerificationDocumentEvidence","type":"ID","domain":"Other","description":"ID of the verified document in the document-management domain."},{"field":"receivedAt","schema":"VerificationDocumentEvidence","type":"Date & Time","domain":"Other","description":"When the document was received."},{"field":"reviewedAt","schema":"VerificationDocumentEvidence","type":"Date & Time","domain":"Other","description":"When a caseworker reviewed the document."},{"field":"reviewedBy","schema":"VerificationDocumentEvidence","type":"ID","domain":"Other","description":"ID of the caseworker who reviewed the document."},{"field":"noticeId","schema":"VerificationDocumentRequest","type":"ID","domain":"Other","description":"ID of the notice in the communication domain."},{"field":"type","schema":"VerificationDocumentRequest","type":"Dropdown","domain":"Other","description":"Template identifier for the notice. Matches the type field on the communication.notice.sent event."},{"field":"sentAt","schema":"VerificationDocumentRequest","type":"Date & Time","domain":"Other","description":"When the notice was sent."},{"field":"dueAt","schema":"VerificationDocumentRequest","type":"Date & Time","domain":"Other","description":"Deadline by which the applicant must respond."},{"field":"channel","schema":"VerificationDocumentRequest","type":"Dropdown","domain":"Other","description":"Channel through which the notice was sent."},{"field":"type","schema":"VerificationElectronicEvidence","type":"Dropdown","domain":"Other","description":""},{"field":"source","schema":"VerificationElectronicEvidence","type":"Dropdown","domain":"Other","description":"The external service that produced this result."},{"field":"result","schema":"VerificationElectronicEvidence","type":"Dropdown","domain":"Other","description":"Whether the service check confirmed the obligation."},{"field":"serviceCallId","schema":"VerificationElectronicEvidence","type":"ID","domain":"Other","description":"ID of the data-exchange service call that produced this result."},{"field":"receivedAt","schema":"VerificationElectronicEvidence","type":"Date & Time","domain":"Other","description":"When the result was received."},{"field":"name","schema":"Person","type":"→ Name","domain":"Client Management","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"Person","type":"Date","domain":"Client Management","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"Person","type":"SSN","domain":"Client Management","description":"Social Security Number for identity verification."},{"field":"address","schema":"Person","type":"→ Address","domain":"Client Management","description":"Address of the person."},{"field":"phoneNumber","schema":"Person","type":"Phone","domain":"Client Management","description":"Phone number for the person."},{"field":"email","schema":"Person","type":"Email","domain":"Client Management","description":"Email address of the person."},{"field":"id","schema":"Person","type":"ID","domain":"Client Management","description":"Unique identifier for the person. When creating an application, clients may\nprovide a temporary ID for linking related records (e.g., linking an absent\nparent to a child). The server replaces client-provided IDs with server-generated\nUUIDs upon submission.\n"},{"field":"demographicInfo","schema":"Person","type":"→ DemographicInfo","domain":"Client Management","description":"Demographic information including sex, marital status, and race."},{"field":"citizenshipInfo","schema":"Person","type":"→ CitizenshipInfo","domain":"Client Management","description":"Citizenship and immigration status information."},{"field":"contactInfo","schema":"Person","type":"→ ContactInfo","domain":"Client Management","description":"Contact information and communication preferences."},{"field":"employmentInfo","schema":"Person","type":"→ EmploymentInfo","domain":"Client Management","description":"Employment and self-employment information."},{"field":"educationInfo","schema":"Person","type":"→ EducationInfo","domain":"Client Management","description":"Student enrollment information for this person."},{"field":"militaryInfo","schema":"Person","type":"→ MilitaryInfo","domain":"Client Management","description":"Military and veteran status information."},{"field":"tribalInfo","schema":"Person","type":"→ TribalInfo","domain":"Client Management","description":"American Indian or Alaska Native tribal information for this person."},{"field":"consentToShareInformation","schema":"Person","type":"Yes/No","domain":"Client Management","description":"Consent to share information with partner agencies."},{"field":"createdAt","schema":"Person","type":"Date & Time","domain":"Client Management","description":"Timestamp when the person record was created."},{"field":"updatedAt","schema":"Person","type":"Date & Time","domain":"Client Management","description":"Timestamp when the person record was last updated."},{"field":"status","schema":"CitizenshipInfo","type":"Dropdown","domain":"Other","description":"Citizenship or immigration status relevant to benefits eligibility."},{"field":"certificateNumber","schema":"CitizenshipInfo","type":"Text","domain":"Other","description":"Certificate number if naturalized or derived citizen."},{"field":"immigrationInfo","schema":"CitizenshipInfo","type":"→ ImmigrationInfo","domain":"Other","description":"Immigration information for this person (if non-citizen)."},{"field":"otherPhoneNumber","schema":"ContactInfo","type":"Phone","domain":"Other","description":"Alternative phone number."},{"field":"mailingAddress","schema":"ContactInfo","type":"→ MailingAddress","domain":"Other","description":"Mailing address if different from residential address."},{"field":"isHomeless","schema":"ContactInfo","type":"Yes/No","domain":"Other","description":"Whether the person is currently homeless."},{"field":"preferredNoticeMethod","schema":"ContactInfo","type":"Dropdown","domain":"Other","description":"Preferred method for receiving official notices."},{"field":"languagePreference","schema":"ContactInfo","type":"→ LanguagePreference","domain":"Other","description":"Language preferences for communications."},{"field":"preferredContactMethod","schema":"ContactInfo","type":"Dropdown","domain":"Other","description":"Preferred method of contact."},{"field":"sex","schema":"DemographicInfo","type":"Dropdown","domain":"Other","description":"Biological sex of the person."},{"field":"maritalStatus","schema":"DemographicInfo","type":"Dropdown","domain":"Other","description":"Current marital status."},{"field":"isHispanicOrLatino","schema":"DemographicInfo","type":"Yes/No","domain":"Other","description":"Whether the person identifies as Hispanic or Latino."},{"field":"race","schema":"DemographicInfo","type":"Multi-select","domain":"Other","description":"Race identification (can select multiple)."},{"field":"lastGradeCompleted","schema":"EducationInfo","type":"Text","domain":"Other","description":"Last grade level completed."},{"field":"isCurrentlyEnrolled","schema":"EducationInfo","type":"Yes/No","domain":"Other","description":"Whether this person is currently enrolled in school."},{"field":"schoolName","schema":"EducationInfo","type":"Text","domain":"Other","description":"Name of the school or educational institution (if currently enrolled)."},{"field":"startDate","schema":"EducationInfo","type":"Date","domain":"Other","description":"Date enrollment started (if currently enrolled)."},{"field":"isFullTimeStudent","schema":"EducationInfo","type":"Yes/No","domain":"Other","description":"Whether the person is a full-time student (if currently enrolled)."},{"field":"expectedGraduationDate","schema":"EducationInfo","type":"Date","domain":"Other","description":"Expected graduation date (if currently enrolled)."},{"field":"jobs","schema":"EmploymentInfo","type":"List of → Job","domain":"Other","description":"Employment records for this person."},{"field":"status","schema":"ImmigrationInfo","type":"Dropdown","domain":"Other","description":"Immigration status category per 8 U.S.C. § 1641 (PRWORA qualified alien categories). Drives eligibility determination and benefit waiting-period rules.\n"},{"field":"documentType","schema":"ImmigrationInfo","type":"Dropdown","domain":"Other","description":"Type of immigration document presented. Determines which fields FDSH VLP requires to initiate a verification check.\n"},{"field":"documentNumber","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"Document number used to verify immigration status via FDSH VLP or USCIS SAVE."},{"field":"alienOrI94Number","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"Alien registration number or I-94 admission number."},{"field":"documentExpirationDate","schema":"ImmigrationInfo","type":"Date","domain":"Other","description":"Expiration date of the immigration document."},{"field":"countryOfIssuance","schema":"ImmigrationInfo","type":"Text","domain":"Other","description":"ISO 3166-1 alpha-2 country code of the country that issued the immigration document."},{"field":"hasSponsor","schema":"ImmigrationInfo","type":"Yes/No","domain":"Other","description":"Whether this non-citizen has a financial sponsor."},{"field":"sponsor","schema":"ImmigrationInfo","type":"→ Sponsor","domain":"Other","description":"Sponsor information for this non-citizen."},{"field":"employer","schema":"Job","type":"→ Employer","domain":"Other","description":"Employer information."},{"field":"startDate","schema":"Job","type":"Date","domain":"Other","description":"Date employment started."},{"field":"endDate","schema":"Job","type":"Date","domain":"Other","description":"Date employment ended (omit if current job)."},{"field":"isMilitaryServiceMember","schema":"MilitaryInfo","type":"Yes/No","domain":"Other","description":"Whether this person is a military service member."},{"field":"veteranStatus","schema":"MilitaryInfo","type":"Yes/No","domain":"Other","description":"Indicates whether the person has served in the armed forces."},{"field":"name","schema":"PersonIdentity","type":"→ Name","domain":"Other","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"PersonIdentity","type":"Date","domain":"Other","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"PersonIdentity","type":"SSN","domain":"Other","description":"Social Security Number for identity verification."},{"field":"address","schema":"PersonIdentity","type":"→ Address","domain":"Other","description":"Address of the person."},{"field":"phoneNumber","schema":"PersonIdentity","type":"Phone","domain":"Other","description":"Phone number for the person."},{"field":"email","schema":"PersonIdentity","type":"Email","domain":"Other","description":"Email address of the person."},{"field":"name","schema":"Sponsor","type":"→ Name","domain":"Other","description":"Legal name of the person."},{"field":"dateOfBirth","schema":"Sponsor","type":"Date","domain":"Other","description":"Birth date of the person."},{"field":"socialSecurityNumber","schema":"Sponsor","type":"SSN","domain":"Other","description":"Social Security Number for identity verification."},{"field":"address","schema":"Sponsor","type":"→ Address","domain":"Other","description":"Address of the person."},{"field":"phoneNumber","schema":"Sponsor","type":"Phone","domain":"Other","description":"Phone number for the person."},{"field":"email","schema":"Sponsor","type":"Email","domain":"Other","description":"Email address of the person."},{"field":"spouse","schema":"Sponsor","type":"→ Spouse","domain":"Other","description":"Basic identity and contact information for a person."},{"field":"totalPeopleInHousehold","schema":"Sponsor","type":"Number","domain":"Other","description":"Total number of people in the sponsor's household."},{"field":"tribeName","schema":"TribalInfo","type":"Text","domain":"Other","description":""},{"field":"tribeState","schema":"TribalInfo","type":"Text","domain":"Other","description":""},{"field":"hasReceivedServiceFromIndianHealthService","schema":"TribalInfo","type":"Yes/No","domain":"Other","description":""},{"field":"isEligibleForIndianHealthService","schema":"TribalInfo","type":"Yes/No","domain":"Other","description":""},{"field":"specversion","schema":"DomainEvent","type":"Dropdown","domain":"Other","description":"CloudEvents specification version."},{"field":"id","schema":"DomainEvent","type":"ID","domain":"Other","description":"Unique event identifier."},{"field":"type","schema":"DomainEvent","type":"Text","domain":"Other","description":"Fully qualified CloudEvents event type following the convention `org.codeforamerica.safety-net-blueprint.{domain}.{entity}.{verb}`.\n"},{"field":"source","schema":"DomainEvent","type":"Text","domain":"Other","description":"Domain base path that produced the event (e.g., `/intake`, `/workflow`)."},{"field":"subject","schema":"DomainEvent","type":"ID","domain":"Other","description":"Entity ID the event pertains to."},{"field":"time","schema":"DomainEvent","type":"Date & Time","domain":"Other","description":"When the event occurred."},{"field":"datacontenttype","schema":"DomainEvent","type":"Dropdown","domain":"Other","description":"Media type of the event payload."},{"field":"traceparent","schema":"DomainEvent","type":["string","null"],"domain":"Other","description":"W3C Trace Context header (optional). Propagated from the triggering request or event. The trace ID component is stable across the full causal chain.\n"},{"field":"data","schema":"DomainEvent","type":"→ Data","domain":"Other","description":"Event payload. Schema is defined per event type in each domain's x-events section."},{"field":"id","schema":"SearchResult","type":"ID","domain":"Other","description":"Unique identifier of the matched resource."},{"field":"type","schema":"SearchResult","type":"Dropdown","domain":"Other","description":"The type of resource matched by the search."},{"field":"title","schema":"SearchResult","type":"Text","domain":"Other","description":"Display title for the result (e.g., person name, case number)."},{"field":"url","schema":"SearchResult","type":"URL","domain":"Other","description":"Canonical API URL of the matched resource."},{"field":"score","schema":"SearchResult","type":"Number","domain":"Other","description":"Relevance score between 0 and 1. Higher is more relevant."},{"field":"attributes","schema":"SearchResult","type":"List of → Attribute","domain":"Other","description":"Typed key-value pairs describing the result (e.g., status, date of birth, case number)."},{"field":"createdAt","schema":"SearchResult","type":"Date & Time","domain":"Other","description":"When the matched resource was created."},{"field":"updatedAt","schema":"SearchResult","type":"Date & Time","domain":"Other","description":"When the matched resource was last updated."},{"field":"type","schema":"SearchFacet","type":"Dropdown","domain":"Other","description":"The type of resource matched by the search."},{"field":"count","schema":"SearchFacet","type":"Number","domain":"Other","description":"Number of matching results for this type."},{"field":"field","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Machine-readable field key (e.g., \"dob\", \"status\", \"caseNumber\")."},{"field":"label","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Human-readable display label (e.g., \"Date of Birth\", \"Status\", \"Case Number\")."},{"field":"value","schema":"SearchResultAttribute","type":"Text","domain":"Other","description":"Display value, pre-formatted as a string regardless of type."},{"field":"type","schema":"SearchResultAttribute","type":"Dropdown","domain":"Other","description":"Value type hint for client rendering:\n- `string` — plain text (default)\n- `date` — date value (client may reformat)\n- `currency` — monetary amount (client may reformat)\n"},{"field":"id","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Unique identifier (server-generated)."},{"field":"startAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"When the appointment begins."},{"field":"endAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"When the appointment ends."},{"field":"appointmentType","schema":"Appointment","type":"Text","domain":"Scheduling","description":"Type of appointment (e.g., interview, recertification, orientation). Free-text, not enum — states define their own types."},{"field":"status","schema":"Appointment","type":"Dropdown","domain":"Scheduling","description":"Current status of the appointment."},{"field":"personId","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Reference to the Person record (the subject of the appointment)."},{"field":"assignedToId","schema":"Appointment","type":"ID","domain":"Scheduling","description":"Reference to the User record (staff member conducting the appointment)."},{"field":"notes","schema":"Appointment","type":"Text","domain":"Scheduling","description":"Free-text notes about the appointment."},{"field":"createdAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"Timestamp when the appointment was created."},{"field":"updatedAt","schema":"Appointment","type":"Date & Time","domain":"Scheduling","description":"Timestamp when the appointment was last updated."},{"field":"userId","schema":"User","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"User","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"ui","schema":"User","type":"→ Ui","domain":"Other","description":"Computed UI permissions and display data for frontend feature toggling.\nBackend computes these from role and permissions to provide\na UI-friendly interface for showing/hiding features.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: name, availableModules, canApproveApplications, etc.\n"},{"field":"preferences","schema":"User","type":"→ Preferences","domain":"Other","description":"User preferences for the application.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: timezone, dateFormat, itemsPerPage, language, theme, etc.\n"},{"field":"id","schema":"User","type":"ID","domain":"Other","description":"Unique identifier for the user (same as userId in JWT claims)."},{"field":"idpSubject","schema":"User","type":"Text","domain":"Other","description":"Subject identifier from the Identity Provider. Immutable after creation.\nFormat varies by IdP (e.g., \"auth0|507f1f77bcf86cd799439011\").\n"},{"field":"email","schema":"User","type":"Email","domain":"Other","description":"User's email address (from IdP or manually set)."},{"field":"status","schema":"User","type":"Dropdown","domain":"Other","description":"User account status."},{"field":"createdAt","schema":"User","type":"Date & Time","domain":"Other","description":"Timestamp when the user was created."},{"field":"updatedAt","schema":"User","type":"Date & Time","domain":"Other","description":"Timestamp when the user was last updated."},{"field":"userId","schema":"FrontendAuthContext","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"FrontendAuthContext","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"ui","schema":"FrontendAuthContext","type":"→ Ui","domain":"Other","description":"Computed UI permissions and display data for frontend feature toggling.\nBackend computes these from role and permissions to provide\na UI-friendly interface for showing/hiding features.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: name, availableModules, canApproveApplications, etc.\n"},{"field":"preferences","schema":"FrontendAuthContext","type":"→ Preferences","domain":"Other","description":"User preferences for the application.\n\nStructure is flexible - states define their own fields via overlays.\nExample fields: timezone, dateFormat, itemsPerPage, language, theme, etc.\n"},{"field":"userId","schema":"TokenClaims","type":"ID","domain":"Other","description":"User Service identifier."},{"field":"roles","schema":"TokenClaims","type":"→ Roles","domain":"Other","description":"Role and permissions for authorization."},{"field":"id","schema":"Queue","type":"ID","domain":"Workflow","description":"Unique identifier for the queue."},{"field":"name","schema":"Queue","type":"Text","domain":"Workflow","description":"Machine-readable name for the queue (e.g., snap-intake)."},{"field":"description","schema":"Queue","type":"Text","domain":"Workflow","description":"Human-readable description of the queue's purpose."},{"field":"source","schema":"Queue","type":"Dropdown","domain":"Workflow","description":"Origin of the queue. \"system\" queues are defined in workflow-config.yaml and cannot be deleted via the API. \"user\" queues are created at runtime via POST /queues and can be deleted. Consumers may use this field to disable destructive actions for system queues without first attempting the operation.\n"},{"field":"createdAt","schema":"Queue","type":"Date & Time","domain":"Workflow","description":"Timestamp when the queue was created."},{"field":"updatedAt","schema":"Queue","type":"Date & Time","domain":"Workflow","description":"Timestamp when the queue was last updated."},{"field":"name","schema":"TaskWritable","type":"Text","domain":"Other","description":"Human-readable label for the task."},{"field":"description","schema":"TaskWritable","type":"Text","domain":"Other","description":"Detailed information about the task."},{"field":"status","schema":"TaskWritable","type":"Text","domain":"Other","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"TaskWritable","type":"Text","domain":"Other","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"TaskWritable","type":"Dropdown","domain":"Other","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"TaskWritable","type":"Dropdown","domain":"Other","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"TaskWritable","type":"Yes/No","domain":"Other","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"TaskWritable","type":"Number","domain":"Other","description":"Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first."},{"field":"startedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When work finished."},{"field":"escalatedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task was escalated."},{"field":"cancelledAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task was cancelled."},{"field":"blockedAt","schema":"TaskWritable","type":"Date & Time","domain":"Other","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"TaskWritable","type":"ID","domain":"Other","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"TaskWritable","type":"Text","domain":"Other","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"TaskWritable","type":"Text","domain":"Other","description":"Optional notes recorded when the task was completed."},{"field":"name","schema":"Task","type":"Text","domain":"Workflow","description":"Human-readable label for the task."},{"field":"description","schema":"Task","type":"Text","domain":"Workflow","description":"Detailed information about the task."},{"field":"status","schema":"Task","type":"Text","domain":"Workflow","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"Task","type":"Text","domain":"Workflow","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"Task","type":"Dropdown","domain":"Workflow","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"Task","type":"Dropdown","domain":"Workflow","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"Task","type":"Yes/No","domain":"Workflow","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"Task","type":"Number","domain":"Workflow","description":"Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first."},{"field":"startedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When work finished."},{"field":"escalatedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task was escalated."},{"field":"cancelledAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task was cancelled."},{"field":"blockedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"Task","type":"ID","domain":"Workflow","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"Task","type":"Text","domain":"Workflow","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"Task","type":"Text","domain":"Workflow","description":"Optional notes recorded when the task was completed."},{"field":"id","schema":"Task","type":"ID","domain":"Workflow","description":"Unique identifier for the task."},{"field":"slaInfo","schema":"Task","type":"List of → SlaInfo","domain":"Workflow","description":"Engine-managed SLA tracking entries. Populated on create and updated on every transition. Read-only — use slaInfo on TaskCreate to specify which SLA types to track.\n"},{"field":"createdAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"Timestamp when the task was created."},{"field":"updatedAt","schema":"Task","type":"Date & Time","domain":"Workflow","description":"Timestamp when the task was last updated."},{"field":"id","schema":"Metric","type":"Text","domain":"Other","description":"Unique metric identifier, from the domain's *-metrics.yaml."},{"field":"name","schema":"Metric","type":"Text","domain":"Other","description":"Human-readable metric name."},{"field":"aggregate","schema":"Metric","type":"Dropdown","domain":"Other","description":"Aggregation function used to compute the value."},{"field":"value","schema":"Metric","type":"Number","domain":"Other","description":"Computed scalar value. count: total matching records. ratio: 0–1. duration: median seconds between paired events. null when groupBy is specified.\n"},{"field":"breakdown","schema":"Metric","type":"→ Breakdown","domain":"Other","description":"Map of group value to computed metric value. Present when groupBy is specified; null otherwise.\n"},{"field":"targets","schema":"Metric","type":"List of → Target","domain":"Other","description":"Thresholds and goals from the metric definition."},{"field":"computedAt","schema":"Metric","type":"Date & Time","domain":"Other","description":"Timestamp when the value was computed."},{"field":"stat","schema":"MetricTarget","type":"Text","domain":"Other","description":"Statistic type (e.g., p50, ratio, trend)."},{"field":"operator","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Comparison operator for evaluating the target."},{"field":"amount","schema":"MetricTarget","type":"Number","domain":"Other","description":"Machine-readable threshold value."},{"field":"unit","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Unit for the amount field."},{"field":"label","schema":"MetricTarget","type":"Text","domain":"Other","description":"Human-readable target label (e.g., \"4h\", \"10%\")."},{"field":"direction","schema":"MetricTarget","type":"Dropdown","domain":"Other","description":"Desired trend direction (for trend-type targets)."},{"field":"name","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Human-readable label for the task."},{"field":"description","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Detailed information about the task."},{"field":"status","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Current lifecycle state. Valid values are injected at resolve time from workflow-state-machine.yaml."},{"field":"taskType","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"The type of work this task represents (e.g., application_review, interview, document_review). Used by state machine guards to enable type-specific lifecycle branches and by routing rules for type-aware assignment. Open string — states extend via overlay without schema changes.\n"},{"field":"subjectType","schema":"TaskCreatedEvent","type":"Dropdown","domain":"Other","description":"The type of entity this task is associated with. Used together with subjectId to form a polymorphic association. States extend the enum via overlay. Resolution of subjectId is conditional on subjectType — no automatic expansion is performed.\n"},{"field":"subjectId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the entity this task is associated with. The target entity type is determined by subjectType. Resolution is conditional on subjectType — consumers must resolve by type; no automatic expansion is performed.\n"},{"field":"programType","schema":"TaskCreatedEvent","type":"Dropdown","domain":"Other","description":"The benefits program this task is associated with. Program-specific field used for routing and SLA assignment on application review tasks. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"isExpedited","schema":"TaskCreatedEvent","type":"Yes/No","domain":"Other","description":"Whether this task requires expedited processing. SNAP-specific concept tied to the 7-day regulatory deadline. Candidate for removal once context enrichment (#203) provides a generic alternative.\n"},{"field":"queueId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the Queue this task is routed to."},{"field":"priority","schema":"TaskCreatedEvent","type":"Number","domain":"Other","description":"Task processing priority (1=expedited, 2=high, 3=normal, 4=low). Lower number = higher urgency. Numeric representation enables correct ascending sort: expedited tasks surface first."},{"field":"startedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When work began (status transitioned to in_progress)."},{"field":"completedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When work finished."},{"field":"escalatedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task was escalated."},{"field":"cancelledAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task was cancelled."},{"field":"blockedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"When the task entered a waiting state (awaiting_client or awaiting_verification)."},{"field":"assignedToId","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Reference to the User assigned to this task."},{"field":"outcome","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Completion outcome recorded when the task was completed (e.g., approved, denied)."},{"field":"completionNotes","schema":"TaskCreatedEvent","type":"Text","domain":"Other","description":"Optional notes recorded when the task was completed."},{"field":"id","schema":"TaskCreatedEvent","type":"ID","domain":"Other","description":"Unique identifier for the task."},{"field":"slaInfo","schema":"TaskCreatedEvent","type":"List of → SlaInfo","domain":"Other","description":"Engine-managed SLA tracking entries. Populated on create and updated on every transition. Read-only — use slaInfo on TaskCreate to specify which SLA types to track.\n"},{"field":"createdAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"Timestamp when the task was created."},{"field":"updatedAt","schema":"TaskCreatedEvent","type":"Date & Time","domain":"Other","description":"Timestamp when the task was last updated."},{"field":"assignedToId","schema":"TaskAssignedEvent","type":"ID","domain":"Other","description":"Caseworker the task was assigned to, if any."},{"field":"queueId","schema":"TaskAssignedEvent","type":"ID","domain":"Other","description":"Queue the task was assigned to, if any."},{"field":"assignedToId","schema":"TaskClaimedEvent","type":"ID","domain":"Other","description":"ID of the caseworker who claimed the task."},{"field":"reason","schema":"TaskReleasedEvent","type":"Text","domain":"Other","description":"Why the task was released."},{"field":"outcome","schema":"TaskCompletedEvent","type":"Text","domain":"Other","description":"The outcome recorded at completion."},{"field":"reason","schema":"TaskCancelledEvent","type":"Text","domain":"Other","description":"Why the task was cancelled."},{"field":"reason","schema":"TaskReopenedEvent","type":"Text","domain":"Other","description":"Why the task was reopened."},{"field":"reason","schema":"TaskEscalatedEvent","type":"Text","domain":"Other","description":"Why the task was escalated."},{"field":"source","schema":"TaskSystemResumedEvent","type":"Text","domain":"Other","description":"System that triggered the automated resumption."},{"field":"result","schema":"TaskSystemResumedEvent","type":"Text","domain":"Other","description":"Result of the verification or external check."},{"field":"outcome","schema":"TaskApprovedEvent","type":"Text","domain":"Other","description":"The outcome recorded at approval."},{"field":"reason","schema":"TaskReturnedToWorkerEvent","type":"Text","domain":"Other","description":"Why the task was returned for revision."},{"field":"priority","schema":"TaskPriorityChangedEvent","type":"Number","domain":"Other","description":"The new priority value (1=expedited, 2=high, 3=normal, 4=low)."},{"field":"reason","schema":"TaskPriorityChangedEvent","type":"Text","domain":"Other","description":"Why the priority was changed."},{"field":"reason","schema":"TaskSlaBreachedEvent","type":"Dropdown","domain":"Other","description":"The SLA breach reason."},{"field":"changes","schema":"TaskUpdatedEvent","type":"List of → Change","domain":"Other","description":"List of fields that changed, with before and after values."}];
 
     // Search functionality with dropdown
     const searchInput = document.getElementById('search');

--- a/packages/explorer/service-blueprints/data/intake.json
+++ b/packages/explorer/service-blueprints/data/intake.json
@@ -347,7 +347,7 @@
         {
           "type": "system",
           "domain": "intake",
-          "text": "Interview record updated"
+          "text": "Caseworker attests interview complete (PATCH Interview.completedAt)"
         }
       ]
     },

--- a/packages/explorer/service-blueprints/output/figma-plugin-dist/main.js
+++ b/packages/explorer/service-blueprints/output/figma-plugin-dist/main.js
@@ -973,10 +973,10 @@
             subtext: "In response to event eligibility.application.expedited"
           },
           {
-            type: "note",
+            type: "system",
             domain: "workflow",
-            text: "\u26A0 Assign expedited SLA track",
-            subtext: "Expedited SLA type and workflow task switching not yet designed"
+            text: "Assign expedited SLA track",
+            subtext: "In response to event eligibility.application.expedited"
           },
           {
             type: "system",
@@ -1134,7 +1134,7 @@
           {
             type: "system",
             domain: "intake",
-            text: "Interview record updated"
+            text: "Caseworker attests interview complete (PATCH Interview.completedAt)"
           }
         ]
       },

--- a/packages/explorer/service-blueprints/src/export-png.js
+++ b/packages/explorer/service-blueprints/src/export-png.js
@@ -14,6 +14,11 @@ import { pathToFileURL } from 'url';
  * @param {string} pngPath   absolute path to write the PNG
  */
 export async function exportHtmlPng(htmlPath, pngPath) {
+  if (process.env.CI) {
+    console.log('CI environment — skipping PNG export');
+    return;
+  }
+
   let puppeteer;
   try {
     puppeteer = (await import('puppeteer')).default;

--- a/packages/explorer/state-machine-docs/output/events.md
+++ b/packages/explorer/state-machine-docs/output/events.md
@@ -4,6 +4,8 @@ Auto-generated from state machine `emit` and subscription declarations.
 
 | Event | Published by | Subscribers |
 |---|---|---|
+| `client_management.person.match_resolved` | *(unknown)* | [Intake/Application](intake.md#application) |
+| `communication.notice.sent` | *(unknown)* | [Intake/Application](intake.md#application) |
 | `data_exchange.call.completed` | *(unknown)* | [Eligibility/Decision](eligibility.md#decision), [Intake/Application](intake.md#application) |
 | `document_management.document_version.uploaded` | *(unknown)* | [Intake/Application](intake.md#application) |
 | `eligibility.application.decision_completed` | *(unknown)* | [Eligibility/Determination](eligibility.md#determination), [Intake/Application](intake.md#application) |
@@ -15,11 +17,15 @@ Auto-generated from state machine `emit` and subscription declarations.
 | `eligibility.determination.eligibility.application.determination_completed` | [Eligibility/Determination](eligibility.md#determination) | *(none)* |
 | `eligibility.determination.eligibility.application.expedited` | [Eligibility/Determination](eligibility.md#determination) | *(none)* |
 | `eligibility.determination.withdrawn` | [Eligibility/Determination](eligibility.md#determination) | *(none)* |
-| `intake.application.closed` | [Intake/Application](intake.md#application) | *(none)* |
+| `intake.application.closed` | [Intake/Application](intake.md#application) | [Workflow/Task](workflow.md) |
+| `intake.application.determination.approval_needed` | [Intake/Application](intake.md#application) | *(none)* |
+| `intake.application.determination.rejected` | [Intake/Application](intake.md#application) | *(none)* |
 | `intake.application.opened` | [Intake/Application](intake.md#application) | *(none)* |
 | `intake.application.review_completed` | [Intake/Application](intake.md#application) | [Eligibility/Determination](eligibility.md#determination) |
 | `intake.application.submitted` | [Intake/Application](intake.md#application) | [Eligibility/Determination](eligibility.md#determination), [Intake/Application](intake.md#application), [Workflow/Task](workflow.md) |
 | `intake.application.withdrawn` | [Intake/Application](intake.md#application) | [Eligibility/Determination](eligibility.md#determination) |
+| `intake.determination.approval_needed` | *(unknown)* | [Workflow/Task](workflow.md) |
+| `intake.determination.rejected` | *(unknown)* | [Workflow/Task](workflow.md) |
 | `intake.verification.created` | *(unknown)* | [Intake/Verification](intake.md#verification) |
 | `intake.verification.inconclusive` | [Intake/Verification](intake.md#verification) | *(none)* |
 | `intake.verification.satisfied` | [Intake/Verification](intake.md#verification) | *(none)* |
@@ -56,6 +62,8 @@ Auto-generated from state machine `emit` and subscription declarations.
 
 These events are subscribed to but have no emitter in the current state machines:
 
+- `client_management.person.match_resolved` — subscribed by [Intake/Application](intake.md#application)
+- `communication.notice.sent` — subscribed by [Intake/Application](intake.md#application)
 - `data_exchange.call.completed` — subscribed by [Eligibility/Decision](eligibility.md#decision), [Intake/Application](intake.md#application)
 - `document_management.document_version.uploaded` — subscribed by [Intake/Application](intake.md#application)
 - `eligibility.application.decision_completed` — subscribed by [Eligibility/Determination](eligibility.md#determination), [Intake/Application](intake.md#application)
@@ -63,6 +71,8 @@ These events are subscribed to but have no emitter in the current state machines
 - `eligibility.application.expedited` — subscribed by [Intake/Application](intake.md#application), [Workflow/Task](workflow.md)
 - `eligibility.decision.created` — subscribed by [Eligibility/Decision](eligibility.md#decision)
 - `eligibility.determination.created` — subscribed by [Intake/Application](intake.md#application)
+- `intake.determination.approval_needed` — subscribed by [Workflow/Task](workflow.md)
+- `intake.determination.rejected` — subscribed by [Workflow/Task](workflow.md)
 - `intake.verification.created` — subscribed by [Intake/Verification](intake.md#verification)
 - `scheduling.appointment.scheduled` — subscribed by [Intake/Application](intake.md#application)
 - `workflow.client_timeout` — subscribed by [Workflow/Task](workflow.md)

--- a/packages/explorer/state-machine-docs/output/index.md
+++ b/packages/explorer/state-machine-docs/output/index.md
@@ -10,6 +10,6 @@ See also: [Published events](events.md)
 |---|---|
 | [Eligibility — Determination](eligibility.md#determination) | `in_progress`, `completed`, `withdrawn` |
 | [Eligibility — Decision](eligibility.md#decision) | `pending`, `approved`, `denied`, `ineligible` |
-| [Intake — Application](intake.md#application) | `draft`, `submitted`, `under_review`, `withdrawn`, `closed` |
+| [Intake — Application](intake.md#application) | `draft`, `submitted`, `under_review`, `pending_approval`, `withdrawn`, `closed` |
 | [Intake — Verification](intake.md#verification) | `pending`, `inconclusive`, `satisfied`, `waived`, `cannot_verify` |
 | [Workflow — Task](workflow.md) | `pending`, `in_progress`, `completed`, `escalated`, `cancelled`, `awaiting_client`, `awaiting_verification`, `pending_review` |

--- a/packages/explorer/state-machine-docs/output/intake.md
+++ b/packages/explorer/state-machine-docs/output/intake.md
@@ -12,7 +12,7 @@ Domain: `intake` | API spec: [intake-openapi.yaml](../../../contracts/intake-ope
   - Actors: applicant, or caseworker
   - Transition: `draft` → `submitted`
   - Record when the application was formally submitted (sets `submittedAt`)
-  - Emit: `intake.application.submitted` — starts the regulatory clock; triggers caseworker task creation and confirmation notice
+  - Emit: `intake.application.submitted` — starts the regulatory clock; triggers caseworker task creation, confirmation notice, and person matching
     - Subscribed by: [Eligibility/Determination](eligibility.md#determination), [Intake/Application](intake.md#application), [Workflow/Task](workflow.md)
 - **open** — System marks a submitted application as under active caseworker review
   - Actors: system only
@@ -23,11 +23,26 @@ Domain: `intake` | API spec: [intake-openapi.yaml](../../../contracts/intake-ope
   - Transition: no state change
   - Emit: `intake.application.review_completed` — signals data collection is complete; triggers eligibility determination
     - Subscribed by: [Eligibility/Determination](eligibility.md#determination)
+- **submit-for-approval** — System routes the application to supervisor review when state-configured approval thresholds are met
+  - Actors: system only
+  - Transition: `under_review` → `pending_approval`
+  - Emit: `intake.application.determination.approval_needed` — triggers supervisor approval task creation; states configure approval thresholds via rules overlay
+- **approve-determination** — Supervisor approves the determination; closes the application and triggers NOA and case creation
+  - Actors: supervisor
+  - Transition: `pending_approval` → `closed`
+  - Record when the intake phase closed (sets `closedAt`)
+  - Emit: `intake.application.closed` — signals intake is complete; triggers case creation
+    - Subscribed by: [Workflow/Task](workflow.md)
+- **reject-determination** — Supervisor rejects the determination and returns the application to the caseworker for revision
+  - Actors: supervisor
+  - Transition: `pending_approval` → `under_review`
+  - Emit: `intake.application.determination.rejected` — signals the determination was rejected; workflow returns the caseworker task to in_progress via return-to-worker
 - **close** — Marks a reviewed application as closed after all determinations are complete
   - Actors: caseworker, supervisor, or system
   - Transition: `under_review` → `closed`
   - Record when the intake phase closed (sets `closedAt`)
   - Emit: `intake.application.closed` — signals intake is complete; triggers case creation
+    - Subscribed by: [Workflow/Task](workflow.md)
 - **withdraw** — Applicant or caseworker withdraws the application before a decision is made
   - Actors: applicant, caseworker, or supervisor
   - Transition: `submitted`/`under_review` → `withdrawn`
@@ -43,8 +58,8 @@ Domain: `intake` | API spec: [intake-openapi.yaml](../../../contracts/intake-ope
   - Create an Interview record when a caseworker claims an application_review task; SNAP requires an interview before determination (7 CFR § 273.2(e))
 - **`intake.application.submitted`** *(emitted by [Intake/Application](intake.md#application))*
   - Look up: application (from `event.subject`)
-  - Create electronic Verifications per member and document Verifications at the household level for the given program
-  - Create electronic Verifications per member and document Verifications at the household level for the given program
+  - Create electronic Verifications per member and document Verifications at the household level for the given program. Residency is a SNAP-required household-level obligation (7 CFR § 273.2(f)(1)(iii)) — no electronic check exists, so it is created as document-type.
+  - Create electronic Verifications per member and document Verifications at the household level for the given program. Residency is a SNAP-required household-level obligation (7 CFR § 273.2(f)(1)(iii)) — no electronic check exists, so it is created as document-type.
 - **`data_exchange.call.completed`**
   - Look up: verification (from `event.data.metadata.intake.verificationId`)
   - Transition the Verification based on the service call result; on inconclusive, creates a document fallback per ex parte rules (42 CFR § 435.911)
@@ -59,9 +74,18 @@ Domain: `intake` | API spec: [intake-openapi.yaml](../../../contracts/intake-ope
   - Look up: member (from `event.data.memberId`)
   - Write eligibility outcome to ApplicationMember.programDeterminations. Informational write-back only — does not trigger application close. Medicaid RTE results may arrive before intake closes; SNAP results typically arrive after.
 - **`eligibility.application.determination_completed`**
-  - Close the application when all program+member combinations are determined
+  - If `false`:
+    - Route to supervisor approval when state-configured thresholds are met; states replace this condition with their CEL threshold expression via rules overlay
+  - Else:
+    - Close the application when all determinations are in and no supervisor approval is required
 - **`eligibility.application.expedited`**
   - Set isExpedited on the application when eligibility screening confirms expedited criteria are met
+- **`client_management.person.match_resolved`**
+  - Look up: member (from `event.data.memberId`)
+  - Set personId and personMatch on ApplicationMember; personId is set only on confirmed matches
+- **`communication.notice.sent`**
+  - Look up: verification (from `event.data.metadata.intake.verificationId`)
+  - `PATCH intake/applications/verifications/$verification.id`
 
 ---
 

--- a/packages/explorer/state-machine-docs/output/workflow.md
+++ b/packages/explorer/state-machine-docs/output/workflow.md
@@ -29,24 +29,24 @@ Domain: `workflow` | API spec: [workflow-openapi.yaml](../../../contracts/workfl
   - Clear assignment so task returns to queue (sets `assignedToId`)
   - Emit: `workflow.task.released` — Emit a domain event recording the release and its reason
   - Route SNAP-only tasks to the SNAP intake queue; falls through to the general queue for multi-program or non-SNAP tasks. For tasks linked to an application, SNAP is determined by the application's program list; for standalone tasks, it is determined by the task's programType field.
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
 - **escalate** — Flags an in-progress task for supervisor attention
   - Actors: caseworker, or supervisor
   - Transition: `in_progress` → `escalated`
   - Record when the task was escalated (sets `escalatedAt`)
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - Emit: `workflow.task.escalated` — Emit a domain event recording the escalation
 - **escalate** — Supervisor escalates a pending task without claiming it first
   - Actors: supervisor
   - Transition: `pending` → `escalated`
   - Record when the task was escalated (sets `escalatedAt`)
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - Emit: `workflow.task.escalated` — Emit a domain event recording the escalation
 - **de-escalate** — Returns an escalated task to the pending queue
   - Actors: supervisor
   - Transition: `escalated` → `pending`
   - Route SNAP-only tasks to the SNAP intake queue; falls through to the general queue for multi-program or non-SNAP tasks. For tasks linked to an application, SNAP is determined by the application's program list; for standalone tasks, it is determined by the task's programType field.
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - Emit: `workflow.task.de-escalated` — Emit a domain event recording the de-escalation
 - **cancel** — Supervisor cancels a task from any active state
   - Actors: supervisor
@@ -58,7 +58,7 @@ Domain: `workflow` | API spec: [workflow-openapi.yaml](../../../contracts/workfl
   - Transition: `cancelled` → `pending`
   - Clear the cancellation timestamp on reopen (sets `cancelledAt`)
   - Route SNAP-only tasks to the SNAP intake queue; falls through to the general queue for multi-program or non-SNAP tasks. For tasks linked to an application, SNAP is determined by the application's program list; for standalone tasks, it is determined by the task's programType field.
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - Emit: `workflow.task.reopened` — Emit a domain event recording the reopen
 - **await-client** — Pauses an in-progress task while waiting for a client response
   - Actors: caseworker, or supervisor
@@ -90,7 +90,7 @@ Domain: `workflow` | API spec: [workflow-openapi.yaml](../../../contracts/workfl
   - Transition: `pending`/`in_progress`/`escalated` → `escalated`
   - If `escalatedAt is not set`:
     - Record first escalation time; not overwritten on subsequent timer-triggered escalations (sets `escalatedAt`)
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - If `reason is "sla_deadline_exceeded"`:
     - Emit: `workflow.task.sla_breached` — Emit a domain event recording the SLA deadline breach for federal compliance reporting
   - Else:
@@ -131,11 +131,11 @@ Domain: `workflow` | API spec: [workflow-openapi.yaml](../../../contracts/workfl
 
 - **`workflow.task.created`**
   - Route SNAP-only tasks to the SNAP intake queue; falls through to the general queue for multi-program or non-SNAP tasks. For tasks linked to an application, SNAP is determined by the application's program list; for standalone tasks, it is determined by the task's programType field.
-  - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+  - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - Schedule auto-escalation 72 business hours after task creation.
 - **`workflow.task.updated`**
   - If `$this.data.changes.exists(c, c.field is "isExpedited" || c.field is "programType")`:
-    - Set expedited priority when the task is flagged as expedited; otherwise set normal priority.
+    - Set expedited priority (1) when the task is flagged as expedited; otherwise set normal priority (3).
   - If `$this.data.changes.exists(c, c.field is "programType" || c.field is "queueId")`:
     - Route SNAP-only tasks to the SNAP intake queue; falls through to the general queue for multi-program or non-SNAP tasks. For tasks linked to an application, SNAP is determined by the application's program list; for standalone tasks, it is determined by the task's programType field.
   - If `$this.data.changes.exists(c, c.field is "slaDeadline") and slaDeadline is set`:
@@ -157,3 +157,24 @@ Domain: `workflow` | API spec: [workflow-openapi.yaml](../../../contracts/workfl
     - `PATCH workflow/tasks/$task.id`
 - **`intake.application.submitted`** *(emitted by [Intake/Application](intake.md#application))*
   - Create an intake review task when an application is submitted
+- **`intake.application.closed`** *(emitted by [Intake/Application](intake.md#application))*
+  - Look up: reviewTask, approvalTask
+  - If `id is set and status is "pending_review"`:
+    - Complete the caseworker task that was awaiting supervisor approval
+  - If `id is set and status is "in_progress"`:
+    - Complete the active caseworker task on application close
+  - If `id is set and status is "pending"`:
+    - Cancel the unclaimed caseworker task when the application was auto-determined at submission
+  - If `id is set`:
+    - Complete the supervisor approval task
+- **`intake.determination.approval_needed`**
+  - Look up: reviewTask
+  - If `id is set`:
+    - Move caseworker task to pending_review while supervisor reviews the determination
+  - Create a supervisor approval task
+- **`intake.determination.rejected`**
+  - Look up: reviewTask, approvalTask
+  - If `id is set`:
+    - Return the caseworker task to in_progress for revision
+  - If `id is set`:
+    - Complete the supervisor approval task with a rejected outcome

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -71,6 +71,18 @@ fi
 
 
 
+step "Checking explorer outputs are up to date"
+if npm run build --workspace=packages/explorer 2>&1; then
+  if git diff --exit-code packages/explorer/ > /dev/null 2>&1; then
+    pass "Explorer outputs are up to date"
+  else
+    fail "Explorer outputs are stale — run 'npm run build --workspace=packages/explorer' and commit the results"
+    git diff --name-only packages/explorer/
+  fi
+else
+  fail "Explorer build failed"
+fi
+
 step "Running integration tests"
 # Kill any orphaned mock server from a previous run
 lsof -ti :1080 | xargs kill -9 2>/dev/null || true


### PR DESCRIPTION
## Summary
- All explorer outputs (ORCA data explorer, state machine docs, service blueprint artifacts) were stale — last built before the Verification entity (PR #298) and the explorer overhaul (PR #300)
- Regenerated by running `npm run build --workspace=packages/explorer` from the current main
- Fixes the GitHub Pages 404 (output path moved from `data-explorer/` to `data-explorer/output/` in PR #300 but the file was never regenerated) and missing Verification→Application relationships in the ORCA explorer