### PR TITLE
Sub-collection list responses omit limit/offset from pagination envelope

### DIFF
--- a/packages/mock-server/src/route-generator.js
+++ b/packages/mock-server/src/route-generator.js
@@ -301,7 +301,7 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, slaType
               const limit = Math.min(parseInt(req.query.limit) || pagination.limitDefault || 25, pagination.limitMax || 100);
               const offset = parseInt(req.query.offset) || 0;
               const result = findAll(endpointWithCollection.collectionName, { [parentField]: parentId }, { limit, offset });
-              return res.json(result);
+              return res.json({ items: result.items || [], total: result.total || 0, limit, offset, hasNext: result.hasNext || false });
             } catch (error) {
               res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred', details: [{ message: error.message }] });
             }

--- a/packages/mock-server/tests/integration/intake-regression.test.js
+++ b/packages/mock-server/tests/integration/intake-regression.test.js
@@ -895,6 +895,24 @@ async function testTaskClaimedRules() {
   });
 }
 
+async function testSubCollectionPaginationEnvelope() {
+  section('Sub-collection list response — pagination envelope');
+
+  await test('GET sub-collection includes limit, offset, and hasNext in response', async () => {
+    const { id: appId } = await createAndSubmitApp(['snap']);
+
+    const res = await fetch(`${BASE_URL}${APP}/${appId}/members`);
+    assert.strictEqual(res.status, 200, 'sub-collection GET should return 200');
+
+    const data = await res.json();
+    assert.ok(Array.isArray(data.items), 'response should have items array');
+    assert.strictEqual(typeof data.total, 'number', 'response should have numeric total');
+    assert.strictEqual(typeof data.limit, 'number', 'response should have numeric limit');
+    assert.strictEqual(typeof data.offset, 'number', 'response should have numeric offset');
+    assert.strictEqual(typeof data.hasNext, 'boolean', 'response should have boolean hasNext');
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -937,6 +955,7 @@ async function runTests() {
     if (membersAvailable) await testRecordDeterminationRule();
     await testCloseOnAllDeterminedRule();
     await testTaskClaimedRules();
+    await testSubCollectionPaginationEnvelope();
   } finally {
     await teardownServer(serverStartedByTests);
   }


### PR DESCRIPTION
Closes #313

## Summary
- Sub-collection GET handler was returning `{items, total}` only; added `limit`, `offset`, and `hasNext` to match the `PaginationPagination` schema required by all list endpoints
- Added a regression test to `intake-regression.test.js` verifying the full envelope

## Notes for reviewer
The fix mirrors the shape already used by `createListHandler` — `limit` and `offset` were already computed locally in the sub-collection handler, they just weren't included in the response.
