### PR TITLE
Discover sub-collection
  names in the seeder (path-based deriveCollectionName)

### DIFF
--- a/packages/mock-server/src/seeder.js
+++ b/packages/mock-server/src/seeder.js
@@ -6,6 +6,7 @@ import { readFileSync, existsSync } from 'fs';
 import yaml from 'js-yaml';
 import { insertResource, clearAll } from './database-manager.js';
 import { collectionToSchemaPrefix, extractIndividualResources } from '@codeforamerica/safety-net-blueprint-contracts/loader';
+import { deriveCollectionName as deriveCollectionNameFromPath } from './collection-utils.js';
 import { join } from 'path';
 import { resolveTimeTokens } from './time-tokens.js';
 
@@ -93,18 +94,29 @@ function deriveCollectionName(api) {
 
 /**
  * Derive all unique collection names from an API's endpoints.
+ *
+ * Uses the path-based `deriveCollectionName` from collection-utils.js (the
+ * same helper the route generator uses) so sub-resource paths map to their
+ * proper sub-collection names rather than collapsing to the top-level
+ * segment. Examples:
+ *   /applications                                       → "applications"
+ *   /applications/{id}/members                          → "application-members"
+ *   /applications/{id}/members/{memberId}/incomes       → "member-incomes"
+ *   /applications/{id}/household-info                   → "household-infos"
+ *
+ * Without this, an API whose paths are all under `/applications/...` would
+ * yield only `applications`, leaving every sub-collection the route handlers
+ * actually query (`application-members`, `member-incomes`, etc.) empty.
+ *
  * @param {Object} api - API metadata object
  * @returns {string[]} Array of collection names
  */
-function deriveAllCollectionNames(api) {
+export function deriveAllCollectionNames(api) {
   const names = new Set();
   const basePath = api.serverBasePath || '';
   for (const endpoint of api.endpoints || []) {
-    const path = basePath && endpoint.path.startsWith(basePath)
-      ? endpoint.path.slice(basePath.length)
-      : endpoint.path;
-    const segment = path.split('/')[1];
-    if (segment) names.add(segment);
+    const name = deriveCollectionNameFromPath(endpoint.path, basePath);
+    if (name) names.add(name);
   }
   // Fallback for APIs with no endpoints
   if (names.size === 0) names.add(deriveCollectionName(api));

--- a/packages/mock-server/tests/unit/seeder.test.js
+++ b/packages/mock-server/tests/unit/seeder.test.js
@@ -7,7 +7,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { seedDatabase, seedAllDatabases, deriveAllCollectionNames } from '../../src/seeder.js';
 import { loadAllSpecs } from '@codeforamerica/safety-net-blueprint-contracts/loader';
-import { count, findAll, clearAll } from '../../src/database-manager.js';
+import { count, findAll, clearAll, insertResource } from '../../src/database-manager.js';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -177,6 +177,47 @@ test('Database Seeder Tests', async (t) => {
     };
     const names = deriveAllCollectionNames(api);
     assert.deepStrictEqual(names.sort(), ['application-members', 'applications']);
+  });
+
+  await t.test('seedAllDatabases - clears sub-collections at boot (not just top-level)', async () => {
+    // Before the discovery fix, only top-level collections were cleared on
+    // boot because deriveAllCollectionNames returned only the first path
+    // segment. Stale sub-collection rows from a previous run could leak into
+    // the next boot. Now that sub-collections are discovered, they should
+    // also be cleared. Guard against regression.
+    const apiSpecs = await loadAllSpecs({ specsDir });
+    const intakeApi = apiSpecs.find((a) => a.name === 'intake');
+    if (!intakeApi) {
+      console.log('  ℹ intake API not present — skipping');
+      return;
+    }
+    const subCollections = deriveAllCollectionNames(intakeApi)
+      .filter((name) => name !== 'applications');
+    if (subCollections.length === 0) {
+      console.log('  ℹ no sub-collections discovered — skipping');
+      return;
+    }
+
+    const sentinelId = '00000000-dead-beef-0000-000000000001';
+    const target = subCollections[0];
+    insertResource(target, {
+      id: sentinelId,
+      applicationId: '00000000-0000-0000-0000-000000000000',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    });
+    assert.strictEqual(
+      findAll(target, { id: sentinelId }).total, 1,
+      'Sentinel should be present before reseed'
+    );
+
+    seedAllDatabases(apiSpecs, specsDir, seedDir);
+
+    assert.strictEqual(
+      findAll(target, { id: sentinelId }).total, 0,
+      `Sub-collection "${target}" should be cleared at boot`
+    );
+    console.log(`  ✓ Sub-collection "${target}" cleared on reseed`);
   });
 
   await t.test('deriveAllCollectionNames - falls back to api object for APIs with no endpoints', () => {

--- a/packages/mock-server/tests/unit/seeder.test.js
+++ b/packages/mock-server/tests/unit/seeder.test.js
@@ -5,7 +5,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { seedDatabase, seedAllDatabases } from '../../src/seeder.js';
+import { seedDatabase, seedAllDatabases, deriveAllCollectionNames } from '../../src/seeder.js';
 import { loadAllSpecs } from '@codeforamerica/safety-net-blueprint-contracts/loader';
 import { count, findAll, clearAll } from '../../src/database-manager.js';
 import { join, dirname } from 'path';
@@ -98,22 +98,95 @@ test('Database Seeder Tests', async (t) => {
   
   await t.test('seedAllDatabases - seeds all discovered APIs', async () => {
     cleanup();
-    
+
     const apiSpecs = await loadAllSpecs({ specsDir });
     const summary = seedAllDatabases(apiSpecs, specsDir, seedDir);
-    
+
     assert.ok(typeof summary === 'object', 'Should return summary object');
     assert.ok(Object.keys(summary).length >= apiSpecs.length,
               'Should have at least one entry per API');
 
     const totalSeeded = Object.values(summary).reduce((sum, count) => sum + count, 0);
     console.log(`  ✓ Seeded ${Object.keys(summary).length} collection(s), ${totalSeeded} total records`);
-    
+
     for (const [apiName, count] of Object.entries(summary)) {
       console.log(`    - ${apiName}: ${count} records`);
     }
   });
-  
+
+  await t.test('deriveAllCollectionNames - top-level paths return top-level collection names', () => {
+    const api = {
+      name: 'persons',
+      serverBasePath: '/client-management',
+      endpoints: [
+        { path: '/client-management/persons' },
+        { path: '/client-management/persons/{personId}' },
+      ],
+    };
+    const names = deriveAllCollectionNames(api);
+    assert.deepStrictEqual(names.sort(), ['persons']);
+  });
+
+  await t.test('deriveAllCollectionNames - sub-resource paths return sub-collection names', () => {
+    // The regression case: pre-fix, deriveAllCollectionNames returned only
+    // `['applications']` for an intake-shaped API because it took the first
+    // path segment. After the fix it should return the proper sub-collection
+    // names (`application-members`, `member-incomes`, etc.) — the same names
+    // the route generator uses when handlers call findAll().
+    const api = {
+      name: 'intake',
+      serverBasePath: '/intake',
+      endpoints: [
+        { path: '/intake/applications' },
+        { path: '/intake/applications/{applicationId}' },
+        { path: '/intake/applications/{applicationId}/members' },
+        { path: '/intake/applications/{applicationId}/members/{memberId}' },
+        { path: '/intake/applications/{applicationId}/members/{memberId}/incomes' },
+        { path: '/intake/applications/{applicationId}/members/{memberId}/expenses' },
+        { path: '/intake/applications/{applicationId}/verifications' },
+        { path: '/intake/applications/{applicationId}/household-info' },
+      ],
+    };
+    const names = deriveAllCollectionNames(api);
+    assert.deepStrictEqual(
+      names.sort(),
+      [
+        'application-members',
+        'application-verifications',
+        'applications',
+        'household-infos',
+        'member-expenses',
+        'member-incomes',
+      ]
+    );
+  });
+
+  await t.test('deriveAllCollectionNames - deduplicates collection names across endpoints', () => {
+    // Multiple endpoints on the same collection (GET list + GET item +
+    // POST + DELETE) should collapse to a single entry per collection.
+    const api = {
+      name: 'intake',
+      serverBasePath: '/intake',
+      endpoints: [
+        { path: '/intake/applications' },
+        { path: '/intake/applications' },
+        { path: '/intake/applications/{applicationId}' },
+        { path: '/intake/applications/{applicationId}/members' },
+        { path: '/intake/applications/{applicationId}/members/{memberId}' },
+      ],
+    };
+    const names = deriveAllCollectionNames(api);
+    assert.deepStrictEqual(names.sort(), ['application-members', 'applications']);
+  });
+
+  await t.test('deriveAllCollectionNames - falls back to api object for APIs with no endpoints', () => {
+    // The seeder-local deriveCollectionName(api) reads api.baseResource or
+    // api.name. Endpoints absent → fallback path.
+    const api = { name: 'tasks', baseResource: '/tasks', serverBasePath: '', endpoints: [] };
+    const names = deriveAllCollectionNames(api);
+    assert.deepStrictEqual(names, ['tasks']);
+  });
+
 });
 
 // Cleanup after all tests


### PR DESCRIPTION
Closes #321

## Summary

The mock-server's seeder discovered collection names by taking only the first path segment of each endpoint (`path.split('/')[1]`). For intake — whose paths all start with `/applications/...`, including the sub-resources added in PR #314 — that yielded a single collection: `applications`. Every sub-collection the route handlers actually query (`application-members`, `application-verifications`, `application-notes`, `member-incomes` / `member-expenses` / `member-assets` / `member-employment-records` / `member-health-coverages`, `household-infos`) was never seeded. `findAll` returned `{ items: [], total: 0 }` regardless of what `*Example*` records were in the seed YAML.

This PR replaces the inline first-segment grab in `deriveAllCollectionNames` with a call to the path-based `deriveCollectionName` from `collection-utils.js` — the same helper the route generator already uses. `extractResourcesForCollection` requires no change because it already feeds `collectionToSchemaPrefix`, which understands `member-incomes → MemberIncome`.

## Why this fixes it

`collection-utils.js`'s `deriveCollectionName(path, basePath)` handles the sub-resource case correctly: it filters out `{param}` segments, prefixes the last segment with the parent singular when the path is a sub-collection, and pluralizes singleton sub-resources (`household-info → household-infos`). The seeder just wasn't using it.

After the fix:

| Path | Collection (before) | Collection (after) |
|------|---------------------|--------------------|
| `/applications` | `applications` | `applications` |
| `/applications/{id}/members` | `applications` | `application-members` |
| `/applications/{id}/members/{memberId}/incomes` | `applications` | `member-incomes` |
| `/applications/{id}/verifications` | `applications` | `application-verifications` |
| `/applications/{id}/household-info` | `applications` | `household-infos` |

The seeder-local `deriveCollectionName(api)` (takes an API object, used in the no-endpoints fallback) is untouched. `deriveAllCollectionNames` is now exported so it's testable in isolation — matching the prevailing pattern from `collection-utils.test.js`.

## Test plan

New unit tests in `packages/mock-server/tests/unit/seeder.test.js`:

- **Top-level paths** return top-level collection names — e.g., an API with `/persons` + `/persons/{id}` resolves to `['persons']`.
- **Sub-resource paths return sub-collection names** — the regression case, using an intake-shaped API with eight representative paths, asserting the result is exactly `['application-members', 'application-verifications', 'applications', 'household-infos', 'member-expenses', 'member-incomes']`.
- **Deduplication** — multiple endpoints on the same collection (`GET` list + `GET` item + `POST`) collapse to a single entry.
- **No-endpoints fallback** — APIs with `endpoints: []` still resolve via `api.baseResource` / `api.name` through the seeder-local `deriveCollectionName(api)`.
- **Sub-collection clear-at-boot** — guards against regression of the broadened clearing behavior described below. Inserts a sentinel record into a discovered sub-collection, runs `seedAllDatabases`, asserts the sentinel is removed (i.e., the sub-collection was cleared as part of boot, not just the top-level `applications`).

`node --test packages/mock-server/tests/unit/seeder.test.js` passes locally.

## Side-effect check (request from reviewer)

The behavior change broadens what `seedAllDatabases` clears at boot: pre-fix, only top-level collections were cleared; post-fix, every sub-collection an API exposes also gets cleared (then re-seeded if matching records exist). The new clear-at-boot test above guards this behavior explicitly. For the upstream test seed (`packages/mock-server/seed/intake.yaml`) this is invisible — it only contains `ApplicationExample1`, and the sub-collections it now clears were already empty pre-fix. Worth a glance at any test that asserted on specific collection state after seeding, in case the prior behavior was being relied on incidentally.