### PR TITLE
Hoist state-machine $defs into
  components.schemas when generating RPC overlays

### DIFF
--- a/packages/contracts/scripts/generate-rpc-overlay.js
+++ b/packages/contracts/scripts/generate-rpc-overlay.js
@@ -170,6 +170,73 @@ function buildRequestBody(requestSchema) {
 }
 
 /**
+ * Walk a JSON value in place. For every local `#/$defs/<Name>` $ref encountered,
+ * rewrite it to `#/components/schemas/<Name>` and add `<Name>` to `collected`.
+ * Cross-file refs (e.g. `./foo.yaml#/$defs/X`) and non-$defs refs are left alone.
+ *
+ * The state-machine YAML is a JSON Schema document with a root `$defs` block, so
+ * actions reference request/response shapes as `#/$defs/<Name>`. When those refs
+ * are inlined verbatim into an OpenAPI spec they dangle, because OpenAPI specs
+ * don't carry a root `$defs` block — schemas live under `#/components/schemas`.
+ *
+ * @param {*} node - The JSON value to walk (mutated in place)
+ * @param {Set<string>} collected - Set to add hoisted schema names to
+ */
+function rewriteLocalDefsRefs(node, collected) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) rewriteLocalDefsRefs(item, collected);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && value.startsWith('#/$defs/')) {
+      const name = value.slice('#/$defs/'.length);
+      collected.add(name);
+      node[key] = `#/components/schemas/${name}`;
+    } else {
+      rewriteLocalDefsRefs(value, collected);
+    }
+  }
+}
+
+/**
+ * Build the transitive closure of `$defs` entries needed to satisfy `rootNames`
+ * against the state-machine's `$defs` block. Each hoisted entry is deep-cloned
+ * and has its own local `#/$defs/...` refs rewritten to `#/components/schemas/...`
+ * form before being added to the result.
+ *
+ * @param {Object|undefined} defs - The state machine's `$defs` object
+ * @param {Set<string>} rootNames - Initial set of needed schema names (from action ops)
+ * @param {string} domain - State machine domain (for warning messages)
+ * @returns {Object} Plain object (name → schema) suitable as an overlay `update` payload
+ */
+function hoistDefs(defs, rootNames, domain) {
+  const hoisted = {};
+  const queue = [...rootNames];
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (Object.prototype.hasOwnProperty.call(hoisted, name)) continue;
+    const original = defs && defs[name];
+    if (!original) {
+      console.warn(
+        `  ${domain}: state-machine action references #/$defs/${name} but no matching entry exists; ref will dangle`
+      );
+      continue;
+    }
+    const clone = JSON.parse(JSON.stringify(original));
+    const nested = new Set();
+    rewriteLocalDefsRefs(clone, nested);
+    hoisted[name] = clone;
+    for (const nestedName of nested) {
+      if (!Object.prototype.hasOwnProperty.call(hoisted, nestedName)) {
+        queue.push(nestedName);
+      }
+    }
+  }
+  return hoisted;
+}
+
+/**
  * Generate an OpenAPI overlay for a single state machine.
  * @param {Object} stateMachine - The parsed state machine contract
  * @param {{ itemPath: string, paramRefs: Array, tag: string, schemaRef: string }} endpointInfo
@@ -233,6 +300,33 @@ export function generateOverlay(stateMachine, endpointInfo) {
     }
   }
 
+  // Walk the generated operations for local `#/$defs/<Name>` refs (carried over
+  // from the state-machine YAML's `$defs:` block) and rewrite them to
+  // `#/components/schemas/<Name>` so they resolve in the destination OpenAPI.
+  // Then build a second overlay action that hoists the referenced $defs entries
+  // (transitively) into `components.schemas`.
+  const neededDefs = new Set();
+  rewriteLocalDefsRefs(pathsUpdate, neededDefs);
+  const hoistedSchemas = hoistDefs(stateMachine.$defs, neededDefs, stateMachine.domain);
+
+  const actions = [
+    {
+      target: '$.paths',
+      file: stateMachine.apiSpec,
+      description: `Add state machine transition endpoints for ${stateMachine.domain}`,
+      update: pathsUpdate
+    }
+  ];
+
+  if (Object.keys(hoistedSchemas).length > 0) {
+    actions.push({
+      target: '$.components.schemas',
+      file: stateMachine.apiSpec,
+      description: `Hoist state-machine action $defs into components.schemas for ${stateMachine.domain}`,
+      update: hoistedSchemas
+    });
+  }
+
   return {
     overlay: '1.0.0',
     info: {
@@ -240,14 +334,7 @@ export function generateOverlay(stateMachine, endpointInfo) {
       version: '1.0.0',
       description: `Auto-generated RPC endpoints from ${stateMachine.domain}-state-machine.yaml`
     },
-    actions: [
-      {
-        target: '$.paths',
-        file: stateMachine.apiSpec,
-        description: `Add state machine transition endpoints for ${stateMachine.domain}`,
-        update: pathsUpdate
-      }
-    ]
+    actions
   };
 }
 
@@ -308,7 +395,7 @@ function main() {
 }
 
 // Export for testing
-export { parseArgs, buildRequestBody };
+export { parseArgs, buildRequestBody, rewriteLocalDefsRefs, hoistDefs };
 
 // Run main when executed directly
 const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(resolve(process.argv[1]));

--- a/packages/contracts/tests/unit/generate-rpc-overlay.test.js
+++ b/packages/contracts/tests/unit/generate-rpc-overlay.test.js
@@ -14,7 +14,9 @@ import {
   discoverStateMachines,
   extractItemEndpoint,
   generateOverlay,
-  buildOperationId
+  buildOperationId,
+  rewriteLocalDefsRefs,
+  hoistDefs
 } from '../../scripts/generate-rpc-overlay.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -289,4 +291,140 @@ test('generateOverlay — correct operationIds', () => {
   assert.strictEqual(paths['/tasks/{taskId}/claim'].post.operationId, 'claimTask');
   assert.strictEqual(paths['/tasks/{taskId}/complete'].post.operationId, 'completeTask');
   assert.strictEqual(paths['/tasks/{taskId}/release'].post.operationId, 'releaseTask');
+});
+
+// =============================================================================
+// rewriteLocalDefsRefs / hoistDefs (state-machine $defs leak fix)
+// =============================================================================
+
+test('rewriteLocalDefsRefs — rewrites local #/$defs/<Name> refs in place', () => {
+  const node = {
+    foo: { $ref: '#/$defs/Foo' },
+    nested: { bar: { $ref: '#/$defs/Bar' } }
+  };
+  const collected = new Set();
+  rewriteLocalDefsRefs(node, collected);
+  assert.strictEqual(node.foo.$ref, '#/components/schemas/Foo');
+  assert.strictEqual(node.nested.bar.$ref, '#/components/schemas/Bar');
+  assert.deepStrictEqual([...collected].sort(), ['Bar', 'Foo']);
+});
+
+test('rewriteLocalDefsRefs — leaves cross-file and non-$defs refs alone', () => {
+  const node = {
+    a: { $ref: './other.yaml#/$defs/X' },
+    b: { $ref: '#/components/schemas/Y' },
+    c: { $ref: './components/responses.yaml#/BadRequest' }
+  };
+  const collected = new Set();
+  rewriteLocalDefsRefs(node, collected);
+  assert.strictEqual(node.a.$ref, './other.yaml#/$defs/X');
+  assert.strictEqual(node.b.$ref, '#/components/schemas/Y');
+  assert.strictEqual(node.c.$ref, './components/responses.yaml#/BadRequest');
+  assert.strictEqual(collected.size, 0);
+});
+
+test('hoistDefs — pulls referenced entries from $defs and rewrites their inner refs', () => {
+  const defs = {
+    Outer: {
+      type: 'object',
+      properties: { inner: { $ref: '#/$defs/Inner' } },
+      required: ['inner']
+    },
+    Inner: {
+      type: 'string',
+      enum: ['a', 'b']
+    },
+    Unused: {
+      type: 'object'
+    }
+  };
+  const hoisted = hoistDefs(defs, new Set(['Outer']), 'test-domain');
+
+  // Transitive: Inner pulled in even though only Outer was named
+  assert.ok(hoisted.Outer);
+  assert.ok(hoisted.Inner);
+  // Unreferenced entries are not hoisted
+  assert.strictEqual(hoisted.Unused, undefined);
+  // Inner ref inside Outer is rewritten to components.schemas form
+  assert.strictEqual(hoisted.Outer.properties.inner.$ref, '#/components/schemas/Inner');
+  // Source defs unchanged (deep-cloned)
+  assert.strictEqual(defs.Outer.properties.inner.$ref, '#/$defs/Inner');
+});
+
+test('hoistDefs — missing $defs entry yields a warning and skips, without throwing', () => {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (msg) => warnings.push(msg);
+  try {
+    const hoisted = hoistDefs({}, new Set(['DoesNotExist']), 'test-domain');
+    assert.deepStrictEqual(hoisted, {});
+    assert.strictEqual(warnings.length, 1);
+    assert.ok(warnings[0].includes('DoesNotExist'));
+    assert.ok(warnings[0].includes('test-domain'));
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test('generateOverlay — hoists state-machine $defs into components.schemas and rewrites refs', () => {
+  const stateMachine = {
+    domain: 'eligibility',
+    object: 'Decision',
+    apiSpec: 'eligibility-openapi.yaml',
+    machines: [
+      {
+        object: 'Decision',
+        states: [{ id: 'pending' }, { id: 'approved' }],
+        initialState: 'pending',
+        actions: [
+          {
+            id: 'approve',
+            transition: { from: 'pending', to: 'approved' },
+            schema: { request: { $ref: '#/$defs/ApproveDecisionRequest' } }
+          }
+        ]
+      }
+    ],
+    $defs: {
+      ApproveDecisionRequest: {
+        type: 'object',
+        required: ['path'],
+        properties: { path: { type: 'string', enum: ['auto', 'manual'] } }
+      }
+    }
+  };
+  const endpointInfo = {
+    itemPath: '/decisions/{decisionId}',
+    paramRefs: [{ $ref: '#/components/parameters/DecisionIdParam' }],
+    tag: 'Decisions',
+    schemaRef: '#/components/schemas/Decision'
+  };
+
+  const overlay = generateOverlay(stateMachine, endpointInfo);
+
+  // Two actions: paths update + components.schemas hoist
+  assert.strictEqual(overlay.actions.length, 2);
+  assert.strictEqual(overlay.actions[0].target, '$.paths');
+  assert.strictEqual(overlay.actions[1].target, '$.components.schemas');
+
+  // requestBody ref in the paths update is rewritten to the components form
+  const approveBody = overlay.actions[0].update['/decisions/{decisionId}/approve']
+    .post.requestBody.content['application/json'].schema;
+  assert.strictEqual(approveBody.$ref, '#/components/schemas/ApproveDecisionRequest');
+
+  // The hoist action carries the matching $defs entry under its original name
+  const hoisted = overlay.actions[1].update;
+  assert.ok(hoisted.ApproveDecisionRequest);
+  assert.strictEqual(hoisted.ApproveDecisionRequest.type, 'object');
+  assert.deepStrictEqual(hoisted.ApproveDecisionRequest.required, ['path']);
+
+  // file: scoping carries over so the overlay applies to the right spec
+  assert.strictEqual(overlay.actions[1].file, 'eligibility-openapi.yaml');
+});
+
+test('generateOverlay — no second action when no $defs refs are present', () => {
+  // Sample state machine uses inline request schemas (no $defs refs)
+  const overlay = generateOverlay(sampleStateMachine, sampleEndpointInfo);
+  assert.strictEqual(overlay.actions.length, 1);
+  assert.strictEqual(overlay.actions[0].target, '$.paths');
 });


### PR DESCRIPTION
Closes #316.

## Summary

When the RPC overlay generator builds OpenAPI path operations from state machine actions, request/response schema `$ref`s to `#/$defs/<Name>` were copied verbatim from the state-machine YAML. Those refs are valid within the state-machine file (it's a JSON Schema document with a root `$defs` block) but dangle once merged into an OpenAPI spec, which has no root `$defs`. Downstream tooling (`@hey-api/openapi-ts`, etc.) crashes on the unresolvable ref.

The fix walks each generated operation's request/response schemas for local `#/$defs/<Name>` refs, rewrites them to `#/components/schemas/<Name>`, and emits a second overlay action that hoists the matching `$defs` entries (transitively) into `components.schemas`. Cross-file refs (`./other.yaml#/$defs/X`) and non-`$defs` refs are left alone.

## Test plan

- [x] Six new unit tests in `packages/contracts/tests/unit/generate-rpc-overlay.test.js` cover the rewrite walker, transitive closure, missing-entry warning, and the second overlay action behavior. All 20 tests in that file pass; full contracts unit suite (336 tests) green locally.
- [x] `npm run resolve && grep '#/\$defs/' packages/resolved/eligibility-openapi.yaml` returns no matches; the three Decision request shapes (`ApproveDecisionRequest`, `DenyDecisionRequest`, `MarkIneligibleRequest`) land cleanly under `components.schemas`.
- [x] `npm run validate` green.
- [x] `@hey-api/openapi-ts` no longer crashes on the resolved eligibility spec when run against a consumer pinning this commit.
- [x] CI: lint + Redocly + integration tests.
