### PR TITLE
Replace review-progress upsert with server-initialized PATCH-by-id

### DIFF
--- a/docs/architecture/domains/intake.md
+++ b/docs/architecture/domains/intake.md
@@ -191,7 +191,7 @@ See [Decision 10](#decision-10-interview-entity-model).
 
 ### Review progress
 
-A per-section tracking record for the caseworker's review of an application. Upsert-by-composite-key (`applicationId` + `section`) — one entry per section, optionally scoped to a specific member for member-level sections. Records are informational: they do not gate the `complete-review` transition, which states can optionally enforce via overlay. See [Decision 17](#decision-17-review-progress-is-a-separate-queryable-resource).
+A per-section tracking record for the caseworker's review of an application. Entries are server-initialized at `submitted → under_review` — one per household section and one per member × member-scoped section. Clients update entries by id. Records are informational: they do not gate the `complete-review` transition, which states can optionally enforce via overlay. See [Decision 17](#decision-17-review-progress-is-a-separate-queryable-resource).
 
 Key fields:
 - `section` + `memberId` (composite key) — upsert semantics: submitting progress for the same section and member replaces the existing entry rather than creating a duplicate. `memberId` is nullable; sections without a member context (e.g., household expenses) use `section` alone as the key.

--- a/packages/contracts/intake-openapi.yaml
+++ b/packages/contracts/intake-openapi.yaml
@@ -432,13 +432,33 @@ paths:
         "500":
           $ref: "./components/responses.yaml#/InternalError"
 
+  /applications/{applicationId}/review-progress/{entryId}:
+    parameters:
+      - $ref: "#/components/parameters/ApplicationIdParam"
+      - $ref: "#/components/parameters/ReviewProgressEntryIdParam"
+
+    get:
+      summary: Get a review progress entry
+      description: Retrieve a single review-progress entry by identifier.
+      operationId: getApplicationReviewProgress
+      tags:
+        - Application Review Progress
+      responses:
+        "200":
+          description: Review progress entry retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReviewProgressEntry"
+        "404":
+          $ref: "./components/responses.yaml#/NotFound"
+        "500":
+          $ref: "./components/responses.yaml#/InternalError"
+
     patch:
-      summary: Upsert a review progress entry
-      description: >
-        Creates or updates the review-progress entry identified by the (section, memberId)
-        composite key. If no matching entry exists it is created; if one exists it is updated.
-        Omit memberId for household-level sections.
-      operationId: upsertApplicationReviewProgress
+      summary: Update a review progress entry
+      description: Apply partial updates to a review-progress entry (e.g., set status).
+      operationId: updateApplicationReviewProgress
       tags:
         - Application Review Progress
       requestBody:
@@ -446,10 +466,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ReviewProgressEntryUpsert"
+              $ref: "#/components/schemas/ReviewProgressEntryWritable"
       responses:
         "200":
-          description: Review progress entry upserted successfully.
+          description: Review progress entry updated successfully.
           content:
             application/json:
               schema:
@@ -1497,6 +1517,12 @@ components:
       in: path
       required: true
       description: Unique identifier of the application note.
+
+    ReviewProgressEntryIdParam:
+      name: entryId
+      in: path
+      required: true
+      description: Unique identifier of the review-progress entry.
       schema:
         type: string
         format: uuid
@@ -2551,14 +2577,6 @@ components:
               type: string
               format: date-time
               readOnly: true
-
-    ReviewProgressEntryUpsert:
-      allOf:
-        - $ref: "#/components/schemas/ReviewProgressEntryWritable"
-        - type: object
-          required:
-            - section
-            - status
 
     ReviewProgressList:
       allOf:

--- a/packages/contracts/intake-state-machine.yaml
+++ b/packages/contracts/intake-state-machine.yaml
@@ -90,12 +90,24 @@ machines:
           - emit: {type: intake.application.withdrawn, data: {reason: $request.reason}, description: Emit intake.application.withdrawn — triggers open task cancellation and withdrawal notice}
     events:
       - type: workflow.task.claimed
-        description: Open the application for review and create an interview record when a caseworker claims the intake review task
+        description: Open the application for review, create an interview record, and initialize review-progress entries when a caseworker claims the intake review task
         context:
           - task: {from: workflow/tasks, where: {id: $this.subject}}
         steps:
           - call: openApplication
           - call: createInterview
+          - call: createReviewProgressEntries
+            with:
+              sections:
+                - {name: demographics, scope: member}
+                - {name: identity, scope: member}
+                - {name: income, scope: member}
+                - {name: employment, scope: member}
+                - {name: health-coverage, scope: member}
+                - {name: assets, scope: household}
+                - {name: contact, scope: household}
+                - {name: expenses, scope: household}
+                - {name: household, scope: household}
       - type: intake.application.submitted
         description: Initiate electronic verification requests for each applicable program when an application is submitted
         context:
@@ -206,6 +218,28 @@ machines:
         if: $task.taskType == "application_review"
         then:
           - call: {POST: intake/applications/interview, body: {applicationId: $task.subjectId}}
+      - id: createReviewProgressEntries
+        description: >
+          Initialize one review-progress entry per section when a caseworker claims an application_review task.
+          Member-scoped sections (scope: member) create one entry per household member; household sections
+          (scope: household) create one entry. States may add, remove, or reclassify sections via overlay.
+        parameters: [sections]
+        if: $task.taskType == "application_review"
+        then:
+          - forEach:
+              in: $params.sections
+              as: section
+            do:
+              - if: $params.section.scope == "member"
+                then:
+                  - forEach:
+                      from: intake/application-members
+                      where: {applicationId: $task.subjectId}
+                      as: member
+                    do:
+                      - call: {POST: intake/applications/review-progress, body: {applicationId: $task.subjectId, section: $params.section.name, memberId: $member.id, status: not_started}}
+                else:
+                  - call: {POST: intake/applications/review-progress, body: {applicationId: $task.subjectId, section: $params.section.name, status: not_started}}
       - id: createProgramVerifications
         description: >
           Create electronic Verifications per member (identity, citizenship, immigration) and per income source (income),

--- a/packages/contracts/patterns/api-patterns.yaml
+++ b/packages/contracts/patterns/api-patterns.yaml
@@ -420,6 +420,23 @@ sub_resource_paths:
       - GET   /applications/{applicationId}/interview
       - PATCH /applications/{applicationId}/interview
 
+  # ---------------------------------------------------------------------------
+  # Server-initialized collections
+  # ---------------------------------------------------------------------------
+  # Some sub-resource collections are pre-populated by the server rather than
+  # created by the caller. Callers read the list and update entries by id via
+  # PATCH /{resources}/{resourceId}/{subResources}/{subResourceId}.
+  #
+  # Prefer this over upsert endpoints (PATCH-by-composite-key). Upsert conflates
+  # create and update, requires the caller to know the composite key, and makes
+  # it impossible to distinguish "entry does not exist" from "entry exists with
+  # these values." Only use an upsert endpoint if there is a documented reason
+  # why server initialization is not feasible.
+  #
+  # Examples:
+  #   - ReviewProgressEntry — initialized per section when a task is claimed
+  #   - Interview — singleton, system-created on application submission
+
 # =============================================================================
 # Events Endpoint Pattern
 # =============================================================================

--- a/packages/mock-server/src/route-generator.js
+++ b/packages/mock-server/src/route-generator.js
@@ -281,74 +281,6 @@ function createReviewContextHandler() {
 }
 
 /**
- * Create a GET handler for GET /applications/{applicationId}/notes.
- * Applies optional ?scope=, ?section=, ?memberId= filters in addition to applicationId.
- */
-/**
- * Create a PATCH handler for PATCH /applications/{applicationId}/review-progress.
- * Upserts an entry identified by the (section, memberId) composite key.
- */
-function createReviewProgressUpsertHandler(apiMetadata) {
-  return (req, res) => {
-    try {
-      const { applicationId } = req.params;
-      const application = findById('applications', applicationId);
-      if (!application) {
-        return res.status(404).json({ code: 'NOT_FOUND', message: 'Application not found' });
-      }
-      if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
-        return res.status(400).json({ code: 'BAD_REQUEST', message: 'Request body must be a JSON object' });
-      }
-      const { section, status } = req.body;
-      if (!section) {
-        return res.status(422).json({ code: 'UNPROCESSABLE_ENTITY', message: 'section is required', details: [{ field: 'section', message: 'required' }] });
-      }
-      if (!status) {
-        return res.status(422).json({ code: 'UNPROCESSABLE_ENTITY', message: 'status is required', details: [{ field: 'status', message: 'required' }] });
-      }
-
-      // Match on composite key: applicationId + section + memberId (null-safe)
-      const { items: candidates } = findAll('application-review-progress', { applicationId, section }, { limit: 1000 });
-      const targetMemberId = req.body.memberId ?? null;
-      const existing = candidates.find(e => (e.memberId ?? null) === targetMemberId);
-
-      let result;
-      let action;
-      if (!existing) {
-        const newRecord = { id: randomUUID(), applicationId, ...req.body };
-        insertResource('application-review-progress', newRecord);
-        result = findAll('application-review-progress', { id: newRecord.id }, { limit: 1 }).items[0];
-        action = 'created';
-      } else {
-        result = update('application-review-progress', existing.id, req.body);
-        action = 'updated';
-      }
-
-      try {
-        const domain = apiMetadata.serverBasePath.replace(/^\//, '');
-        emitEvent({
-          domain,
-          object: 'review-progress-entry',
-          action,
-          resourceId: result.id,
-          subject: applicationId,
-          source: apiMetadata.serverBasePath,
-          data: { changes: [] },
-          callerId: req.headers['x-caller-id'] || null,
-          traceparent: req.headers['traceparent'] || null,
-          now: result.updatedAt,
-        });
-      } catch (e) { /* non-fatal */ }
-
-      res.json(result);
-    } catch (error) {
-      console.error('Review progress upsert handler error:', error);
-      res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred', details: [{ message: error.message }] });
-    }
-  };
-}
-
-/**
  * Register routes for an API specification
  * @param {Object} app - Express app
  * @param {Object} apiMetadata - API metadata from OpenAPI spec
@@ -403,9 +335,6 @@ export function registerRoutes(app, apiMetadata, baseUrl, stateMachines, slaType
           res.status(405).set('Allow', 'GET').json({ code: 'METHOD_NOT_ALLOWED', message: 'This endpoint is read-only' });
         });
       }
-    } else if (endpoint.operationId === 'upsertApplicationReviewProgress') {
-      handler = createReviewProgressUpsertHandler(apiMetadata);
-      description = 'Upsert review progress entry';
     } else if (endpoint.operationId === 'search') {
       // Cross-resource search endpoint — custom handler
       handler = createSearchHandler(apiMetadata);

--- a/packages/mock-server/tests/integration/intake-regression.test.js
+++ b/packages/mock-server/tests/integration/intake-regression.test.js
@@ -997,102 +997,108 @@ async function testReviewContext() {
 // ---------------------------------------------------------------------------
 
 async function testReviewProgress() {
-  section('Review progress — GET + PATCH /applications/{id}/review-progress');
+  section('Review progress — server-initialized entries + PATCH-by-id');
 
-  const app = await createOpenApp();
-  const appId = app.id;
+  // Submit an app with one member, then claim the task to trigger initialization
+  const { id: appId } = await createAndSubmitApp(['snap']);
+  const member = await (await fetch(`${BASE_URL}${APP}/${appId}/members`, {
+    method: 'POST', headers: CASEWORKER,
+    body: { applicationId: appId, firstName: 'Test', lastName: 'Member', programsApplyingFor: ['snap'], roles: ['household_member'] },
+  })).json();
+  const task = await (await fetch(`${BASE_URL}${TASKS}`, {
+    method: 'POST', headers: CASEWORKER,
+    body: { name: 'Intake review', taskType: 'application_review', subjectId: appId, programType: 'snap' },
+  })).json();
+  await fetch(`${BASE_URL}${TASKS}/${task.id}/claim`, { method: 'POST', headers: CASEWORKER });
+
   const BASE_PROGRESS = `${BASE_URL}${APP}/${appId}/review-progress`;
 
-  await test('GET — returns paginated shape with empty items initially', async () => {
+  // 4 household sections + 5 member-scoped sections × 1 member = 9 entries
+  const HOUSEHOLD_SECTIONS = ['assets', 'contact', 'expenses', 'household'];
+  const MEMBER_SECTIONS = ['demographics', 'identity', 'income', 'employment', 'health-coverage'];
+  const EXPECTED_TOTAL = HOUSEHOLD_SECTIONS.length + MEMBER_SECTIONS.length;
+
+  await test('GET — returns all pre-initialized entries after task claim', async () => {
     const res = await fetch(BASE_PROGRESS);
     assert.strictEqual(res.status, 200);
     const data = await res.json();
-    assert.ok('items' in data, 'items present');
-    assert.ok('total' in data, 'total present');
-    assert.ok('limit' in data, 'limit present');
-    assert.ok('offset' in data, 'offset present');
-    assert.ok('hasNext' in data, 'hasNext present');
-    assert.ok(Array.isArray(data.items));
-    assert.strictEqual(data.total, 0);
+    assert.ok('items' in data && 'total' in data && 'limit' in data && 'offset' in data && 'hasNext' in data, 'pagination shape');
+    assert.strictEqual(data.total, EXPECTED_TOTAL, `expected ${EXPECTED_TOTAL} entries (${HOUSEHOLD_SECTIONS.length} household + ${MEMBER_SECTIONS.length} member-scoped)`);
   });
 
-  await test('PATCH — creates entry (upsert)', async () => {
-    const res = await fetch(BASE_PROGRESS, {
+  await test('household sections have no memberId', async () => {
+    const { items } = await (await fetch(BASE_PROGRESS)).json();
+    for (const section of HOUSEHOLD_SECTIONS) {
+      const entry = items.find(e => e.section === section);
+      assert.ok(entry, `household entry exists for section=${section}`);
+      assert.ok(!entry.memberId, `section=${section} should not have memberId`);
+    }
+  });
+
+  await test('member-scoped sections are linked to the member', async () => {
+    const { items } = await (await fetch(BASE_PROGRESS)).json();
+    for (const section of MEMBER_SECTIONS) {
+      const entry = items.find(e => e.section === section && e.memberId === member.id);
+      assert.ok(entry, `member entry exists for section=${section}`);
+    }
+  });
+
+  await test('all initialized entries have status=not_started', async () => {
+    const { items } = await (await fetch(BASE_PROGRESS)).json();
+    assert.ok(items.every(e => e.status === 'not_started'), 'all entries start as not_started');
+  });
+
+  await test('PATCH by id — updates status', async () => {
+    const { items } = await (await fetch(BASE_PROGRESS)).json();
+    const entry = items.find(e => e.section === 'income' && e.memberId === member.id);
+    assert.ok(entry, 'income entry exists');
+
+    const res = await fetch(`${BASE_PROGRESS}/${entry.id}`, {
       method: 'PATCH', headers: CASEWORKER,
-      body: { section: 'income', status: 'in_progress' },
+      body: { status: 'in_progress' },
     });
+    assert.strictEqual(res.status, 200);
+    const updated = await res.json();
+    assert.strictEqual(updated.status, 'in_progress');
+    assert.strictEqual(updated.id, entry.id, 'id unchanged');
+    assert.strictEqual(updated.section, 'income', 'section unchanged');
+    assert.strictEqual(updated.memberId, member.id, 'memberId unchanged');
+  });
+
+  await test('GET by id — returns single entry', async () => {
+    const { items } = await (await fetch(BASE_PROGRESS)).json();
+    const entry = items[0];
+    const res = await fetch(`${BASE_PROGRESS}/${entry.id}`);
     assert.strictEqual(res.status, 200);
     const data = await res.json();
-    assert.strictEqual(data.section, 'income');
-    assert.strictEqual(data.status, 'in_progress');
-    assert.ok(data.id, 'id assigned');
-    assert.strictEqual(data.applicationId, appId);
-  });
-
-  await test('PATCH — updates existing entry by composite key', async () => {
-    const res = await fetch(BASE_PROGRESS, {
-      method: 'PATCH', headers: CASEWORKER,
-      body: { section: 'income', status: 'complete' },
-    });
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual((await res.json()).status, 'complete');
-
-    const list = await (await fetch(BASE_PROGRESS)).json();
-    const incomeEntries = list.items.filter(e => e.section === 'income');
-    assert.strictEqual(incomeEntries.length, 1, 'upsert should not duplicate');
-  });
-
-  await test('PATCH — member-scoped entry is separate from household entry', async () => {
-    const memberId = '00000000-0000-0000-0000-000000000099';
-    const res = await fetch(BASE_PROGRESS, {
-      method: 'PATCH', headers: CASEWORKER,
-      body: { section: 'income', status: 'not_started', memberId },
-    });
-    assert.strictEqual(res.status, 200);
-    assert.strictEqual((await res.json()).memberId, memberId);
-
-    const list = await (await fetch(BASE_PROGRESS)).json();
-    const incomeEntries = list.items.filter(e => e.section === 'income');
-    assert.strictEqual(incomeEntries.length, 2, 'household and member entries are distinct');
+    assert.strictEqual(data.id, entry.id);
   });
 
   await test('GET ?section= — filters to matching entries only', async () => {
-    await fetch(BASE_PROGRESS, {
-      method: 'PATCH', headers: CASEWORKER,
-      body: { section: 'assets', status: 'not_started' },
-    });
-    const res = await fetch(`${BASE_PROGRESS}?section=income`);
+    const res = await fetch(`${BASE_PROGRESS}?section=assets`);
     const data = await res.json();
-    assert.ok(data.items.every(e => e.section === 'income'), 'all items match section filter');
+    assert.strictEqual(data.total, 1, 'one household assets entry');
+    assert.ok(data.items.every(e => e.section === 'assets'));
   });
 
-  await test('PATCH — missing section → 422', async () => {
-    const res = await fetch(BASE_PROGRESS, {
+  await test('GET ?memberId= — filters to member entries only', async () => {
+    const res = await fetch(`${BASE_PROGRESS}?memberId=${member.id}`);
+    const data = await res.json();
+    assert.strictEqual(data.total, MEMBER_SECTIONS.length, `${MEMBER_SECTIONS.length} member-scoped entries`);
+    assert.ok(data.items.every(e => e.memberId === member.id));
+  });
+
+  await test('PATCH by id — 404 for unknown entry id', async () => {
+    const res = await fetch(`${BASE_PROGRESS}/00000000-0000-0000-0000-000000000000`, {
       method: 'PATCH', headers: CASEWORKER,
       body: { status: 'complete' },
     });
-    assert.strictEqual(res.status, 422);
-  });
-
-  await test('PATCH — missing status → 422', async () => {
-    const res = await fetch(BASE_PROGRESS, {
-      method: 'PATCH', headers: CASEWORKER,
-      body: { section: 'income' },
-    });
-    assert.strictEqual(res.status, 422);
-  });
-
-  await test('404 for unknown application', async () => {
-    const res = await fetch(`${BASE_URL}${APP}/00000000-0000-0000-0000-000000000000/review-progress`);
     assert.strictEqual(res.status, 404);
   });
 
-  await test('PATCH emits event with application ID as subject', async () => {
-    const eventsRes = await fetch(`${BASE_URL}/platform/events?subject=${appId}`);
-    const data = await eventsRes.json();
-    const progressEvents = data.items.filter(e => e.type.includes('review_progress'));
-    assert.ok(progressEvents.length > 0, 'at least one review_progress event emitted');
-    assert.ok(progressEvents.every(e => e.subject === appId), 'all review_progress events use application ID as subject');
+  await test('GET list — 404 for unknown application', async () => {
+    const res = await fetch(`${BASE_URL}${APP}/00000000-0000-0000-0000-000000000000/review-progress`);
+    assert.strictEqual(res.status, 404);
   });
 }
 


### PR DESCRIPTION
Closes #346

## Summary
- Replaced `PATCH /applications/{id}/review-progress` (upsert-by-composite-key) with `GET` + `PATCH /applications/{id}/review-progress/{entryId}` (standard by-id)
- Added `createReviewProgressEntries` procedure to the intake state machine, triggered on `workflow.task.claimed` — creates one entry per household section and one per member × member-scoped section; sections are a configurable overlay point
- Removed `createReviewProgressUpsertHandler` from route-generator; the new endpoints are handled by existing sub-resource routing
- Updated `intake.md` entity description and `api-patterns.yaml` to document the server-initialized collection convention

## Notes for reviewer
The architecture decision (Decision 17) always specified server initialization — this PR implements what was already decided. Sections are passed as `[{name, scope}]` objects rather than two separate lists, which prevents a section from appearing in both scopes and makes the overlay extension point clean.

Validation steps are in the issue.