### PR TITLE
fix(mock-server): respect schema contract on create + update (#341)

### DIFF
--- a/docs/guides/creating-apis.md
+++ b/docs/guides/creating-apis.md
@@ -110,6 +110,7 @@ Every resource must include `id` (uuid, readOnly), `createdAt` (date-time, readO
 - Must return 201 Created
 - Should have Location header
 - Must have request body
+- For sub-resource POSTs (`/resources/{id}/sub-resources`), the request schema **must** use `additionalProperties: true` (or omit the constraint entirely). The mock-server spreads URL path params into the body so denormalized parent FKs persist on the child record; a schema with `additionalProperties: false` would reject the auto-injected params. See `patterns/api-patterns.yaml` → `sub_resource_paths` → `collection.collection_path.methods.POST` for the full rationale.
 
 ### Required for PATCH Endpoints
 - Must return 200 OK

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -333,6 +333,18 @@ sub_resource_paths:
             Create a child resource scoped to the parent. The parent ID in the
             URL replaces the need to include it in the request body. Returns 201
             with a Location header pointing to the new child item path.
+
+            REQUEST SCHEMA CONSTRAINT — additionalProperties: true (or omitted)
+            is REQUIRED for sub-resource POST request schemas. The mock-server's
+            create-handler spreads every URL path param into the request body
+            so that nested routes (e.g.
+            /applications/{applicationId}/members/{memberId}/incomes) carry
+            both the parent FK and the grandparent FK onto the persisted
+            record — schemas typically declare both as required. A request
+            schema with additionalProperties: false would reject the
+            auto-injected params and 422 the create. If a schema needs to
+            restrict its top-level shape, declare each URL param explicitly
+            in properties[] so the server-injected values match the schema.
           success_response:
             code: 201
             headers:

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -308,11 +308,7 @@ machines:
       - type: intake.application.submitted
         description: Create an application review task when a new application is submitted
         steps:
-          # Required-nullable fields (description, case, dueAt, startedAt, completedAt)
-          # are set to null explicitly so the resulting Task satisfies its response
-          # contract. The engine's required-defaults extraction provides the same
-          # guarantee; stating intent at the call site keeps the procedure honest.
-          - call: {POST: workflow/tasks, body: {taskType: application_review, name: Application review, description: null, status: pending, subjectType: application, subjectId: $this.subject, case: null, dueAt: null, startedAt: null, completedAt: null}, description: Create an intake review task when an application is submitted}
+          - call: {POST: workflow/tasks, body: {taskType: application_review, name: Application review, status: pending, subjectType: application, subjectId: $this.subject}, description: Create an intake review task when an application is submitted}
       - type: intake.application.closed
         description: Complete open tasks for the application when intake closes; handles direct close, supervisor-approved close, and auto-determination paths
         context:

--- a/packages/contracts/workflow-state-machine.yaml
+++ b/packages/contracts/workflow-state-machine.yaml
@@ -308,7 +308,11 @@ machines:
       - type: intake.application.submitted
         description: Create an application review task when a new application is submitted
         steps:
-          - call: {POST: workflow/tasks, body: {taskType: application_review, name: Application review, status: pending, subjectType: application, subjectId: $this.subject}, description: Create an intake review task when an application is submitted}
+          # Required-nullable fields (description, case, dueAt, startedAt, completedAt)
+          # are set to null explicitly so the resulting Task satisfies its response
+          # contract. The engine's required-defaults extraction provides the same
+          # guarantee; stating intent at the call site keeps the procedure honest.
+          - call: {POST: workflow/tasks, body: {taskType: application_review, name: Application review, description: null, status: pending, subjectType: application, subjectId: $this.subject, case: null, dueAt: null, startedAt: null, completedAt: null}, description: Create an intake review task when an application is submitted}
       - type: intake.application.closed
         description: Complete open tasks for the application when intake closes; handles direct close, supervisor-approved close, and auto-determination paths
         context:

--- a/packages/mock-server/src/deep-merge.js
+++ b/packages/mock-server/src/deep-merge.js
@@ -44,9 +44,12 @@ export function deepMerge(target, source, readOnlyFields = ['id', 'createdAt']) 
       continue;
     }
     
-    // If value is an object, recursively merge
+    // If value is an object, recursively merge.
+    // readOnlyFields applies only at the top level — at nested levels, an `id`
+    // field is the FK on an embedded expanded reference and MUST be writable.
+    // See issue #341.
     if (typeof value === 'object') {
-      result[key] = deepMerge(result[key] || {}, value, readOnlyFields);
+      result[key] = deepMerge(result[key] || {}, value, []);
       continue;
     }
     

--- a/packages/mock-server/src/route-generator.js
+++ b/packages/mock-server/src/route-generator.js
@@ -189,17 +189,33 @@ function convertPathFormat(path) {
 
 
 /**
- * Extract required array field names from a JSON Schema (handles allOf).
- * Returns a defaults map like { evidence: [], documentRequests: [] }.
+ * Extract default values for required fields in a JSON Schema (handles allOf).
+ *
+ * The engine guarantees the response schema's `required` contract for every
+ * persisted resource. Two cases produce a default:
+ *   - required + type: 'array'            -> []
+ *   - required + type: ['X', 'null']      -> null  (any nullable type wins)
+ *
+ * Non-required fields and required non-nullable scalars get no default — the
+ * caller (request body or state-machine procedure) must supply them or fail
+ * loudly via schema validation. This prevents masking real validation gaps.
+ *
+ * Returns a defaults map like { evidence: [], description: null }.
  */
-function extractRequiredArrayDefaults(responseSchema) {
+export function extractRequiredDefaults(responseSchema) {
   if (!responseSchema) return {};
   const defaults = {};
   const schemas = responseSchema.allOf || [responseSchema];
   for (const s of schemas) {
     const props = s.properties || {};
     for (const field of (s.required || [])) {
-      if (props[field]?.type === 'array') {
+      const prop = props[field];
+      if (!prop) continue;
+      // Nullable wins over array: a type union that includes 'null' means
+      // the schema explicitly allows null content, even for arrays.
+      if (Array.isArray(prop.type) && prop.type.includes('null')) {
+        defaults[field] = null;
+      } else if (prop.type === 'array') {
         defaults[field] = [];
       }
     }
@@ -397,9 +413,9 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, slaType
       const smForEndpoint = smEntry?.stateMachine || null;
       const machineForEndpoint = smEntry?.machine || null;
       const domainSlaTypes = smForEndpoint ? findSlaTypes(slaTypes, smForEndpoint.domain) : [];
-      const arrayDefaults = extractRequiredArrayDefaults(endpoint.responseSchema);
-      if (machineForEndpoint?.initialState) arrayDefaults.status = machineForEndpoint.initialState;
-      if (Object.keys(arrayDefaults).length > 0) registerCollectionDefaults(collectionName, arrayDefaults);
+      const requiredDefaults = extractRequiredDefaults(endpoint.responseSchema);
+      if (machineForEndpoint?.initialState) requiredDefaults.status = machineForEndpoint.initialState;
+      if (Object.keys(requiredDefaults).length > 0) registerCollectionDefaults(collectionName, requiredDefaults);
       handler = createCreateHandler(apiMetadata, endpointWithCollection, baseUrl, smForEndpoint, domainSlaTypes, machineForEndpoint);
       description = 'Create resource';
     } else if (isSubResourceEndpoint(endpoint.path)) {
@@ -461,9 +477,9 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, slaType
           const subSmForEndpoint = subSmEntry?.stateMachine || null;
           const subMachineForEndpoint = subSmEntry?.machine || null;
           const subDomainSlaTypes = subSmForEndpoint ? findSlaTypes(slaTypes, subSmForEndpoint.domain) : [];
-          const subArrayDefaults = extractRequiredArrayDefaults(endpoint.responseSchema);
-          if (subMachineForEndpoint?.initialState) subArrayDefaults.status = subMachineForEndpoint.initialState;
-          if (Object.keys(subArrayDefaults).length > 0) registerCollectionDefaults(collectionName, subArrayDefaults);
+          const subRequiredDefaults = extractRequiredDefaults(endpoint.responseSchema);
+          if (subMachineForEndpoint?.initialState) subRequiredDefaults.status = subMachineForEndpoint.initialState;
+          if (Object.keys(subRequiredDefaults).length > 0) registerCollectionDefaults(collectionName, subRequiredDefaults);
           const baseCreateHandler = createCreateHandler(apiMetadata, endpointWithCollection, baseUrl, subSmForEndpoint, subDomainSlaTypes, subMachineForEndpoint, { eventSubjectField: parentField });
           handler = (req, res) => {
             req.body = { ...(req.body || {}), [parentField]: req.params[parentParam] };

--- a/packages/mock-server/src/route-generator.js
+++ b/packages/mock-server/src/route-generator.js
@@ -189,6 +189,23 @@ function convertPathFormat(path) {
 
 
 /**
+ * Merge URL path params into a request body for sub-resource POST handlers.
+ *
+ * Sub-sub-resource routes like POST /applications/{applicationId}/members/{memberId}/incomes
+ * have multiple {paramName} path segments. The persisted record needs every
+ * parent FK denormalized onto it (per the schema's required[] list); the
+ * URL is the authoritative source for those identities.
+ *
+ * Spreading every param into the body is safe because request schemas in
+ * the contracts use additionalProperties: true. Path params win on key
+ * collision: a client cannot override the URL-supplied parent FK by also
+ * passing it in the body.
+ */
+export function mergePathParamsIntoBody(body, params) {
+  return { ...(body || {}), ...(params || {}) };
+}
+
+/**
  * Extract default values for required fields in a JSON Schema (handles allOf).
  *
  * The engine guarantees the response schema's `required` contract for every
@@ -482,7 +499,10 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, slaType
           if (Object.keys(subRequiredDefaults).length > 0) registerCollectionDefaults(collectionName, subRequiredDefaults);
           const baseCreateHandler = createCreateHandler(apiMetadata, endpointWithCollection, baseUrl, subSmForEndpoint, subDomainSlaTypes, subMachineForEndpoint, { eventSubjectField: parentField });
           handler = (req, res) => {
-            req.body = { ...(req.body || {}), [parentField]: req.params[parentParam] };
+            // Spread ALL path params, not just the last one — sub-sub-resource
+            // routes (e.g. /applications/{applicationId}/members/{memberId}/incomes)
+            // need every parent FK on the persisted record. See mergePathParamsIntoBody.
+            req.body = mergePathParamsIntoBody(req.body, req.params);
             return baseCreateHandler(req, res);
           };
           description = 'Create sub-resource';

--- a/packages/mock-server/tests/unit/deep-merge.test.js
+++ b/packages/mock-server/tests/unit/deep-merge.test.js
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for deepMerge.
+ *
+ * Issue #341: readOnlyFields (default ['id', 'createdAt']) must apply only at
+ * the top level of the merge. At nested levels, `id` is the FK on an embedded
+ * expanded reference (per x-relationship.style: expand in the resolver) and
+ * MUST be writable; stripping it silently breaks PATCH end-to-end for any
+ * caller that updates a relationship.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { deepMerge } from '../../src/deep-merge.js';
+
+// =============================================================================
+// Top-level readOnly preservation (regression guards)
+// =============================================================================
+
+test('deepMerge — top-level id is preserved when source attempts to change it', () => {
+  const target = { id: 'original', name: 'Task A' };
+  const source = { id: 'attacker-supplied', name: 'Task B' };
+  const result = deepMerge(target, source);
+  assert.strictEqual(result.id, 'original');
+  assert.strictEqual(result.name, 'Task B');
+});
+
+test('deepMerge — top-level createdAt is preserved when source attempts to change it', () => {
+  const target = { id: 't1', createdAt: '2024-01-01T00:00:00Z', status: 'pending' };
+  const source = { createdAt: '2026-06-02T00:00:00Z', status: 'in_progress' };
+  const result = deepMerge(target, source);
+  assert.strictEqual(result.createdAt, '2024-01-01T00:00:00Z');
+  assert.strictEqual(result.status, 'in_progress');
+});
+
+// =============================================================================
+// Nested id MUST be writable (the issue #341 bug)
+// =============================================================================
+
+test('deepMerge — nested id is written through (issue #341)', () => {
+  // Reproduces the assignedTo expansion case: Task.assignedTo is the expanded
+  // User subset { id, firstName, lastName, username }. The id is the FK and
+  // MUST be writable on PATCH.
+  const target = {
+    id: 'task-1',
+    name: 'Review application',
+    assignedTo: null,
+  };
+  const source = {
+    assignedTo: {
+      id: 'user-jdoe',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      username: 'jdoe',
+    },
+  };
+  const result = deepMerge(target, source);
+
+  assert.strictEqual(result.id, 'task-1', 'top-level id stays');
+  assert.deepStrictEqual(result.assignedTo, {
+    id: 'user-jdoe',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    username: 'jdoe',
+  });
+});
+
+test('deepMerge — nested createdAt is written through (issue #341)', () => {
+  // Same principle for createdAt: if it appears on a nested embedded reference,
+  // it is not the parent resource's own createdAt and should not be protected.
+  const target = {
+    id: 'task-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    metadata: { createdAt: 'old-nested-value' },
+  };
+  const source = {
+    metadata: { createdAt: 'new-nested-value' },
+  };
+  const result = deepMerge(target, source);
+
+  assert.strictEqual(result.createdAt, '2024-01-01T00:00:00Z', 'top-level createdAt protected');
+  assert.strictEqual(result.metadata.createdAt, 'new-nested-value');
+});
+
+test('deepMerge — id is writable at depth 2+', () => {
+  const target = {
+    id: 'app-1',
+    primaryApplicant: {
+      id: 'member-old',
+      person: { id: 'person-old', name: 'Old Name' },
+    },
+  };
+  const source = {
+    primaryApplicant: {
+      id: 'member-new',
+      person: { id: 'person-new', name: 'New Name' },
+    },
+  };
+  const result = deepMerge(target, source);
+
+  assert.strictEqual(result.id, 'app-1');
+  assert.strictEqual(result.primaryApplicant.id, 'member-new');
+  assert.strictEqual(result.primaryApplicant.person.id, 'person-new');
+  assert.strictEqual(result.primaryApplicant.person.name, 'New Name');
+});
+
+// =============================================================================
+// Other deepMerge semantics (regression guards around the fix)
+// =============================================================================
+
+test('deepMerge — nested non-id property merges normally', () => {
+  const target = { profile: { firstName: 'Jane', lastName: 'Doe' } };
+  const source = { profile: { lastName: 'Smith' } };
+  const result = deepMerge(target, source);
+  assert.deepStrictEqual(result.profile, { firstName: 'Jane', lastName: 'Smith' });
+});
+
+test('deepMerge — explicit null in source overwrites target', () => {
+  const target = { id: 't1', assignedTo: { id: 'u1', firstName: 'Jane' } };
+  const source = { assignedTo: null };
+  const result = deepMerge(target, source);
+  assert.strictEqual(result.assignedTo, null);
+});
+
+test('deepMerge — undefined in source is skipped', () => {
+  const target = { name: 'original' };
+  const source = { name: undefined };
+  const result = deepMerge(target, source);
+  assert.strictEqual(result.name, 'original');
+});
+
+test('deepMerge — arrays are replaced, not merged', () => {
+  const target = { tags: ['a', 'b', 'c'] };
+  const source = { tags: ['x'] };
+  const result = deepMerge(target, source);
+  assert.deepStrictEqual(result.tags, ['x']);
+});
+
+test('deepMerge — custom readOnlyFields apply only at top level', () => {
+  const target = {
+    version: 1,
+    nested: { version: 1 },
+  };
+  const source = {
+    version: 99,
+    nested: { version: 99 },
+  };
+  const result = deepMerge(target, source, ['version']);
+  assert.strictEqual(result.version, 1, 'top-level version protected');
+  assert.strictEqual(result.nested.version, 99, 'nested version is writable');
+});

--- a/packages/mock-server/tests/unit/required-defaults.test.js
+++ b/packages/mock-server/tests/unit/required-defaults.test.js
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for extractRequiredDefaults.
+ *
+ * Companion to issue #341 (scope-creep). The engine guarantees the
+ * response schema's `required` contract for every persisted resource:
+ *   - required + type: array          -> defaults to []
+ *   - required + type: ['X', 'null']  -> defaults to null
+ *   - required + non-nullable scalar  -> no default (caller must supply)
+ *   - non-required                    -> no default
+ *
+ * Without this guarantee, state-machine procedures that create resources
+ * without explicitly setting every required-nullable field (e.g.
+ * intake.application.submitted -> POST workflow/tasks) silently produce
+ * records where the field is `undefined`, which fails downstream Zod
+ * validation in generated TypeScript clients.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { extractRequiredDefaults } from '../../src/route-generator.js';
+
+// =============================================================================
+// Existing behavior: required arrays default to []
+// =============================================================================
+
+test('extractRequiredDefaults — required array field defaults to []', () => {
+  const schema = {
+    required: ['evidence'],
+    properties: {
+      evidence: { type: 'array' },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { evidence: [] });
+});
+
+test('extractRequiredDefaults — multiple required arrays', () => {
+  const schema = {
+    required: ['evidence', 'documentRequests'],
+    properties: {
+      evidence: { type: 'array' },
+      documentRequests: { type: 'array' },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {
+    evidence: [],
+    documentRequests: [],
+  });
+});
+
+// =============================================================================
+// New behavior: required nullable fields default to null
+// =============================================================================
+
+test('extractRequiredDefaults — required nullable string defaults to null', () => {
+  const schema = {
+    required: ['description'],
+    properties: {
+      description: { type: ['string', 'null'] },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { description: null });
+});
+
+test('extractRequiredDefaults — required nullable object defaults to null', () => {
+  const schema = {
+    required: ['case'],
+    properties: {
+      case: { type: ['object', 'null'], properties: {} },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { case: null });
+});
+
+test('extractRequiredDefaults — required nullable date-time defaults to null', () => {
+  const schema = {
+    required: ['dueAt'],
+    properties: {
+      dueAt: { type: ['string', 'null'], format: 'date-time' },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { dueAt: null });
+});
+
+test('extractRequiredDefaults — required nullable array defaults to null (nullable wins over array)', () => {
+  // A field declared as both array and null is genuinely optional content
+  // even when required — null is more honest than [] because the schema
+  // explicitly says "may be null".
+  const schema = {
+    required: ['tags'],
+    properties: {
+      tags: { type: ['array', 'null'] },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { tags: null });
+});
+
+// =============================================================================
+// Non-defaulting cases
+// =============================================================================
+
+test('extractRequiredDefaults — non-required nullable field is not defaulted', () => {
+  // If it's not in required[], the response is allowed to omit it entirely.
+  const schema = {
+    required: [],
+    properties: {
+      maybe: { type: ['string', 'null'] },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {});
+});
+
+test('extractRequiredDefaults — required non-nullable scalar is not defaulted', () => {
+  // Caller MUST supply these — defaulting would mask a real validation gap.
+  const schema = {
+    required: ['name'],
+    properties: {
+      name: { type: 'string' },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {});
+});
+
+test('extractRequiredDefaults — required field absent from properties is not defaulted', () => {
+  const schema = {
+    required: ['ghost'],
+    properties: {},
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {});
+});
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+test('extractRequiredDefaults — null/undefined schema returns empty map', () => {
+  assert.deepStrictEqual(extractRequiredDefaults(null), {});
+  assert.deepStrictEqual(extractRequiredDefaults(undefined), {});
+});
+
+test('extractRequiredDefaults — schema without required[] returns empty map', () => {
+  const schema = {
+    properties: {
+      foo: { type: ['string', 'null'] },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {});
+});
+
+test('extractRequiredDefaults — allOf is flattened', () => {
+  const schema = {
+    allOf: [
+      { required: ['evidence'], properties: { evidence: { type: 'array' } } },
+      { required: ['note'], properties: { note: { type: ['string', 'null'] } } },
+    ],
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), {
+    evidence: [],
+    note: null,
+  });
+});
+
+test('extractRequiredDefaults — mixed shape (the Task schema case)', () => {
+  // Mirrors the actual Task schema from workflow-openapi.yaml that triggered
+  // this fix: id/name/status are non-nullable required, description is
+  // nullable required, and engine-created tasks omit description.
+  const schema = {
+    required: ['id', 'name', 'description', 'status', 'createdAt', 'updatedAt'],
+    properties: {
+      id: { type: 'string', format: 'uuid' },
+      name: { type: 'string' },
+      description: { type: ['string', 'null'] },
+      status: { type: 'string', enum: ['pending', 'in_progress'] },
+      createdAt: { type: 'string', format: 'date-time' },
+      updatedAt: { type: 'string', format: 'date-time' },
+    },
+  };
+  assert.deepStrictEqual(extractRequiredDefaults(schema), { description: null });
+});

--- a/packages/mock-server/tests/unit/sub-resource-create.test.js
+++ b/packages/mock-server/tests/unit/sub-resource-create.test.js
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for mergePathParamsIntoBody.
+ *
+ * Companion to issue #341 (scope-creep, third related engine issue).
+ *
+ * Sub-sub-resource POST routes (e.g.
+ * POST /applications/{applicationId}/members/{memberId}/incomes) historically
+ * injected only the LAST URL param (memberId) into the request body. The
+ * schema for MemberIncome requires BOTH memberId and applicationId — the
+ * grandparent FK is denormalized onto the record. Stripping applicationId
+ * during create produces records that fail downstream Zod validation in
+ * generated TypeScript clients.
+ *
+ * Fix: spread ALL path params into the body. The URL is the authoritative
+ * source for parent FK identities; params win over body fields of the same
+ * name. additionalProperties: true on request schemas (current convention)
+ * means extra params don't trip validation when the URL param name doesn't
+ * happen to match a schema field.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { mergePathParamsIntoBody } from '../../src/route-generator.js';
+
+test('mergePathParamsIntoBody — empty body + empty params returns empty object', () => {
+  assert.deepStrictEqual(mergePathParamsIntoBody({}, {}), {});
+});
+
+test('mergePathParamsIntoBody — null body + null params returns empty object', () => {
+  assert.deepStrictEqual(mergePathParamsIntoBody(null, null), {});
+});
+
+test('mergePathParamsIntoBody — body fields are preserved when no params overlap', () => {
+  const body = { amount: 1800, frequency: 'monthly' };
+  const params = { memberId: 'm1' };
+  assert.deepStrictEqual(mergePathParamsIntoBody(body, params), {
+    amount: 1800,
+    frequency: 'monthly',
+    memberId: 'm1',
+  });
+});
+
+test('mergePathParamsIntoBody — all path params land in the body (issue #341 grandparent FK case)', () => {
+  // The actual bug: POST /applications/{applicationId}/members/{memberId}/incomes
+  // produces a MemberIncome that needs both FKs in the persisted record.
+  const body = { amount: 1800, frequency: 'monthly', source: 'employment' };
+  const params = { applicationId: 'app-1', memberId: 'mem-1' };
+  assert.deepStrictEqual(mergePathParamsIntoBody(body, params), {
+    amount: 1800,
+    frequency: 'monthly',
+    source: 'employment',
+    applicationId: 'app-1',
+    memberId: 'mem-1',
+  });
+});
+
+test('mergePathParamsIntoBody — path params win on key collision', () => {
+  // URL is authoritative for parent identities. A client trying to override
+  // the parent FK via the body should not succeed; the URL is the system
+  // of record for "which parent does this belong to."
+  const body = { applicationId: 'attacker-supplied', amount: 1800 };
+  const params = { applicationId: 'real-from-url' };
+  assert.deepStrictEqual(mergePathParamsIntoBody(body, params), {
+    applicationId: 'real-from-url',
+    amount: 1800,
+  });
+});
+
+test('mergePathParamsIntoBody — singly-nested route still works (single param case)', () => {
+  // Backwards compatibility: /applications/{applicationId}/documents
+  const body = { type: 'paystub' };
+  const params = { applicationId: 'app-1' };
+  assert.deepStrictEqual(mergePathParamsIntoBody(body, params), {
+    type: 'paystub',
+    applicationId: 'app-1',
+  });
+});
+
+test('mergePathParamsIntoBody — empty body + non-empty params returns the params', () => {
+  const params = { applicationId: 'app-1', memberId: 'mem-1' };
+  assert.deepStrictEqual(mergePathParamsIntoBody({}, params), {
+    applicationId: 'app-1',
+    memberId: 'mem-1',
+  });
+});
+
+test('mergePathParamsIntoBody — body + empty params returns the body unchanged', () => {
+  const body = { amount: 1800 };
+  assert.deepStrictEqual(mergePathParamsIntoBody(body, {}), { amount: 1800 });
+});


### PR DESCRIPTION
## Summary

Engine-side bugs in the mock-server that all surface when downstream consumers exercise the `cbms-steel-thread` bootstrap simulator end-to-end. All are facets of *"the engine drops contract-required content on writes."* Bundled on one branch because each was discovered while validating the previous fix; happy to split #2 and #3 into a separate umbrella issue if reviewers prefer (offered in [#341](https://github.com/codeforamerica/safety-net-blueprint/issues/341#issuecomment-4607551449)).

**Commit 1 — `a6f756f` — `deepMerge` propagated `readOnlyFields` recursively** (fixes #341)
`packages/mock-server/src/deep-merge.js` treated `['id', 'createdAt']` as read-only at every nesting level, silently stripping the `id` field from nested expanded references on PATCH. Symptom: `PATCH /workflow/tasks/{id}` with `assignedTo: { id, ... }` returned 200, but `assignedTo.id` never persisted — assignment silently failed. Fix: pass `[]` on the recursive call so `readOnlyFields` applies only at the top level. Nested `id` is the FK on an embedded expanded reference and MUST be writable.

**Commit 2 — `5e6f2fd` — engine didn't auto-default required-nullable fields on create**
Procedures POSTing a resource without explicitly setting every required-nullable field produced records with the field simply absent. Generated TypeScript clients (Zod) then failed response validation with `expected string|null, received undefined` on 200 responses. Concrete trigger: `intake.application.submitted → POST workflow/tasks` only set `{taskType, name, status, subjectType, subjectId}`, omitting `description`/`case`/`dueAt`/`startedAt`/`completedAt`. Fix: extended `extractRequiredArrayDefaults` (renamed `extractRequiredDefaults`, now exported) in `route-generator.js` to also default required-nullable fields (`type: ['X', 'null']`) to `null`. Symmetric to the existing required-array → `[]` default. Required non-nullable scalars still get no default — caller must supply them so as not to mask real validation gaps.

**Commit 3 — `8da61ef` — sub-resource POST handlers injected only the LAST URL param**
Sub-sub-resource routes (e.g. `POST /applications/{applicationId}/members/{memberId}/incomes`) injected only `memberId` into the request body. The `MemberIncome` schema requires BOTH `memberId` AND `applicationId` (grandparent FK denormalized for direct querying). Stripping `applicationId` during create produced records that failed downstream Zod validation across the steel-thread Application overview (`Income`, `Expenses`, `Assets`, `Health insurance` all surfaced the same `applicationId: expected string, received undefined`). Fix: extracted `mergePathParamsIntoBody` helper, sub-resource POST handler now spreads ALL `req.params` into the body. URL is the authoritative source for parent FK identities; path params win on key collision so a client cannot override a URL-supplied parent FK via the body. Safe because contract request schemas use `additionalProperties: true` — extra params that don't match a schema field are accepted as harmless extras.

**Commit 4 — `cd15a9e` — revert procedure-side null padding (kept engine fix)**
Commit 2 originally also touched `workflow-state-machine.yaml`, adding explicit `description: null, case: null, dueAt: null, startedAt: null, completedAt: null` to the `intake.application.submitted` POST body as defense-in-depth. After review the procedure change is redundant — the engine fix in commit 2 already guarantees the contract on every create, so the explicit nulls are duplicate state with no behavioral effect. This commit reverts just the YAML portion of commit 2, keeping the engine fix intact. The PR is now cleanly scoped to engine-side fixes only.

## Test plan

- [x] **31 new unit tests** across three focused files, all passing locally:
  - `tests/unit/deep-merge.test.js` (10 tests) — top-level `id`/`createdAt` still protected (regression guards), nested `id`/`createdAt` now writable, depth-2+ writes, custom `readOnlyFields` scope, surrounding null/undefined/array semantics
  - `tests/unit/required-defaults.test.js` (13 tests) — existing array semantics preserved, new nullable semantics, non-defaulting cases (non-required, non-nullable scalar, ghost field, no schema, no required), `allOf` flattening, Task-shape regression test mirroring the actual bug
  - `tests/unit/sub-resource-create.test.js` (8 tests) — empty inputs, body preservation, grandparent FK case (the actual bug), key-collision precedence (URL wins), backward-compat for singly-nested routes, edge cases
- [x] Full mock-server unit suite shows same **14 pre-existing failing files** before and after these commits — no new regressions introduced
- [x] **End-to-end verified downstream** in `cbms-steel-thread`: bootstrap simulates Leslie Trent's intake fan-out (members → member-scoped records → submit → engine produces application_review task) and the SPA dashboard loads her task assigned to `jdoe` with no Zod errors on the Application overview (Income/Expenses/Assets/Coverage all populate)